### PR TITLE
Proxy DescribeMutableState request

### DIFF
--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -90,7 +90,7 @@ func (s *adminServiceProxyServer) DescribeHistoryHost(ctx context.Context, in0 *
 }
 
 func (s *adminServiceProxyServer) DescribeMutableState(ctx context.Context, in0 *adminservice.DescribeMutableStateRequest) (*adminservice.DescribeMutableStateResponse, error) {
-	return nil, status.Errorf(codes.PermissionDenied, "Calling method DescribeMutableState is not allowed.")
+	return s.adminClient.DescribeMutableState(ctx, in0)
 }
 
 func (s *adminServiceProxyServer) GetDLQMessages(ctx context.Context, in0 *adminservice.GetDLQMessagesRequest) (*adminservice.GetDLQMessagesResponse, error) {


### PR DESCRIPTION
## What was changed

Allow DescribeMutableState to be proxied, and apply name translation to adminservice requests.

## Why?

DescribeMutableState is needed for force-replication to work, and we need to apply name translation to it. Opted to simply enable name translation for all adminservice requests to keep code simple.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Ran force-replication in a local setup with s2s-proxy

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
