### PR TITLE
Move namespaceNameTranslations to top-level of config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,11 +68,10 @@ type (
 	}
 
 	ProxyConfig struct {
-		Name                     string                         `yaml:"name"`
-		Server                   ProxyServerConfig              `yaml:"server"`
-		Client                   ProxyClientConfig              `yaml:"client"`
-		NamespaceNameTranslation NamespaceNameTranslationConfig `yaml:"namespaceNameTranslation"`
-		ACLPolicy                *ACLPolicy                     `yaml:"aclPolicy"`
+		Name             string            `yaml:"name"`
+		Server           ProxyServerConfig `yaml:"server"`
+		Client           ProxyClientConfig `yaml:"client"`
+		ACLPolicy        *ACLPolicy        `yaml:"aclPolicy"`
 	}
 
 	MuxTransportConfig struct {
@@ -88,10 +87,11 @@ type (
 	}
 
 	S2SProxyConfig struct {
-		Inbound       *ProxyConfig         `yaml:"inbound"`
-		Outbound      *ProxyConfig         `yaml:"outbound"`
-		MuxTransports []MuxTransportConfig `yaml:"mux"`
-		HealthCheck   *HealthCheckConfig   `yaml:"healthCheck"`
+		Inbound                  *ProxyConfig                   `yaml:"inbound"`
+		Outbound                 *ProxyConfig                   `yaml:"outbound"`
+		MuxTransports            []MuxTransportConfig           `yaml:"mux"`
+		HealthCheck              *HealthCheckConfig             `yaml:"healthCheck"`
+		NamespaceNameTranslation NamespaceNameTranslationConfig `yaml:"namespaceNameTranslation"`
 	}
 
 	NamespaceNameTranslationConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func TestLoadS2SConfig(t *testing.T) {
 			LocalName:  "example",
 			RemoteName: "example.cloud",
 		},
-	}, s2sConfig.Outbound.NamespaceNameTranslation.Mappings)
+	}, s2sConfig.NamespaceNameTranslation.Mappings)
 
 	aclConfig := s2sConfig.Inbound.ACLPolicy
 	assert.NotEmpty(t, aclConfig)

--- a/develop/sample-config.yaml
+++ b/develop/sample-config.yaml
@@ -48,10 +48,10 @@ outbound:
         keyPath: ""
         serverCAPath: ""
         serverName: ""
-  namespaceNameTranslation:
-    mappings:
-      - localName: "example"
-        remoteName: "example.cloud"
 healthCheck:
   protocol: "http"
   listenAddress: ""
+namespaceNameTranslation:
+  mappings:
+    - localName: "example"
+      remoteName: "example.cloud"

--- a/interceptor/namespace_translator.go
+++ b/interceptor/namespace_translator.go
@@ -23,10 +23,11 @@ func NewNamespaceNameTranslator(
 	logger log.Logger,
 	cfg config.ProxyConfig,
 	isInbound bool,
+	nameTranslations config.NamespaceNameTranslationConfig,
 ) *NamespaceNameTranslator {
 	requestNameMapping := map[string]string{}
 	responseNameMapping := map[string]string{}
-	for _, tr := range cfg.NamespaceNameTranslation.Mappings {
+	for _, tr := range nameTranslations.Mappings {
 		if isInbound {
 			// For inbound listener,
 			//   - incoming requests from remote server are modifed to match local server

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -40,14 +40,14 @@ type (
 	}
 )
 
-func makeServerOptions(logger log.Logger, cfg config.ProxyConfig, isInbound bool) ([]grpc.ServerOption, error) {
+func makeServerOptions(logger log.Logger, cfg config.ProxyConfig, isInbound bool, nameTranslations config.NamespaceNameTranslationConfig) ([]grpc.ServerOption, error) {
 	unaryInterceptors := []grpc.UnaryServerInterceptor{}
 	streamInterceptors := []grpc.StreamServerInterceptor{}
 
-	if len(cfg.NamespaceNameTranslation.Mappings) > 0 {
+	if len(nameTranslations.Mappings) > 0 {
 		// NamespaceNameTranslator needs to be called before namespace access control so that
 		// local name can be used in namespace allowed list.
-		unaryInterceptors = append(unaryInterceptors, interceptor.NewNamespaceNameTranslator(logger, cfg, isInbound).Intercept)
+		unaryInterceptors = append(unaryInterceptors, interceptor.NewNamespaceNameTranslator(logger, cfg, isInbound, nameTranslations).Intercept)
 	}
 
 	if isInbound && cfg.ACLPolicy != nil {
@@ -80,7 +80,7 @@ func (ps *ProxyServer) startServer(
 	opts := ps.opts
 	logger := ps.logger
 
-	serverOpts, err := makeServerOptions(logger, cfg, opts.IsInbound)
+	serverOpts, err := makeServerOptions(logger, cfg, opts.IsInbound, opts.Config.NamespaceNameTranslation)
 	if err != nil {
 		return err
 	}

--- a/proxy/test/echo_proxy_test.go
+++ b/proxy/test/echo_proxy_test.go
@@ -101,13 +101,9 @@ func withServerConfig(serverCfg config.ProxyServerConfig, inbound bool) cfgOptio
 	}
 }
 
-func withNamespaceTranslation(mapping []config.NameMappingConfig, inbound bool) cfgOption {
+func withNamespaceTranslation(mapping []config.NameMappingConfig, _ bool) cfgOption {
 	return func(c *config.S2SProxyConfig) {
-		if inbound {
-			c.Inbound.NamespaceNameTranslation.Mappings = mapping
-		} else {
-			c.Outbound.NamespaceNameTranslation.Mappings = mapping
-		}
+		c.NamespaceNameTranslation.Mappings = mapping
 	}
 }
 


### PR DESCRIPTION
## What was changed

Move `namespaceNameTranslations` field to the top-level of config. It is now shared by the inbound and outbound servers, and we only need to define it once.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

`make test`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
