### PR TITLE
Add API response override for DescribeCluster

### DIFF
--- a/auth/policy.go
+++ b/auth/policy.go
@@ -7,7 +7,6 @@ var (
 		"DeprecateNamespace",
 		"ListNamespaces",
 		"RegisterNamespace",
-		"GetSystemInfo",
 	}
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -67,11 +67,22 @@ type (
 		MuxTransportName string `yaml:"mux"`
 	}
 
+	DescribeClusterOverride struct {
+		Response struct {
+			FailoverVersionIncrement *int64 `yaml:"failover_version_increment,omitempty"`
+		} `yaml:"response"`
+	}
+
+	APIOverridesConfig struct {
+		DescribeCluster *DescribeClusterOverride `yaml:"DescribeCluster"`
+	}
+
 	ProxyConfig struct {
-		Name      string            `yaml:"name"`
-		Server    ProxyServerConfig `yaml:"server"`
-		Client    ProxyClientConfig `yaml:"client"`
-		ACLPolicy *ACLPolicy        `yaml:"aclPolicy"`
+		Name         string              `yaml:"name"`
+		Server       ProxyServerConfig   `yaml:"server"`
+		Client       ProxyClientConfig   `yaml:"client"`
+		ACLPolicy    *ACLPolicy          `yaml:"aclPolicy"`
+		APIOverrides *APIOverridesConfig `yaml:"api_overrides"`
 	}
 
 	MuxTransportConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -67,14 +67,20 @@ type (
 		MuxTransportName string `yaml:"mux"`
 	}
 
+	DescribeClusterResponseOverrides struct {
+		FailoverVersionIncrement *int64 `yaml:"failover_version_increment,omitempty"`
+	}
+
 	DescribeClusterOverride struct {
-		Response struct {
-			FailoverVersionIncrement *int64 `yaml:"failover_version_increment,omitempty"`
-		} `yaml:"response"`
+		Response DescribeClusterResponseOverrides `yaml:"response"`
+	}
+
+	AdminSerivceOverrides struct {
+		DescribeCluster *DescribeClusterOverride `yaml:"DescribeCluster"`
 	}
 
 	APIOverridesConfig struct {
-		DescribeCluster *DescribeClusterOverride `yaml:"DescribeCluster"`
+		AdminSerivce AdminSerivceOverrides `yaml:"adminService"`
 	}
 
 	ProxyConfig struct {

--- a/config/config.go
+++ b/config/config.go
@@ -75,12 +75,12 @@ type (
 		Response DescribeClusterResponseOverrides `yaml:"response"`
 	}
 
-	AdminSerivceOverrides struct {
+	AdminServiceOverrides struct {
 		DescribeCluster *DescribeClusterOverride `yaml:"DescribeCluster"`
 	}
 
 	APIOverridesConfig struct {
-		AdminSerivce AdminSerivceOverrides `yaml:"adminService"`
+		AdminSerivce AdminServiceOverrides `yaml:"adminService"`
 	}
 
 	ProxyConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,7 @@ func TestLoadS2SConfig(t *testing.T) {
 	assert.Greater(t, len(aclConfig.AllowedMethods.AdminService), 0)
 	assert.Equal(t, []string{"namespace1", "namespace2"}, aclConfig.AllowedNamespaces)
 	assert.Equal(t, HTTP, s2sConfig.HealthCheck.Protocol)
-	assert.Equal(t, int64(100), *s2sConfig.Inbound.APIOverrides.DescribeCluster.Response.FailoverVersionIncrement)
+	assert.Equal(t, int64(100), *s2sConfig.Inbound.APIOverrides.AdminSerivce.DescribeCluster.Response.FailoverVersionIncrement)
 }
 
 func TestLoadS2SConfigMux(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ func TestLoadS2SConfig(t *testing.T) {
 	assert.Greater(t, len(aclConfig.AllowedMethods.AdminService), 0)
 	assert.Equal(t, []string{"namespace1", "namespace2"}, aclConfig.AllowedNamespaces)
 	assert.Equal(t, HTTP, s2sConfig.HealthCheck.Protocol)
+	assert.Equal(t, int64(100), *s2sConfig.Inbound.APIOverrides.DescribeCluster.Response.FailoverVersionIncrement)
 }
 
 func TestLoadS2SConfigMux(t *testing.T) {

--- a/develop/sample-config.yaml
+++ b/develop/sample-config.yaml
@@ -30,6 +30,11 @@ inbound:
       - namespace1
       - namespace2
 
+  api_overrides:
+    DescribeCluster:
+      response:
+        failover_version_increment : 100
+
 outbound:
   name: "outbound-proxy"
   server:

--- a/develop/sample-config.yaml
+++ b/develop/sample-config.yaml
@@ -29,7 +29,6 @@ inbound:
     allowedNamespaces:
       - namespace1
       - namespace2
-
   api_overrides:
     DescribeCluster:
       response:

--- a/develop/sample-config.yaml
+++ b/develop/sample-config.yaml
@@ -30,9 +30,10 @@ inbound:
       - namespace1
       - namespace2
   api_overrides:
-    DescribeCluster:
-      response:
-        failover_version_increment : 100
+    adminService:
+      DescribeCluster:
+        response:
+          failover_version_increment : 100
 
 outbound:
   name: "outbound-proxy"

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -92,7 +92,7 @@ func (s *adminServiceProxyServer) DescribeCluster(ctx context.Context, in0 *admi
 	if inbound := s.Config.Inbound; s.IsInbound && inbound != nil {
 		apply(inbound.APIOverrides)
 	} else if outbound := s.Config.Outbound; !s.IsInbound && outbound != nil {
-		apply(inbound.APIOverrides)
+		apply(outbound.APIOverrides)
 	}
 
 	return resp, err

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -79,20 +79,22 @@ func (s *adminServiceProxyServer) DeleteWorkflowExecution(ctx context.Context, i
 
 func (s *adminServiceProxyServer) DescribeCluster(ctx context.Context, in0 *adminservice.DescribeClusterRequest) (*adminservice.DescribeClusterResponse, error) {
 	resp, err := s.adminClient.DescribeCluster(ctx, in0)
-
-	apply := func(overrides *config.APIOverridesConfig) {
-		if overrides != nil && overrides.DescribeCluster != nil {
-			responseOverride := overrides.DescribeCluster.Response
-			if responseOverride.FailoverVersionIncrement != nil {
-				resp.FailoverVersionIncrement = *responseOverride.FailoverVersionIncrement
-			}
+	var overrides *config.APIOverridesConfig
+	if s.IsInbound {
+		if s.Config.Inbound != nil {
+			overrides = s.Config.Inbound.APIOverrides
+		}
+	} else {
+		if s.Config.Outbound != nil {
+			overrides = s.Config.Outbound.APIOverrides
 		}
 	}
 
-	if inbound := s.Config.Inbound; s.IsInbound && inbound != nil {
-		apply(inbound.APIOverrides)
-	} else if outbound := s.Config.Outbound; !s.IsInbound && outbound != nil {
-		apply(outbound.APIOverrides)
+	if overrides != nil && overrides.AdminSerivce.DescribeCluster != nil {
+		responseOverride := overrides.AdminSerivce.DescribeCluster.Response
+		if responseOverride.FailoverVersionIncrement != nil {
+			resp.FailoverVersionIncrement = *responseOverride.FailoverVersionIncrement
+		}
 	}
 
 	return resp, err

--- a/proxy/adminservice_test.go
+++ b/proxy/adminservice_test.go
@@ -151,7 +151,7 @@ func (s *adminserviceSuite) TestAPIOverrides_FailoverVersionIncrement() {
 	createOverride := func() *config.ProxyConfig {
 		return &config.ProxyConfig{
 			APIOverrides: &config.APIOverridesConfig{
-				AdminSerivce: config.AdminSerivceOverrides{
+				AdminSerivce: config.AdminServiceOverrides{
 					DescribeCluster: &config.DescribeClusterOverride{
 						Response: config.DescribeClusterResponseOverrides{
 							FailoverVersionIncrement: &overrideValue,

--- a/proxy/adminservice_test.go
+++ b/proxy/adminservice_test.go
@@ -136,3 +136,78 @@ func (s *adminserviceSuite) TestAddOrUpdateRemoteCluster() {
 		})
 	}
 }
+
+func (s *adminserviceSuite) TestAPIOverrides_FailoverVersionIncrement() {
+	req := &adminservice.DescribeClusterRequest{}
+	resp := &adminservice.DescribeClusterResponse{
+		FailoverVersionIncrement: 1,
+	}
+
+	overrideValue := int64(100)
+	overrideResp := &adminservice.DescribeClusterResponse{
+		FailoverVersionIncrement: overrideValue,
+	}
+
+	createOverride := func() *config.ProxyConfig {
+		return &config.ProxyConfig{
+			APIOverrides: &config.APIOverridesConfig{
+				AdminSerivce: config.AdminSerivceOverrides{
+					DescribeCluster: &config.DescribeClusterOverride{
+						Response: config.DescribeClusterResponseOverrides{
+							FailoverVersionIncrement: &overrideValue,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		opts     proxyOptions
+		mockResp *adminservice.DescribeClusterResponse
+		expResp  *adminservice.DescribeClusterResponse
+	}{
+		{
+			name: "nil override config",
+			opts: proxyOptions{
+				IsInbound: true,
+			},
+			mockResp: resp,
+			expResp:  resp,
+		},
+		{
+			name: "override inbound",
+			opts: proxyOptions{
+				IsInbound: true,
+				Config: config.S2SProxyConfig{
+					Inbound: createOverride(),
+				},
+			},
+			mockResp: resp,
+			expResp:  overrideResp,
+		},
+		{
+			name: "override outbound",
+			opts: proxyOptions{
+				IsInbound: false,
+				Config: config.S2SProxyConfig{
+					Outbound: createOverride(),
+				},
+			},
+			mockResp: resp,
+			expResp:  overrideResp,
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			ctx := context.Background()
+			server := s.newAdminServiceProxyServer(c.opts)
+			s.adminClientMock.EXPECT().DescribeCluster(ctx, gomock.Any()).Return(c.mockResp, nil)
+			resp, err := server.DescribeCluster(ctx, req)
+			s.NoError(err)
+			s.Equal(c.expResp, resp)
+		})
+	}
+}


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

This allows to connect two clusters with mis-matched initial_failover_version. 

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
