### PR TITLE
Support disabling request translation per-request

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,9 +1,30 @@
 package common
 
 import (
+	"context"
+	"strconv"
+
 	"go.temporal.io/server/common/log/tag"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	RequestTranslationHeaderName string = "s2s-request-translation"
 )
 
 func ServiceTag(sv string) tag.ZapTag {
 	return tag.NewStringTag("service", sv)
+}
+
+// IsRequestTranslationDisabled returns true if `s2s-request-translation=false` in gRPC metadata.
+func IsRequestTranslationDisabled(ctx context.Context) bool {
+	values := metadata.ValueFromIncomingContext(ctx, RequestTranslationHeaderName)
+	if len(values) == 0 {
+		return false
+	}
+	enabled, err := strconv.ParseBool(values[0])
+	if err != nil {
+		return false
+	}
+	return !enabled
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestIsRequestTranslationDisabled(t *testing.T) {
+	tests := []struct {
+		meta        map[string]string
+		expDisabled bool
+	}{
+		{
+			meta: nil,
+		},
+		{
+			meta: map[string]string{},
+		},
+		{
+			meta: map[string]string{RequestTranslationHeaderName: ""},
+		},
+		{
+			meta: map[string]string{RequestTranslationHeaderName: "true"},
+		},
+		{
+			meta: map[string]string{RequestTranslationHeaderName: "asdf"},
+		},
+		{
+			meta:        map[string]string{RequestTranslationHeaderName: "false"},
+			expDisabled: true,
+		},
+		{
+			meta:        map[string]string{RequestTranslationHeaderName: "0"},
+			expDisabled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf("%v", tc.meta)
+		t.Run(name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.New(tc.meta))
+			require.Equal(t, tc.expDisabled, IsRequestTranslationDisabled(ctx))
+		})
+
+	}
+
+}

--- a/proxy/adminservice_test.go
+++ b/proxy/adminservice_test.go
@@ -11,7 +11,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	"google.golang.org/grpc/metadata"
 
-	//"github.com/temporalio/s2s-proxy/common"
 	"github.com/temporalio/s2s-proxy/common"
 	"github.com/temporalio/s2s-proxy/config"
 	"github.com/temporalio/s2s-proxy/encryption"


### PR DESCRIPTION
## What was changed

Add support for the `s2s-request-translation` gRPC metadata field. If `s2s-request-translation=false` is specified on an incoming request, s2s-proxy will not apply request translation.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
