### PR TITLE
POC: Filter namespace data

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ type (
 		HealthCheck              *HealthCheckConfig             `yaml:"healthCheck"`
 		NamespaceNameTranslation NamespaceNameTranslationConfig `yaml:"namespaceNameTranslation"`
 		Metrics                  *MetricsConfig                 `yaml:"metrics"`
+		FilterNsData             bool                           `yaml:"filterNsData"`
 	}
 
 	NamespaceNameTranslationConfig struct {


### PR DESCRIPTION
## What was changed

For GetNamespaceReplicationTasks,

* Inbound server: Remove fields from namespace `Data` in the response
* Outbound server: Add fields to namespace `Data` in the response. Do GetNamespace on the destination cluster to find current value of the fields

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
