### PR TITLE
Add Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ build: clean-builds amd64-build
 # Docker
 AWS_ECR_REGION ?=
 AWS_ECR_PROFILE ?=
-DOCKER_REPO ?= 
+DOCKER_REPO ?=
 DOCKER_TAG ?= $(shell whoami | tr -d " ")-local-$(shell git rev-parse --short HEAD)
 DOCKER_IMAGE ?= temporal-s2s-proxy
 
@@ -106,3 +106,17 @@ docker-login:
 docker-build-push:
 	@docker buildx build --platform=linux/amd64,linux/arm64 -t "${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_TAG}" --push .
 
+
+.PHONY: helm-install
+helm-install:
+	brew install helm
+	helm plugin install https://github.com/helm-unittest/helm-unittest.git
+
+.PHONY: helm-test
+helm-test:
+	cd charts; helm unittest s2s-proxy/
+
+.PHONY: helm-example
+helm-example:
+	cd charts; helm template example ./s2s-proxy -f ./s2s-proxy/values.example.yaml > s2s-proxy/example.yaml
+	@echo "Example written to charts/s2s-proxy/example.yaml"

--- a/charts/s2s-proxy/.helmignore
+++ b/charts/s2s-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/s2s-proxy/.helmignore
+++ b/charts/s2s-proxy/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+tests/

--- a/charts/s2s-proxy/.helmignore
+++ b/charts/s2s-proxy/.helmignore
@@ -22,3 +22,5 @@
 *.tmproj
 .vscode/
 tests/
+example.yaml
+values.example.yaml

--- a/charts/s2s-proxy/Chart.yaml
+++ b/charts/s2s-proxy/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: s2s-proxy
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/charts/s2s-proxy/README.md
+++ b/charts/s2s-proxy/README.md
@@ -30,11 +30,8 @@ Testing
 
 ## Unit tests
 
-Install [helm-unittest](https://github.com/helm-unittest/helm-unittest).
+Install [helm-unittest](https://github.com/helm-unittest/helm-unittest)
 
 ```
-
-
-
-
-
+helm unittest .
+```

--- a/charts/s2s-proxy/README.md
+++ b/charts/s2s-proxy/README.md
@@ -1,0 +1,40 @@
+Overview
+--------
+
+This Helm chart deploys the s2s-proxy.
+
+It creates the following Kubernetes resources:
+
+* ConfigMap containing the s2s-proxy config
+* Deployment to deploy s2s-proxy pod(s)
+* Service to load balancer across the s2s-proxy outbound server(s)
+
+
+Configuration
+-------------
+
+Use the `configOverride` field in values.yaml to override arbitrary values in the s2s-proxy config file. These overrides are merged on top of the
+[files/defaults.yaml](/charts/s2s-proxy/files/default.yaml).
+
+For example, to configure the mux `serverAddress`:
+
+```yaml
+configOverride:
+  mux:
+    client:
+       serverAddress: "s2s-proxy-endpoint.example.tmprl.cloud:8233"
+```
+
+Testing
+-------
+
+## Unit tests
+
+Install [helm-unittest](https://github.com/helm-unittest/helm-unittest).
+
+```
+
+
+
+
+

--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -1,0 +1,141 @@
+---
+# Source: s2s-proxy/templates/configmap.yaml
+apiVersion: v1
+data:
+  config.yml: |-
+    healthCheck:
+      listenAddress: 0.0.0.0:8234
+      protocol: http
+    inbound:
+      aclPolicy:
+        allowedMethods:
+          adminService:
+          - AddOrUpdateRemoteCluster
+          - RemoveRemoteCluster
+          - DescribeCluster
+          - DescribeMutableState
+          - GetNamespaceReplicationMessages
+          - GetWorkflowExecutionRawHistoryV2
+          - ListClusters
+          - StreamWorkflowReplicationMessages
+          - ReapplyEvents
+          - GetNamespace
+      client:
+        tcp:
+          serverAddress: frontend-wumbo.temporal.svc.cluster.local:7233
+          tls:
+            certificatePath: test-cert
+            keyPath: ""
+            serverCAPath: ""
+            serverName: ""
+      name: inbound-server
+      server:
+        mux: muxed
+        type: mux
+    metrics:
+      prometheus:
+        framework: tally
+        listenAddress: 0.0.0.0:8002
+    mux:
+    - client:
+        serverAddress: 0.0.0.0:7777
+        tls:
+          certificatePath: abc
+          keyPath: ""
+          serverCAPath: ""
+          serverName: ""
+      mode: client
+      name: muxed
+    namespaceNameTranslation:
+    - localName: local
+      remoteName: cloud
+    outbound:
+      client:
+        mux: muxed
+        type: mux
+      name: outbound-server
+      server:
+        tcp:
+          listenAddress: 0.0.0.0:8888
+          tls:
+            certificatePath: ""
+            clientCAPath: ""
+            keyPath: ""
+            requireClientAuth: false
+kind: ConfigMap
+metadata:
+  name: example-s2s-proxy
+---
+# Source: s2s-proxy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-s2s-proxy
+  labels:
+    helm.sh/chart: s2s-proxy-0.1.0
+    app.kubernetes.io/name: s2s-proxy
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8888
+      targetPort: 8888
+      protocol: TCP
+      name: rpc-egress
+  selector:
+    app.kubernetes.io/name: s2s-proxy
+    app.kubernetes.io/instance: example
+---
+# Source: s2s-proxy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-s2s-proxy
+  labels:
+    helm.sh/chart: s2s-proxy-0.1.0
+    app.kubernetes.io/name: s2s-proxy
+    app.kubernetes.io/instance: example
+    app.kubernetes.io/version: "0.1.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: s2s-proxy
+      app.kubernetes.io/instance: example
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: s2s-proxy-0.1.0
+        app.kubernetes.io/name: s2s-proxy
+        app.kubernetes.io/instance: example
+        app.kubernetes.io/version: "0.1.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      containers:
+        - name: s2s-proxy
+          image: "temporaliotest/s2s-proxy:v0.1.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8888
+            name: rpc-egress
+            protocol: TCP
+          - containerPort: 8234
+            name: rpc-healthcheck
+            protocol: TCP
+          - containerPort: 8002
+            name: rpc-metrics
+            protocol: TCP
+          env:
+            - name: CONFIG_YML
+              value: "/config/config.yaml"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http

--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -2,7 +2,7 @@
 # Source: s2s-proxy/templates/configmap.yaml
 apiVersion: v1
 data:
-  config.yml: |-
+  config.yaml: |-
     healthCheck:
       listenAddress: 0.0.0.0:8234
       protocol: http
@@ -22,9 +22,9 @@ data:
           - GetNamespace
       client:
         tcp:
-          serverAddress: frontend-wumbo.temporal.svc.cluster.local:7233
+          serverAddress: frontend-ingress.temporal.svc.cluster.local:7233
           tls:
-            certificatePath: test-cert
+            certificatePath: ""
             keyPath: ""
             serverCAPath: ""
             serverName: ""
@@ -35,20 +35,21 @@ data:
     metrics:
       prometheus:
         framework: tally
-        listenAddress: 0.0.0.0:8002
+        listenAddress: 0.0.0.0:9090
     mux:
     - client:
-        serverAddress: 0.0.0.0:7777
+        serverAddress: s2s-proxy-sample.example.tmprl.cloud:8233
         tls:
-          certificatePath: abc
-          keyPath: ""
+          certificatePath: /s2c-server-tls/tls.crt
+          keyPath: /s2c-server-tls/tls.key
           serverCAPath: ""
           serverName: ""
       mode: client
       name: muxed
     namespaceNameTranslation:
-    - localName: local
-      remoteName: cloud
+      mappings:
+      - localName: my-local
+        remoteName: my-cloud.acct
     outbound:
       client:
         mux: muxed
@@ -56,7 +57,7 @@ data:
       name: outbound-server
       server:
         tcp:
-          listenAddress: 0.0.0.0:8888
+          listenAddress: 0.0.0.0:9233
           tls:
             certificatePath: ""
             clientCAPath: ""
@@ -80,8 +81,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 8888
-      targetPort: 8888
+    - port: 9233
+      targetPort: 9233
       protocol: TCP
       name: rpc-egress
   selector:
@@ -119,13 +120,13 @@ spec:
           image: "temporaliotest/s2s-proxy:v0.1.0"
           imagePullPolicy: IfNotPresent
           ports:
-          - containerPort: 8888
+          - containerPort: 9233
             name: rpc-egress
             protocol: TCP
           - containerPort: 8234
             name: rpc-healthcheck
             protocol: TCP
-          - containerPort: 8002
+          - containerPort: 9090
             name: rpc-metrics
             protocol: TCP
           env:
@@ -133,9 +134,24 @@ spec:
               value: "/config/config.yaml"
           livenessProbe:
             httpGet:
-              path: /
-              port: http
+              path: /health
+              port: 8234
           readinessProbe:
             httpGet:
-              path: /
-              port: http
+              path: /health
+              port: 8234
+          volumeMounts:
+            - mountPath: /config
+              name: config-volume
+            - mountPath: /s2c-server-tls
+              name: s2c-server-tls
+              readOnly: true
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: example-s2s-proxy
+          name: config-volume
+        - name: s2c-server-tls
+          secret:
+            optional: false
+            secretName: s2c-server-tls

--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -117,7 +117,7 @@ spec:
     spec:
       containers:
         - name: s2s-proxy
-          image: "temporaliotest/s2s-proxy:v0.1.0"
+          image: "temporalio/s2s-proxy:v0.1.0"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 9233

--- a/charts/s2s-proxy/files/default.yaml
+++ b/charts/s2s-proxy/files/default.yaml
@@ -1,0 +1,61 @@
+inbound:
+  name: "inbound-server"
+  server:
+    type: "mux"
+    mux: "muxed"
+  client:
+    tcp:
+      serverAddress: "frontend-ingress.temporal.svc.cluster.local:7233"
+      tls:
+        certificatePath: ""
+        keyPath: ""
+        serverCAPath: ""
+        serverName: ""
+
+  aclPolicy:
+    allowedMethods:
+      adminService:
+        - AddOrUpdateRemoteCluster
+        - RemoveRemoteCluster
+        - DescribeCluster
+        - DescribeMutableState
+        - GetNamespaceReplicationMessages
+        - GetWorkflowExecutionRawHistoryV2
+        - ListClusters
+        - StreamWorkflowReplicationMessages
+        - ReapplyEvents
+        - GetNamespace
+
+outbound:
+  name: "outbound-server"
+  server:
+    tcp:
+      listenAddress: "0.0.0.0:9233"
+      tls:
+        certificatePath: ""
+        keyPath: ""
+        clientCAPath: ""
+        requireClientAuth: false
+  client:
+    type: "mux"
+    mux: "muxed"
+
+mux:
+  - name: "muxed"
+    mode: "client"
+    client:
+      serverAddress: "" # Temporal cloud migration server endpoint
+      tls:
+        certificatePath: ""
+        keyPath: ""
+        serverCAPath: ""
+        serverName: ""
+
+healthCheck:
+  protocol: "http"
+  listenAddress: "0.0.0.0:8234"
+
+metrics:
+  prometheus:
+    framework: "tally"
+    listenAddress: "0.0.0.0:8002"

--- a/charts/s2s-proxy/files/default.yaml
+++ b/charts/s2s-proxy/files/default.yaml
@@ -58,4 +58,4 @@ healthCheck:
 metrics:
   prometheus:
     framework: "tally"
-    listenAddress: "0.0.0.0:8002"
+    listenAddress: "0.0.0.0:9090"

--- a/charts/s2s-proxy/templates/_helpers.tpl
+++ b/charts/s2s-proxy/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "s2s-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "s2s-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "s2s-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "s2s-proxy.labels" -}}
+helm.sh/chart: {{ include "s2s-proxy.chart" . }}
+{{ include "s2s-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "s2s-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "s2s-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
+Merge default config with overrides
+*/}}
+{{- define "s2s-proxy.mergedConfig" -}}
+{{- $defaults := .Files.Get "files/default.yaml" | fromYaml }}
+{{- $overrides := .Values.configOverride }}
+{{- $merged := mergeOverwrite $defaults $overrides }}
+{{- $merged | toYaml }}
+{{- end }}
+
+{{/*
+Parse port numbers from merged config
+*/}}
+{{- define "s2s-proxy.parsedPorts" -}}
+{{- $config := (include "s2s-proxy.mergedConfig" . | fromYaml) }}
+
+{{- $outbound := $config.outbound.server.tcp.listenAddress }}
+{{- $egressPort := (split ":" $outbound)._1 }}
+
+{{- $health := $config.healthCheck.listenAddress }}
+{{- $healthPort := (split ":" $health)._1 }}
+
+{{- $metrics := $config.metrics.prometheus.listenAddress }}
+{{- $metricsPort := (split ":" $metrics)._1 }}
+
+{{- dict "egress" $egressPort "health" $healthPort "metrics" $metricsPort | toYaml }}
+{{- end }}

--- a/charts/s2s-proxy/templates/_helpers.tpl
+++ b/charts/s2s-proxy/templates/_helpers.tpl
@@ -57,7 +57,7 @@ Merge default config with overrides
 {{- define "s2s-proxy.mergedConfig" -}}
 {{- $defaults := .Files.Get "files/default.yaml" | fromYaml }}
 {{- $overrides := .Values.configOverride }}
-{{- $merged := deepCopy $defaults | merge $overrides }}
+{{- $merged := deepCopy $defaults | merge $overrides -}}
 
 {{/* Merge the mux list in a better way */}}
 {{- $mergedMux := list }}
@@ -66,7 +66,7 @@ Merge default config with overrides
     {{- $mergedItem := deepCopy $item | merge $overrideItem }}
     {{- $mergedMux = append $mergedMux $mergedItem }}
 {{- end }}
-{{- $_ := set $merged "mux" $mergedMux }}
+{{- $_ := set $merged "mux" $mergedMux -}}
 
 {{- $merged | toYaml }}
 {{- end }}

--- a/charts/s2s-proxy/templates/_helpers.tpl
+++ b/charts/s2s-proxy/templates/_helpers.tpl
@@ -57,7 +57,17 @@ Merge default config with overrides
 {{- define "s2s-proxy.mergedConfig" -}}
 {{- $defaults := .Files.Get "files/default.yaml" | fromYaml }}
 {{- $overrides := .Values.configOverride }}
-{{- $merged := mergeOverwrite $defaults $overrides }}
+{{- $merged := deepCopy $defaults | merge $overrides }}
+
+{{/* Merge the mux list in a better way */}}
+{{- $mergedMux := list }}
+{{- range $index, $item := $defaults.mux }}
+    {{- $overrideItem := default dict (index $overrides.mux $index) }}
+    {{- $mergedItem := deepCopy $item | merge $overrideItem }}
+    {{- $mergedMux = append $mergedMux $mergedItem }}
+{{- end }}
+{{- $_ := set $merged "mux" $mergedMux }}
+
 {{- $merged | toYaml }}
 {{- end }}
 

--- a/charts/s2s-proxy/templates/configmap.yaml
+++ b/charts/s2s-proxy/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  config.yml: |-
+    {{- include "s2s-proxy.mergedConfig" . | nindent 4 }}
+kind: ConfigMap
+metadata:
+  name: {{ include "s2s-proxy.fullname" . }}

--- a/charts/s2s-proxy/templates/configmap.yaml
+++ b/charts/s2s-proxy/templates/configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  config.yml: |-
+  config.yaml: |-
     {{- include "s2s-proxy.mergedConfig" . | nindent 4 }}
 kind: ConfigMap
 metadata:

--- a/charts/s2s-proxy/templates/deployment.yaml
+++ b/charts/s2s-proxy/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "s2s-proxy.fullname" . }}
+  labels:
+    {{- include "s2s-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "s2s-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "s2s-proxy.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (print "v" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          {{- $ports := (include "s2s-proxy.parsedPorts" . | fromYaml) }}
+          - containerPort: {{ $ports.egress }}
+            name: rpc-egress
+            protocol: TCP
+          - containerPort: {{ $ports.health }}
+            name: rpc-healthcheck
+            protocol: TCP
+          - containerPort: {{ $ports.metrics }}
+            name: rpc-metrics
+            protocol: TCP
+          env:
+            - name: CONFIG_YML
+              value: "/config/config.yaml"
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            - mountPath: /config
+              name: config-volume
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: {{ include "s2s-proxy.fullname" . }}
+          name: config-volume
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/s2s-proxy/templates/deployment.yaml
+++ b/charts/s2s-proxy/templates/deployment.yaml
@@ -69,12 +69,12 @@ spec:
               name: config-volume
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with .Values.volumes }}
       volumes:
         - configMap:
             defaultMode: 420
             name: {{ include "s2s-proxy.fullname" . }}
           name: config-volume
+      {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/s2s-proxy/templates/service.yaml
+++ b/charts/s2s-proxy/templates/service.yaml
@@ -7,9 +7,10 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
+  {{- $ports := (include "s2s-proxy.parsedPorts" . | fromYaml) }}
+    - port: {{ $ports.egress }}
+      targetPort: {{ $ports.egress }}
       protocol: TCP
-      name: http
+      name: rpc-egress
   selector:
     {{- include "s2s-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/s2s-proxy/templates/service.yaml
+++ b/charts/s2s-proxy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "s2s-proxy.fullname" . }}
+  labels:
+    {{- include "s2s-proxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "s2s-proxy.selectorLabels" . | nindent 4 }}

--- a/charts/s2s-proxy/tests/configmap_test.yaml
+++ b/charts/s2s-proxy/tests/configmap_test.yaml
@@ -1,0 +1,41 @@
+suite: test configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: should override s2s-proxy config
+    set:
+      configOverride:
+        healthCheck:
+          listenAddress: 0.0.0.0:1111
+        inbound:
+          client:
+            tcp:
+              serverAddress: "frontend-other:2222"
+        mux:
+        - client:
+            serverAddress: "addr:3333"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME-s2s-proxy
+      # Brittle regex matching. Not sure how better to check yaml inside of a string though.
+      - matchRegex:
+          path: data["config.yml"]
+          pattern: |-
+            healthCheck:
+              \s*listenAddress: 0.0.0.0:1111
+      - matchRegex:
+          path: data["config.yml"]
+          pattern: |-
+              client:
+                \s*tcp:
+                  \s*serverAddress: frontend-other:2222
+      - matchRegex:
+          path: data["config.yml"]
+          pattern: |-
+            mux:
+            - client:
+                serverAddress: addr:3333
+

--- a/charts/s2s-proxy/tests/configmap_test.yaml
+++ b/charts/s2s-proxy/tests/configmap_test.yaml
@@ -22,18 +22,18 @@ tests:
           pattern: RELEASE-NAME-s2s-proxy
       # Brittle regex matching. Not sure how better to check yaml inside of a string though.
       - matchRegex:
-          path: data["config.yml"]
+          path: data["config.yaml"]
           pattern: |-
             healthCheck:
               \s*listenAddress: 0.0.0.0:1111
       - matchRegex:
-          path: data["config.yml"]
+          path: data["config.yaml"]
           pattern: |-
               client:
                 \s*tcp:
                   \s*serverAddress: frontend-other:2222
       - matchRegex:
-          path: data["config.yml"]
+          path: data["config.yaml"]
           pattern: |-
             mux:
             - client:

--- a/charts/s2s-proxy/tests/deployment_test.yaml
+++ b/charts/s2s-proxy/tests/deployment_test.yaml
@@ -1,0 +1,46 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should configure the image repo and tag
+    set:
+      image.repository: "testrepo/test"
+      image.tag: "1.2.3"
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME-s2s-proxy
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: testrepo/test:1.2.3
+
+  - it: should set container ports based on configOverride
+    set:
+      configOverride:
+        healthCheck:
+          listenAddress: 0.0.0.0:1111
+        outbound:
+          server:
+            tcp:
+              listenAddress: "127.0.0.1:2222"
+        metrics:
+          prometheus:
+            listenAddress: ":3333"
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+            - containerPort: 2222
+              name: rpc-egress
+              protocol: TCP
+            - containerPort: 1111
+              name: rpc-healthcheck
+              protocol: TCP
+            - containerPort: 3333
+              name: rpc-metrics
+              protocol: TCP
+

--- a/charts/s2s-proxy/tests/service_test.yaml
+++ b/charts/s2s-proxy/tests/service_test.yaml
@@ -1,0 +1,27 @@
+suite: test service
+templates:
+  - service.yaml
+tests:
+  - it: should configure egress port based on configOverride
+    set:
+      configOverride:
+        outbound:
+          server:
+            tcp:
+              listenAddress: "127.0.0.1:2222"
+    asserts:
+      - isKind:
+          of: Service
+      - matchRegex:
+          path: metadata.name
+          pattern: RELEASE-NAME-s2s-proxy
+      - equal:
+          path: spec.ports[0]
+          value:
+            port: 2222
+            targetPort: 2222
+            protocol: TCP
+            name: rpc-egress
+
+
+

--- a/charts/s2s-proxy/tests/service_test.yaml
+++ b/charts/s2s-proxy/tests/service_test.yaml
@@ -22,6 +22,3 @@ tests:
             targetPort: 2222
             protocol: TCP
             name: rpc-egress
-
-
-

--- a/charts/s2s-proxy/values.example.yaml
+++ b/charts/s2s-proxy/values.example.yaml
@@ -1,0 +1,27 @@
+# Mount TLS certificate
+volumes:
+  - name: s2c-server-tls
+    secret:
+      secretName: s2c-server-tls
+      optional: false
+
+volumeMounts:
+  - name: s2c-server-tls
+    mountPath: "/s2c-server-tls"
+    readOnly: true
+
+# Provide s2s-proxy config file overrides.
+# - Configure the server address
+# - Configure namespace name translations
+configOverride:
+  mux:
+    - client:
+        serverAddress: "s2s-proxy-sample.example.tmprl.cloud:8233"
+        tls:
+          certificatePath: "/s2c-server-tls/tls.crt"
+          keyPath: "/s2c-server-tls/tls.key"
+
+  namespaceNameTranslation:
+    mappings:
+    - localName: my-local
+      remoteName: my-cloud.acct

--- a/charts/s2s-proxy/values.yaml
+++ b/charts/s2s-proxy/values.yaml
@@ -37,12 +37,10 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+# Service for the s2s-proxy outbound server
 service:
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
-  port: 80
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -59,12 +57,12 @@ resources: {}
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
-    path: /
-    port: http
+    path: /health
+    port: 8234
 readinessProbe:
   httpGet:
-    path: /
-    port: http
+    path: /health
+    port: 8234
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/charts/s2s-proxy/values.yaml
+++ b/charts/s2s-proxy/values.yaml
@@ -1,0 +1,91 @@
+# Default values for s2s-proxy.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: temporaliotest/s2s-proxy
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Overrides for the s2s-proxy config file.
+# This is deep merged with default values in files/default.yaml
+configOverride: {}
+

--- a/charts/s2s-proxy/values.yaml
+++ b/charts/s2s-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: temporaliotest/s2s-proxy
+  repository: temporalio/s2s-proxy
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
## What was changed

* Create it with `helm create`
* Remove/edit various things
* Add unittests using helm-unittest
* Add a chart README 
* Add a few Makefile commands

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

* Run `make helm-install` to install helm + helm-unittest
* Run `make helm-test` to run unittests
* Run `make helm-example` to generate the example.yaml file (which is also committed)

With local kind cluster,

* Install kind: `brew install kind`
* Create kind cluster: `kind create cluster`
* Create kube secret for client cert

  ```
  kubectl create secret tls s2c-server-tls \
      --cert "/Users/pglass/Downloads/s2c/local-certs/ca.pem" \
      --key "/Users/pglass/Downloads/s2c/local-certs/ca.key"
  ```

* Write `values.test-env.yaml`. This configures the secret, the serverAddress, and name translation:

  ```yaml
  volumes:
    - name: s2c-server-tls
      secret:
        secretName: s2c-server-tls
        optional: false
  
  volumeMounts:
    - name: s2c-server-tls
      mountPath: "/s2c-server-tls"
      readOnly: true
  
  configOverride:
    mux:
      - client:
          serverAddress: "s2s-proxy-s-cgsrel-ue-a-2-main.temporal-dev.tmprl-test.cloud:8233"
          tls:
            certificatePath: "/s2c-server-tls/tls.crt"
            keyPath: "/s2c-server-tls/tls.key"
  
    namespaceNameTranslation:
      mappings:
      - localName: pgl-local
        remoteName: pgl-tcld.temporal-dev
  ```

* Install the helm chart (using `local` for the name):

  ```
  helm install local ./s2s-proxy -f values.test-env.yaml
  ```

* Check things are running:

  ```
  $ kubectl get all
  NAME                                   READY   STATUS    RESTARTS   AGE
  pod/local-s2s-proxy-5dc4b65b56-clvc2   1/1     Running   0          11m
  
  NAME                      TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)    AGE
  service/kubernetes        ClusterIP   10.96.0.1     <none>        443/TCP    45m
  service/local-s2s-proxy   ClusterIP   10.96.90.59   <none>        9233/TCP   20m
  
  NAME                              READY   UP-TO-DATE   AVAILABLE   AGE
  deployment.apps/local-s2s-proxy   1/1     1            1           20m
  ```

* Shell into pod and test the connection:

  ```
  local-s2s-proxy-5dc4b65b56-clvc2:/# tctl --address local-s2s-proxy.default.svc.cluster.local:9233 admin cl d
  ...
    "clusterName": "s-cgsrel-ue-a-2",
    "historyShardCount": 512,
  ...
  }
  ```

* Cleanup: 

  ```
  helm uninstall local
  kind delete cluster
  ```

4. Any docs updates needed?

* Added Helm README file
