### PR TITLE
add example deployment configuration with Kustomize.

### DIFF
--- a/kustomize/s2s-proxy/README.md
+++ b/kustomize/s2s-proxy/README.md
@@ -1,0 +1,88 @@
+# s2s-proxy Kustomize Configuration
+
+This directory contains the Kustomize configuration for deploying the `s2s-proxy` application. It was converted from the original Helm chart.
+
+## Overview
+
+Kustomize allows for declarative, template-free management of Kubernetes application configurations. This setup provides a `base` configuration and an example `overlay` to demonstrate how to customize the deployment for different environments or needs.
+
+### Base Configuration (`base/`)
+
+The `base/` directory contains the core Kubernetes manifests for `s2s-proxy`:
+*   `configmap.yaml`: Contains the default application configuration (derived from `files/default.yaml` in the Helm chart).
+*   `deployment.yaml`: Defines the `s2s-proxy` Deployment, including replica count, image, ports, probes, and volume mounts for the configuration.
+*   `service.yaml`: Exposes the `s2s-proxy` application within the cluster.
+*   `kustomization.yaml`: Lists the resources and can define common labels or other base-level Kustomize instructions.
+
+The base aims to replicate the Helm chart deployed with its default values.
+
+### Overlays (`overlays/`)
+
+The `overlays/` directory is where you can define variations of the base configuration. We have provided an example `development` overlay.
+
+#### Development Overlay (`overlays/development/`)
+
+This overlay demonstrates common customization patterns:
+*   **Resource Naming**: Adds a `dev-` prefix to all resources (e.g., `dev-s2s-proxy-deployment`).
+*   **Image Customization**: Changes the image tag for the `s2s-proxy` container.
+*   **Replica Count**: Modifies the number of replicas for the Deployment using a JSON patch.
+*   **Configuration Override**: Patches the `s2s-proxy-config` ConfigMap using a strategic merge patch (`configmap-patch.yaml`). This is analogous to using `configOverride` in the Helm chart's `values.yaml`.
+
+## How to Use
+
+You will need `kubectl` (with Kustomize built-in, v1.14+) or a standalone `kustomize` CLI.
+
+### View Rendered Manifests
+
+To see the Kubernetes YAML that Kustomize will generate for a specific overlay (e.g., `development`):
+
+```bash
+# Using kubectl
+kubectl kustomize overlays/development
+
+# Or using standalone kustomize CLI
+kustomize build overlays/development
+```
+
+To view the manifests for the base configuration:
+
+```bash
+# Using kubectl
+kubectl kustomize base
+
+# Or using standalone kustomize CLI
+kustomize build base
+```
+
+### Apply to a Cluster
+
+To apply the `development` overlay configuration to your Kubernetes cluster:
+
+```bash
+kubectl apply -k overlays/development
+```
+
+To apply the base configuration (generally less common for direct application, usually an overlay is applied):
+
+```bash
+kubectl apply -k base
+```
+
+### Delete from a Cluster
+
+To delete the resources applied from the `development` overlay:
+
+```bash
+kubectl delete -k overlays/development
+```
+
+## Customizing Further
+
+1.  **Create New Overlays**: Copy the `overlays/development` directory to a new directory (e.g., `overlays/production`) and modify its `kustomization.yaml` and patches as needed.
+2.  **Modify Patches**:
+    *   Adjust `images` entries in the overlay's `kustomization.yaml` to change container images or tags.
+    *   Modify `patches` entries to change fields in the Deployment, Service, etc. JSON patches offer precise control.
+    *   Update or create new strategic merge patch files (like `configmap-patch.yaml`) to alter ConfigMap data or other resource specifications.
+3.  **Adjust the Base**: If a change should apply to all environments, consider modifying the manifests or `kustomization.yaml` in the `base/` directory. However, it's often preferable to keep the base minimal and apply all changes via overlays.
+
+This Kustomize setup provides a flexible way to manage `s2s-proxy` deployments across different environments. 

--- a/kustomize/s2s-proxy/base/configmap.yaml
+++ b/kustomize/s2s-proxy/base/configmap.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s2s-proxy-config
+data:
+  config.yaml: |
+    inbound:
+      name: "inbound-server"
+      server:
+        type: "mux"
+        mux: "muxed"
+      client:
+        tcp:
+          serverAddress: "frontend-ingress.temporal.svc.cluster.local:7233"
+          tls:
+            certificatePath: ""
+            keyPath: ""
+            serverCAPath: ""
+            serverName: ""
+
+      aclPolicy:
+        allowedMethods:
+          adminService:
+            - AddOrUpdateRemoteCluster
+            - RemoveRemoteCluster
+            - DescribeCluster
+            - DescribeMutableState
+            - GetNamespaceReplicationMessages
+            - GetWorkflowExecutionRawHistoryV2
+            - ListClusters
+            - StreamWorkflowReplicationMessages
+            - ReapplyEvents
+            - GetNamespace
+
+    outbound:
+      name: "outbound-server"
+      server:
+        tcp:
+          listenAddress: "0.0.0.0:9233"
+          tls:
+            certificatePath: ""
+            keyPath: ""
+            clientCAPath: ""
+            requireClientAuth: false
+      client:
+        type: "mux"
+        mux: "muxed"
+
+    mux:
+      - name: "muxed"
+        mode: "client"
+        client:
+          serverAddress: "" # Temporal cloud migration server endpoint
+          tls:
+            certificatePath: ""
+            keyPath: ""
+            serverCAPath: ""
+            serverName: ""
+
+    healthCheck:
+      protocol: "http"
+      listenAddress: "0.0.0.0:8234"
+
+    metrics:
+      prometheus:
+        framework: "tally"
+        listenAddress: "0.0.0.0:9090" 

--- a/kustomize/s2s-proxy/base/deployment.yaml
+++ b/kustomize/s2s-proxy/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s2s-proxy
+  labels:
+    app.kubernetes.io/name: s2s-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: s2s-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: s2s-proxy
+    spec:
+      containers:
+        - name: s2s-proxy
+          image: temporalio/s2s-proxy:v0.1.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: rpc-egress
+              containerPort: 9233
+              protocol: TCP
+            - name: rpc-healthcheck
+              containerPort: 8234
+              protocol: TCP
+            - name: rpc-metrics
+              containerPort: 9090
+              protocol: TCP
+          env:
+            - name: CONFIG_YML
+              value: "/config/config.yaml"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8234
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8234
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: s2s-proxy-config # This should match the ConfigMap name
+            defaultMode: 420 

--- a/kustomize/s2s-proxy/base/kustomization.yaml
+++ b/kustomize/s2s-proxy/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - service.yaml
+  - deployment.yaml
+
+# Common labels to add to all resources
+commonLabels:
+  app.kubernetes.io/name: s2s-proxy
+  # You might want to add instance or version labels here as well
+  # app.kubernetes.io/instance: s2s-proxy-dev
+  # app.kubernetes.io/version: "0.1.0" 

--- a/kustomize/s2s-proxy/base/service.yaml
+++ b/kustomize/s2s-proxy/base/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: s2s-proxy
+  labels:
+    app.kubernetes.io/name: s2s-proxy
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9233
+      targetPort: 9233
+      protocol: TCP
+      name: rpc-egress
+  selector:
+    app.kubernetes.io/name: s2s-proxy 

--- a/kustomize/s2s-proxy/overlays/development/configmap-patch.yaml
+++ b/kustomize/s2s-proxy/overlays/development/configmap-patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s2s-proxy-config # This name must match the base ConfigMap's name
+data:
+  config.yaml: |
+    # Only include the fields you want to change/add.
+    # Kustomize will merge this with the base config.yaml data.
+    # Note: For list items like 'mux', strategic merge typically replaces the whole list
+    # or merges items by key if a merge key is defined (e.g., 'name').
+    # If Helm's merge logic for lists is more complex (e.g., merging by index),
+    # a JSON patch on the ConfigMap might be needed for precise replication.
+    # However, for named items in a list (like 'mux' items with 'name'), Kustomize should merge.
+
+    # Example: Override serverAddress for the 'muxed' mux item
+    mux:
+      - name: "muxed" # This identifies the item in the list to merge/patch
+        client:
+          serverAddress: "override.temporal.example.com:1234" # New value
+
+    # Example: If you wanted to change healthCheck listenAddress
+    # healthCheck:
+    #  listenAddress: "0.0.0.0:7777" 

--- a/kustomize/s2s-proxy/overlays/development/kustomization.yaml
+++ b/kustomize/s2s-proxy/overlays/development/kustomization.yaml
@@ -1,0 +1,39 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Inherit from the base
+resources:
+  - ../../base
+
+# Example: Add a name prefix to all resources for this overlay
+namePrefix: dev-
+
+# Example: Change image tag
+images:
+  - name: temporalio/s2s-proxy
+    newTag: v0.2.0 # Example new tag
+
+patches:
+  # Patch for Deployment replicas
+  - target:
+      kind: Deployment
+      name: s2s-proxy
+    patch: |- # This is a JSON6902 patch
+      - op: replace
+        path: /spec/replicas
+        value: 3
+  # Strategic merge patch for the ConfigMap
+  - path: configmap-patch.yaml # This is a strategic merge patch
+    target:
+      kind: ConfigMap
+      name: s2s-proxy-config # Ensures it applies to the correct ConfigMap from the base
+# We could also patch the ConfigMap here to override configuration values.
+# For example, to change the health check port:
+# configMapGenerator:
+# - name: s2s-proxy-config # This must match the name of the configmap in the base
+#   behavior: merge
+#   literals:
+#   - | 
+#     healthCheck.listenAddress="0.0.0.0:8888"
+# The above literal merge might not work directly for nested YAML, 
+# a JSON patch or strategic merge on the configmap might be better for complex changes. 


### PR DESCRIPTION
## What was changed

Added Kustomize support

## Why?

Kustomize is very popular in k8s ecosystem. Figured it would be an enhancement.


---

See `//kustomize/s2s-proxy/README.md`