### PR TITLE
Allow ListNamespaces as it is needed for disconnecting cluster safely

### DIFF
--- a/auth/policy.go
+++ b/auth/policy.go
@@ -5,7 +5,6 @@ import "slices"
 var (
 	workflowServiceDisallowedAPIs = []string{
 		"DeprecateNamespace",
-		"ListNamespaces",
 		"RegisterNamespace",
 	}
 )

--- a/interceptor/access_control_test.go
+++ b/interceptor/access_control_test.go
@@ -92,7 +92,11 @@ func TestAllowedWorkflowMigrationAPIs(t *testing.T) {
 			expAllowed: true,
 		},
 		{
-			methodName: "ListNamespaces",
+			methodName: "DeprecateNamespace",
+			expAllowed: false,
+		},
+		{
+			methodName: "RegisterNamespace",
 			expAllowed: false,
 		},
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

As one of the safety checks before disconnecting two clusters, we want to make sure no namespace is still being replicated between the two and this is done by calling `ListNamespaces` on both clusters to fetch replication metedata. 

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
