### PR TITLE
Add benchmark for name translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GOLANGCI_LINT ?= $(shell which golangci-lint)
 # Disable cgo by default.
 CGO_ENABLED ?= 0
 TEST_ARG ?= -race -timeout=5m
+BENCH_ARG ?= -benchtime=5000x
 
 ALL_SRC         := $(shell find . -name "*.go")
 ALL_SRC         += go.mod
@@ -30,6 +31,9 @@ s2s-proxy: $(ALL_SRC)
 lint:
 	@printf $(COLOR) "Running golangci-lint...\n"
 	@$(GOLANGCI_LINT) run
+
+bench:
+	@go test -run '^$$' -benchmem -bench=. ./... $(BENCH_ARG)
 
 # Mocks
 clean-mocks:

--- a/interceptor/access_control_test.go
+++ b/interceptor/access_control_test.go
@@ -175,6 +175,6 @@ func testNamespaceAccessControl(t *testing.T, objCases []objCase) {
 }
 
 func TestNamespaceAccessControl(t *testing.T) {
-	testNamespaceAccessControl(t, generateNamespaceObjCases(t))
+	testNamespaceAccessControl(t, generateNamespaceObjCases())
 	testNamespaceAccessControl(t, generateNamespaceReplicationMessages())
 }

--- a/interceptor/namespace_translator_test.go
+++ b/interceptor/namespace_translator_test.go
@@ -50,7 +50,7 @@ type (
 	}
 )
 
-func generateNamespaceObjCases(t *testing.T) []objCase {
+func generateNamespaceObjCases() []objCase {
 	return []objCase{
 		{
 			objName:           "Namespace field",
@@ -174,8 +174,8 @@ func generateNamespaceObjCases(t *testing.T) []objCase {
 				return &adminservice.GetWorkflowExecutionRawHistoryV2Response{
 					NextPageToken: []byte("some-token"),
 					HistoryBatches: []*common.DataBlob{
-						makeHistoryEventsBlob(t, ns),
-						makeHistoryEventsBlob(t, ns),
+						makeHistoryEventsBlob(ns),
+						makeHistoryEventsBlob(ns),
 					},
 					HistoryNodeIds: []int64{123},
 				}
@@ -245,8 +245,8 @@ func generateNamespaceObjCases(t *testing.T) []objCase {
 											NamespaceId:  "some-ns-id",
 											WorkflowId:   "some-wf-id",
 											RunId:        "some-run-id",
-											Events:       makeHistoryEventsBlob(t, ns),
-											NewRunEvents: makeHistoryEventsBlob(t, ns),
+											Events:       makeHistoryEventsBlob(ns),
+											NewRunEvents: makeHistoryEventsBlob(ns),
 										},
 									},
 								},
@@ -256,8 +256,8 @@ func generateNamespaceObjCases(t *testing.T) []objCase {
 											NamespaceId:  "some-ns-id",
 											WorkflowId:   "some-wf-id-2",
 											RunId:        "some-run-id-2",
-											Events:       makeHistoryEventsBlob(t, ns),
-											NewRunEvents: makeHistoryEventsBlob(t, ns),
+											Events:       makeHistoryEventsBlob(ns),
+											NewRunEvents: makeHistoryEventsBlob(ns),
 										},
 									},
 								},
@@ -296,12 +296,12 @@ func generateNamespaceObjCases(t *testing.T) []objCase {
 											WorkflowId:  "some-wf-id",
 											RunId:       "some-run-id",
 											EventBatches: []*common.DataBlob{
-												makeHistoryEventsBlob(t, ns),
-												makeHistoryEventsBlob(t, ns),
+												makeHistoryEventsBlob(ns),
+												makeHistoryEventsBlob(ns),
 											},
 											NewRunInfo: &replicationspb.NewRunInfo{
 												RunId:      "some-new-run-id",
-												EventBatch: makeHistoryEventsBlob(t, ns),
+												EventBatch: makeHistoryEventsBlob(ns),
 											},
 										},
 									},
@@ -312,12 +312,12 @@ func generateNamespaceObjCases(t *testing.T) []objCase {
 											VersionedTransitionArtifact: &replicationspb.VersionedTransitionArtifact{
 												StateAttributes: nil,
 												EventBatches: []*common.DataBlob{
-													makeHistoryEventsBlob(t, ns),
-													makeHistoryEventsBlob(t, ns),
+													makeHistoryEventsBlob(ns),
+													makeHistoryEventsBlob(ns),
 												},
 												NewRunInfo: &replicationspb.NewRunInfo{
 													RunId:      "some-run-id",
-													EventBatch: makeHistoryEventsBlob(t, ns),
+													EventBatch: makeHistoryEventsBlob(ns),
 												},
 											},
 											NamespaceId: "some-ns-id",
@@ -540,7 +540,7 @@ func testTranslateNamespace(t *testing.T, objCases []objCase) {
 	}
 }
 
-func makeHistoryEventsBlob(t *testing.T, ns string) *common.DataBlob {
+func makeHistoryEventsBlob(ns string) *common.DataBlob {
 	evts := []*history.HistoryEvent{
 		{
 			EventId:   1,
@@ -568,12 +568,14 @@ func makeHistoryEventsBlob(t *testing.T, ns string) *common.DataBlob {
 
 	s := serialization.NewSerializer()
 	blob, err := s.SerializeEvents(evts, enums.ENCODING_TYPE_PROTO3)
-	require.NoError(t, err)
+	if err != nil {
+		panic(err)
+	}
 	return blob
 }
 
 func TestTranslateNamespaceName(t *testing.T) {
-	testTranslateNamespace(t, generateNamespaceObjCases(t))
+	testTranslateNamespace(t, generateNamespaceObjCases())
 }
 
 func TestTranslateNamespaceReplicationMessages(t *testing.T) {

--- a/interceptor/reflection_test.go
+++ b/interceptor/reflection_test.go
@@ -1,0 +1,42 @@
+package interceptor
+
+import (
+	"testing"
+)
+
+func BenchmarkVisitNamespace(b *testing.B) {
+	variants := []struct {
+		testName    string
+		inputNSName string
+		mapping     map[string]string
+	}{
+		{
+			testName:    "name changed",
+			inputNSName: "orig",
+			mapping:     map[string]string{"orig": "orig.cloud"},
+		},
+		{
+			testName:    "name unchanged",
+			inputNSName: "orig",
+			mapping:     map[string]string{"other": "other.cloud"},
+		},
+	}
+	cases := generateNamespaceObjCases()
+
+	for _, c := range cases {
+		b.Run(c.objName, func(b *testing.B) {
+			for _, variant := range variants {
+				translator := createNameTranslator(variant.mapping)
+				b.Run(variant.testName, func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						b.StopTimer()
+						input := c.makeType(variant.inputNSName)
+
+						b.StartTimer()
+						visitNamespace(input, translator)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What was changed

Add a benchmark test for the reflection-based name translation

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

* `make bench` - (also runs another benchmark)
* `BENCH_ARG="-bench '^BenchmarkVisitNamespace' -benchtime=5000x" make bench` - just run the new bench function

```
BenchmarkVisitNamespace/Namespace_field/name_changed-14                     5000               860.8 ns/op           240 B/op          6 allocs/op
BenchmarkVisitNamespace/Namespace_field/name_unchanged-14                   5000               720.1 ns/op           224 B/op          5 allocs/op
BenchmarkVisitNamespace/WorkflowNamespace_field/name_changed-14             5000               710.8 ns/op           240 B/op          6 allocs/op
BenchmarkVisitNamespace/WorkflowNamespace_field/name_unchanged-14                   5000               632.7 ns/op           224 B/op          5 allocs/op
BenchmarkVisitNamespace/Nested_Namespace_field/name_changed-14                      5000              1186 ns/op             512 B/op         11 allocs/op
BenchmarkVisitNamespace/Nested_Namespace_field/name_unchanged-14                    5000               972.0 ns/op           496 B/op         10 allocs/op
BenchmarkVisitNamespace/list_of_structs/name_changed-14                             5000              1359 ns/op             584 B/op         12 allocs/op
BenchmarkVisitNamespace/list_of_structs/name_unchanged-14                           5000              1176 ns/op             568 B/op         11 allocs/op
BenchmarkVisitNamespace/list_of_ptrs/name_changed-14                                5000              1398 ns/op             648 B/op         13 allocs/op
BenchmarkVisitNamespace/list_of_ptrs/name_unchanged-14                              5000              1230 ns/op             632 B/op         12 allocs/op
BenchmarkVisitNamespace/RespondWorkflowTaskCompletedRequest/name_changed-14                 5000              7772 ns/op           11048 B/op         74 allocs/op
BenchmarkVisitNamespace/RespondWorkflowTaskCompletedRequest/name_unchanged-14               5000              7656 ns/op           11000 B/op         71 allocs/op
BenchmarkVisitNamespace/PollWorkflowTaskQueueResponse/name_changed-14                       5000              5436 ns/op            5984 B/op         55 allocs/op
BenchmarkVisitNamespace/PollWorkflowTaskQueueResponse/name_unchanged-14                     5000              5183 ns/op            5968 B/op         54 allocs/op
BenchmarkVisitNamespace/GetWorkflowExecutionRawHistoryV2Response/name_changed-14            5000             22405 ns/op           39648 B/op        313 allocs/op
BenchmarkVisitNamespace/GetWorkflowExecutionRawHistoryV2Response/name_unchanged-14          5000             21075 ns/op           37992 B/op        284 allocs/op
BenchmarkVisitNamespace/DescribeNamespaceResponse/name_changed-14                           5000              2641 ns/op            2656 B/op         22 allocs/op
BenchmarkVisitNamespace/DescribeNamespaceResponse/name_unchanged-14                         5000              2776 ns/op            2656 B/op         22 allocs/op
BenchmarkVisitNamespace/UpdateNamespaceResponse/name_changed-14                             5000              5229 ns/op            5704 B/op         45 allocs/op
BenchmarkVisitNamespace/UpdateNamespaceResponse/name_unchanged-14                           5000              5046 ns/op            5704 B/op         45 allocs/op
BenchmarkVisitNamespace/ListNamespacesResponse/name_changed-14                              5000              3345 ns/op            2976 B/op         30 allocs/op
BenchmarkVisitNamespace/ListNamespacesResponse/name_unchanged-14                            5000              3353 ns/op            2976 B/op         30 allocs/op
BenchmarkVisitNamespace/StreamWorkflowReplicationMessagesResponse/name_changed-14           5000            103102 ns/op          178443 B/op       1638 allocs/op
BenchmarkVisitNamespace/StreamWorkflowReplicationMessagesResponse/name_unchanged-14         5000             99668 ns/op          170203 B/op       1494 allocs/op
BenchmarkVisitNamespace/circular_pointer/name_changed-14                                    5000              1273 ns/op             592 B/op         13 allocs/op
BenchmarkVisitNamespace/circular_pointer/name_unchanged-14                                  5000              1101 ns/op             560 B/op         11 allocs/op
```


3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
