### PR TITLE
Support translating cluster name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,15 +104,16 @@ type (
 	}
 
 	S2SProxyConfig struct {
-		Inbound                  *ProxyConfig                   `yaml:"inbound"`
-		Outbound                 *ProxyConfig                   `yaml:"outbound"`
-		MuxTransports            []MuxTransportConfig           `yaml:"mux"`
-		HealthCheck              *HealthCheckConfig             `yaml:"healthCheck"`
-		NamespaceNameTranslation NamespaceNameTranslationConfig `yaml:"namespaceNameTranslation"`
-		Metrics                  *MetricsConfig                 `yaml:"metrics"`
+		Inbound                  *ProxyConfig          `yaml:"inbound"`
+		Outbound                 *ProxyConfig          `yaml:"outbound"`
+		MuxTransports            []MuxTransportConfig  `yaml:"mux"`
+		HealthCheck              *HealthCheckConfig    `yaml:"healthCheck"`
+		NamespaceNameTranslation NameTranslationConfig `yaml:"namespaceNameTranslation"`
+		ClusterNameTranslation   NameTranslationConfig `yaml:"clusterNameTranslation"`
+		Metrics                  *MetricsConfig        `yaml:"metrics"`
 	}
 
-	NamespaceNameTranslationConfig struct {
+	NameTranslationConfig struct {
 		Mappings []NameMappingConfig `yaml:"mappings"`
 	}
 
@@ -276,7 +277,7 @@ func (mc *MockConfigProvider) GetS2SProxyConfig() S2SProxyConfig {
 }
 
 // ToMaps returns request and response mappings.
-func (n NamespaceNameTranslationConfig) ToMaps(inBound bool) (map[string]string, map[string]string) {
+func (n NameTranslationConfig) ToMaps(inBound bool) (map[string]string, map[string]string) {
 	reqMap := make(map[string]string)
 	respMap := make(map[string]string)
 	if inBound {

--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -16,6 +16,7 @@ var (
 		"WorkflowNamespace":       true, // PollActivityTaskQueueResponse
 		"ParentWorkflowNamespace": true, // WorkflowExecutionStartedEventAttributes
 	}
+
 	dataBlobFieldNames = map[string]bool{
 		"Events":         true, // HistoryTaskAttributes
 		"NewRunEvents":   true, // HistoryTaskAttributes
@@ -23,6 +24,13 @@ var (
 		"EventBatches":   true, // BackfillHistoryTaskAttributes, VersionedTransitionArtifact
 		"EventsBatches":  true, // HistoryTaskAttributes
 		"HistoryBatches": true, // GetWorkflowExecutionRawHistoryV2
+	}
+
+	clusterNameFields = map[string]bool{
+		"ClusterName":       true, // DescribeCluster, ListClusters, ReplicationTasks, GetNamespace (Clusters)
+		"SourceCluster":     true, // HistoryDLQKey
+		"TargetCluster":     true, // HistoryDLQKey
+		"ActiveClusterName": true, // GetNamespace
 	}
 )
 
@@ -64,47 +72,19 @@ func visitNamespace(obj any, match matcher) (bool, error) {
 			}
 			matched = matched || ok
 		} else if dataBlobFieldNames[fieldType.Name] {
-			switch evt := vwp.Interface().(type) {
-			case []*common.DataBlob:
-				newEvts, changed, err := translateDataBlobs(match, evt...)
-				if err != nil {
-					return visit.Stop, err
-				}
-				if changed {
-					if err := visit.Assign(vwp, reflect.ValueOf(newEvts)); err != nil {
-						return visit.Stop, err
-					}
-				}
-				matched = matched || changed
-			case *common.DataBlob:
-				newEvt, changed, err := translateOneDataBlob(match, evt)
-				if err != nil {
-					return visit.Stop, err
-				}
-				if changed {
-					if err := visit.Assign(vwp, reflect.ValueOf(newEvt)); err != nil {
-						return visit.Stop, err
-					}
-				}
-				matched = matched || changed
-			default:
-				return visit.Continue, nil
+			changed, err := visitDataBlobs(vwp, match, visitNamespace)
+			if err != nil {
+				return visit.Stop, err
 			}
+			matched = matched || changed
+			return visit.Continue, nil
 		} else if namespaceFieldNames[fieldType.Name] {
-			name, ok := vwp.Interface().(string)
-			if !ok {
-				return visit.Continue, nil
+			changed, err := visitStringField(vwp, match)
+			if err != nil {
+				return visit.Stop, err
 			}
-			newName, ok := match(name)
-			if !ok {
-				return visit.Continue, nil
-			}
-			if name != newName {
-				if err := visit.Assign(vwp, reflect.ValueOf(newName)); err != nil {
-					return visit.Stop, err
-				}
-			}
-			matched = matched || ok
+			matched = matched || changed
+			return visit.Continue, nil
 		}
 
 		return visit.Continue, nil
@@ -112,11 +92,94 @@ func visitNamespace(obj any, match matcher) (bool, error) {
 	return matched, err
 }
 
-func translateOneDataBlob(match matcher, blob *common.DataBlob) (*common.DataBlob, bool, error) {
+// visitClusterName uses reflection to recursively visit all fields
+// in the given object. When it finds matching string fields, it invokes
+// the provided match function.
+func visitClusterName(obj any, match matcher) (bool, error) {
+	var matched bool
+
+	// The visitor function can return Skip, Stop, or Continue to control recursion.
+	err := visit.Values(obj, func(vwp visit.ValueWithParent) (visit.Action, error) {
+		// Grab name of this struct field from the parent.
+		if vwp.Parent == nil || vwp.Parent.Kind() != reflect.Struct {
+			return visit.Continue, nil
+		}
+		fieldType := vwp.Parent.Type().Field(int(vwp.Index.Int()))
+		if !fieldType.IsExported() {
+			// Ignore unexported fields, particularly private gRPC message fields.
+			return visit.Skip, nil
+		}
+
+		if dataBlobFieldNames[fieldType.Name] {
+			changed, err := visitDataBlobs(vwp, match, visitClusterName)
+			if err != nil {
+				return visit.Stop, err
+			}
+			matched = matched || changed
+			return visit.Continue, nil
+		} else if clusterNameFields[fieldType.Name] {
+			changed, err := visitStringField(vwp, match)
+			if err != nil {
+				return visit.Stop, err
+			}
+			matched = matched || changed
+			return visit.Continue, nil
+		}
+
+		return visit.Continue, nil
+	})
+	return matched, err
+}
+
+func visitDataBlobs(vwp visit.ValueWithParent, match matcher, visitor visitor) (bool, error) {
+	switch evt := vwp.Interface().(type) {
+	case []*common.DataBlob:
+		newEvts, changed, err := translateDataBlobs(match, visitor, evt...)
+		if err != nil {
+			return changed, err
+		}
+		if changed {
+			if err := visit.Assign(vwp, reflect.ValueOf(newEvts)); err != nil {
+				return changed, err
+			}
+		}
+		return changed, nil
+	case *common.DataBlob:
+		newEvt, changed, err := translateOneDataBlob(match, visitor, evt)
+		if err != nil {
+			return changed, err
+		}
+		if changed {
+			if err := visit.Assign(vwp, reflect.ValueOf(newEvt)); err != nil {
+				return changed, err
+			}
+		}
+		return changed, nil
+	default:
+		return false, nil
+	}
+}
+
+func visitStringField(vwp visit.ValueWithParent, match matcher) (bool, error) {
+	name, ok := vwp.Interface().(string)
+	if !ok {
+		return false, nil
+	}
+	newName, ok := match(name)
+	if !ok || name == newName {
+		return false, nil
+	}
+	if err := visit.Assign(vwp, reflect.ValueOf(newName)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func translateOneDataBlob(match matcher, visit visitor, blob *common.DataBlob) (*common.DataBlob, bool, error) {
 	if blob == nil || len(blob.Data) == 0 {
 		return blob, false, nil
 	}
-	blobs, changed, err := translateDataBlobs(match, blob)
+	blobs, changed, err := translateDataBlobs(match, visit, blob)
 	if err != nil {
 		return nil, false, err
 	}
@@ -126,7 +189,7 @@ func translateOneDataBlob(match matcher, blob *common.DataBlob) (*common.DataBlo
 	return blobs[0], changed, err
 }
 
-func translateDataBlobs(match matcher, blobs ...*common.DataBlob) ([]*common.DataBlob, bool, error) {
+func translateDataBlobs(match matcher, visit visitor, blobs ...*common.DataBlob) ([]*common.DataBlob, bool, error) {
 	if len(blobs) == 0 {
 		return blobs, false, nil
 	}
@@ -140,7 +203,7 @@ func translateDataBlobs(match matcher, blobs ...*common.DataBlob) ([]*common.Dat
 			return blobs, anyChanged, err
 		}
 
-		changed, err := visitNamespace(evt, match)
+		changed, err := visit(evt, match)
 		if err != nil {
 			return blobs, anyChanged, err
 		}

--- a/interceptor/translator.go
+++ b/interceptor/translator.go
@@ -21,6 +21,14 @@ func NewNamespaceNameTranslator(reqMap, respMap map[string]string) Translator {
 	}
 }
 
+func NewClusterNameTranslator(reqMap, respMap map[string]string) Translator {
+	return &translatorImpl{
+		matchReq:  createNameTranslator(reqMap),
+		matchResp: createNameTranslator(respMap),
+		visitor:   visitClusterName,
+	}
+}
+
 func (n *translatorImpl) TranslateRequest(req any) (bool, error) {
 	return n.visitor(req, n.matchReq)
 }


### PR DESCRIPTION
## What was changed

* Add `clusterNameTranslation` field to the config file (same format as `namespaceNameTranslation`)
* Add `visitClusterName` reflection function to translate cluster name, and bit of code deduplication

## Why?

<!-- Tell your future self why have you made these changes -->

## Checklist

<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
