### PR TITLE
Add pprof port flag

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -55,6 +56,12 @@ func buildCLIOptions() *cli.App {
 					Usage:    "Set log level(debug, info, warn, error). Default level is info",
 					Required: false,
 				},
+				&cli.IntFlag{
+					Name:        config.PProfPortFlag,
+					Usage:       "Port for the pprof HTTP server. Set to -1 to disable the pprof server.",
+					Required:    false,
+					DefaultText: "6060",
+				},
 			},
 			Action: startProxy,
 		},
@@ -63,19 +70,30 @@ func buildCLIOptions() *cli.App {
 	return app
 }
 
-func startProfile() {
+func startProfile(c *cli.Context) {
+	port := 6060
+	if c.IsSet(config.PProfPortFlag) { // Allow for port=0 to select a random port.
+		port = c.Int(config.PProfPortFlag)
+	}
+	if port < 0 {
+		return // pprof server disabled
+	}
+	if port > 65535 {
+		panic(fmt.Sprintf("invalid pprof port number %d", port))
+	}
+
+	address := fmt.Sprintf("localhost:%d", port)
 	go func() {
-		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+		if err := http.ListenAndServe(address, nil); err != nil {
 			panic(err)
 		}
 	}()
-
 }
 
 func startProxy(c *cli.Context) error {
 	var proxyParams ProxyParams
 
-	startProfile()
+	startProfile(c)
 
 	var logCfg log.Config
 	if logLevel := c.String(config.LogLevelFlag); len(logLevel) != 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 const (
 	ConfigPathFlag = "config"
 	LogLevelFlag   = "level"
+	PProfPortFlag  = "pprof-port"
 )
 
 type TransportType string


### PR DESCRIPTION
## What was changed

Add `--pprof-port` flag to allow changing or disabling the pprof server.

## Why?

To run two s2s-proxy locally without conflicting pprof bind ports

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Help text:

```
$ ~/code/s2s-proxy/bins/s2s-proxy start -h
NAME:
   s2s-proxy start - Starts the proxy.

USAGE:
   s2s-proxy start [command options]

OPTIONS:
   --config value      path to proxy config yaml file
   --level value       Set log level(debug, info, warn, error). Default level is info
   --pprof-port value  Port for the pprof HTTP server. Set to -1 to disable the pprof server. (default: 6060)
   --help, -h          show help
```

Start two proxies with `--pprof-port -1` (pprof disabled)

```
$ s2s-proxy start --config proxy-a.yaml --level info --pprof-port -1
$ s2s-proxy start --config proxy-b.yaml --level info --pprof-port -1
$ curl localhost:6060
curl: (7) Failed to connect to localhost port 6060 after 0 ms: Couldn't connect to server
```

Start proxy with different port number

```
$ s2s-proxy start --config proxy-a.yaml --pprof-port 5050
# Check for some http response
$ curl localhost:5050
404 page not found
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
