### PR TITLE
Filter ListNamespacesResponse from the proxy to remove names not in the ACL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+#Workspace directory from GoLand
+.idea/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/temporalio/s2s-proxy/auth"
 	"github.com/temporalio/s2s-proxy/client"
 	"github.com/temporalio/s2s-proxy/config"
 	"github.com/temporalio/s2s-proxy/encryption"
@@ -77,6 +78,13 @@ func makeServerOptions(logger log.Logger, cfg config.ProxyConfig, isInbound bool
 	return opts, nil
 }
 
+func (ps *ProxyServer) makeNamespaceACL() *auth.AccessControl {
+	if ps.opts.IsInbound && ps.config.ACLPolicy != nil {
+		return auth.NewAccesControl(ps.config.ACLPolicy.AllowedNamespaces)
+	}
+	return nil
+}
+
 func (ps *ProxyServer) startServer(
 	serverTransport transport.ServerTransport,
 	clientTransport transport.ClientTransport,
@@ -95,7 +103,7 @@ func (ps *ProxyServer) startServer(
 		cfg.Name,
 		cfg.Server,
 		NewAdminServiceProxyServer(cfg.Name, cfg.Client, clientFactory, opts, logger),
-		NewWorkflowServiceProxyServer(cfg.Name, cfg.Client, clientFactory, logger),
+		NewWorkflowServiceProxyServer(cfg.Name, cfg.Client, clientFactory, ps.makeNamespaceACL(), logger),
 		serverOpts,
 		serverTransport,
 		logger,

--- a/proxy/workflowservice.go
+++ b/proxy/workflowservice.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 
+	"github.com/temporalio/s2s-proxy/auth"
 	"github.com/temporalio/s2s-proxy/client"
 	feclient "github.com/temporalio/s2s-proxy/client/frontend"
 	"github.com/temporalio/s2s-proxy/common"
@@ -16,6 +17,7 @@ type (
 	workflowServiceProxyServer struct {
 		workflowservice.UnimplementedWorkflowServiceServer
 		workflowServiceClient workflowservice.WorkflowServiceClient
+		namespaceAccess       *auth.AccessControl
 		logger                log.Logger
 	}
 )
@@ -27,15 +29,37 @@ func NewWorkflowServiceProxyServer(
 	serviceName string,
 	clientConfig config.ProxyClientConfig,
 	clientFactory client.ClientFactory,
+	namespaceAccess *auth.AccessControl,
 	logger log.Logger,
 ) workflowservice.WorkflowServiceServer {
 	logger = log.With(logger, common.ServiceTag(serviceName))
 	clientProvider := client.NewClientProvider(clientConfig, clientFactory, logger)
 	return &workflowServiceProxyServer{
 		workflowServiceClient: feclient.NewLazyClient(clientProvider),
+		namespaceAccess:       namespaceAccess,
 		logger:                logger,
 	}
 }
+
+// ListNamespaces wraps the same method on the underlying workflowservice.WorkflowServiceClient.
+// In particular, this version checks the returned namespaces against the configured ACL and makes sure we're not
+// returning disallowed namespaces to the customer.
+func (s *workflowServiceProxyServer) ListNamespaces(ctx context.Context, req *workflowservice.ListNamespacesRequest) (*workflowservice.ListNamespacesResponse, error) {
+	response, err := s.workflowServiceClient.ListNamespaces(ctx, req)
+	if response != nil && response.Namespaces != nil && s.namespaceAccess != nil {
+		// Even in the case of error, if there is a Namespaces list to iterate we want to remove any partial success data
+		newNamespaceList := make([]*workflowservice.DescribeNamespaceResponse, 0, len(response.Namespaces))
+		for _, ns := range response.Namespaces {
+			if s.namespaceAccess.IsAllowed(ns.NamespaceInfo.Name) {
+				newNamespaceList = append(newNamespaceList, ns)
+			}
+		}
+		response.Namespaces = newNamespaceList
+	}
+	return response, err
+}
+
+// Passthrough APIs below this point
 
 func (s *workflowServiceProxyServer) CountWorkflowExecutions(ctx context.Context, in0 *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
 	return s.workflowServiceClient.CountWorkflowExecutions(ctx, in0)
@@ -123,10 +147,6 @@ func (s *workflowServiceProxyServer) ListBatchOperations(ctx context.Context, in
 
 func (s *workflowServiceProxyServer) ListClosedWorkflowExecutions(ctx context.Context, in0 *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
 	return s.workflowServiceClient.ListClosedWorkflowExecutions(ctx, in0)
-}
-
-func (s *workflowServiceProxyServer) ListNamespaces(ctx context.Context, in0 *workflowservice.ListNamespacesRequest) (*workflowservice.ListNamespacesResponse, error) {
-	return s.workflowServiceClient.ListNamespaces(ctx, in0)
 }
 
 func (s *workflowServiceProxyServer) ListOpenWorkflowExecutions(ctx context.Context, in0 *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {

--- a/proxy/workflowservice_test.go
+++ b/proxy/workflowservice_test.go
@@ -1,0 +1,100 @@
+package proxy
+
+import (
+	"context"
+	gomockold "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/temporalio/s2s-proxy/auth"
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/encryption"
+	clientmock "github.com/temporalio/s2s-proxy/mocks/client"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/namespace/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
+	"go.temporal.io/server/common/log"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/metadata"
+	"slices"
+	"testing"
+)
+
+var (
+	listNamespacesResponse = &workflowservice.ListNamespacesResponse{
+		Namespaces: []*workflowservice.DescribeNamespaceResponse{
+			{
+				NamespaceInfo: &namespace.NamespaceInfo{
+					Name:        "Bob Ross's Paint Shop",
+					State:       enums.NAMESPACE_STATE_REGISTERED,
+					Description: "Happy Little Trees aplenty",
+					OwnerEmail:  "bob-ross@happy-accidents.com",
+					Data:        nil,
+					Id:          "abcd-efgh-ijkl-mnop",
+					Capabilities: &namespace.NamespaceInfo_Capabilities{
+						EagerWorkflowStart: true,
+						SyncUpdate:         true,
+						AsyncUpdate:        true,
+					},
+					SupportsSchedules: true,
+				},
+			},
+			{
+				NamespaceInfo: &namespace.NamespaceInfo{
+					Name:        "Steve's Auto Repair",
+					State:       enums.NAMESPACE_STATE_REGISTERED,
+					Description: "It's not in Bob's cluster",
+					OwnerEmail:  "steve@sad-accidents.com",
+					Data:        nil,
+					Id:          "qrst-uvwx-yzab-cdef",
+					Capabilities: &namespace.NamespaceInfo_Capabilities{
+						EagerWorkflowStart: true,
+						SyncUpdate:         true,
+						AsyncUpdate:        true,
+					},
+					SupportsSchedules: true,
+				},
+			},
+		},
+	}
+)
+
+// Simple test for the workflow client filtering: This mocks out the underlying WorkflowServiceClient and returns
+// a predefined set of namespaces to the proxy layer. Then we check to make sure the proxy kept the allowed namespace
+// and rejected the disallowed namespace.
+func TestNamespaceFiltering(t *testing.T) {
+	clientFactoryController := gomock.NewController(t)
+	// workflowservicemock is still using golang-mock and not uber-mock, so we get to have two controllers here
+	wfServiceController := gomockold.NewController(t)
+	mockServiceClient := workflowservicemock.NewMockWorkflowServiceClient(wfServiceController)
+	mockServiceClient.EXPECT().ListNamespaces(gomock.Any(), gomock.Any()).Return(listNamespacesResponse, nil)
+
+	mockClientFactory := clientmock.NewMockClientFactory(clientFactoryController)
+	clientConfig := config.ProxyClientConfig{
+		TCPClientSetting: config.TCPClientSetting{
+			ServerAddress: "fake-forward-address",
+			TLS:           encryption.ClientTLSConfig{},
+		},
+	}
+	mockClientFactory.EXPECT().NewRemoteWorkflowServiceClient(clientConfig).Return(mockServiceClient, nil).Times(1)
+	wfProxy := NewWorkflowServiceProxyServer("My cool test server", clientConfig, mockClientFactory,
+		auth.NewAccesControl([]string{"Bob Ross's Paint Shop"}), log.NewTestLogger())
+
+	res, _ := wfProxy.ListNamespaces(metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{})),
+		&workflowservice.ListNamespacesRequest{
+			PageSize:        10,
+			NextPageToken:   nil,
+			NamespaceFilter: &namespace.NamespaceFilter{IncludeDeleted: true},
+		})
+
+	assert.NotEqualf(t, -1, slices.IndexFunc(res.Namespaces, func(ns *workflowservice.DescribeNamespaceResponse) bool {
+		return ns.NamespaceInfo.Name == "Bob Ross's Paint Shop"
+	}), "Couldn't find \"%s\" in the response! It should have matched the ACL.\nResponse: %s", "Bob Ross's Paint Shop", res.Namespaces)
+	steveIndex := slices.IndexFunc(res.Namespaces, func(ns *workflowservice.DescribeNamespaceResponse) bool {
+		return ns.NamespaceInfo.Name == "Steve's Auto Repair"
+	})
+	var matchingNS *namespace.NamespaceInfo
+	if steveIndex > 0 {
+		matchingNS = res.Namespaces[steveIndex].NamespaceInfo
+	}
+	assert.Equalf(t, -1, steveIndex, "Shouldn't have found namespace %s\n in list response: %s", matchingNS, res.Namespaces)
+}


### PR DESCRIPTION
## What was changed
After the proxy calls the upstream workflowservice, filter namespaces not in the ACL out of the response.

## Why?
In the future, we'll want to migrate into cells with other customers. When we do that, we don't want to leak namespace details between customers.

1. Closes https://temporalio.atlassian.net/browse/CGS-1033

2. How was this tested:
Added a test in proxy/workflowservice_test.go