### PR TITLE
Add search attribute translation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -283,6 +283,10 @@ func (mc *MockConfigProvider) GetS2SProxyConfig() S2SProxyConfig {
 	return mc.config
 }
 
+func (n NameTranslationConfig) IsEnabled() bool {
+	return len(n.Mappings) > 0
+}
+
 // ToMaps returns request and response mappings.
 func (n NameTranslationConfig) ToMaps(inBound bool) (map[string]string, map[string]string) {
 	reqMap := make(map[string]string)

--- a/config/config.go
+++ b/config/config.go
@@ -106,20 +106,21 @@ type (
 	}
 
 	S2SProxyConfig struct {
-		Inbound                  *ProxyConfig                   `yaml:"inbound"`
-		Outbound                 *ProxyConfig                   `yaml:"outbound"`
-		MuxTransports            []MuxTransportConfig           `yaml:"mux"`
-		HealthCheck              *HealthCheckConfig             `yaml:"healthCheck"`
-		NamespaceNameTranslation NamespaceNameTranslationConfig `yaml:"namespaceNameTranslation"`
-		Metrics                  *MetricsConfig                 `yaml:"metrics"`
-		ProfilingConfig          ProfilingConfig                `yaml:"profiling"`
+		Inbound                    *ProxyConfig          `yaml:"inbound"`
+		Outbound                   *ProxyConfig          `yaml:"outbound"`
+		MuxTransports              []MuxTransportConfig  `yaml:"mux"`
+		HealthCheck                *HealthCheckConfig    `yaml:"healthCheck"`
+		NamespaceNameTranslation   NameTranslationConfig `yaml:"namespaceNameTranslation"`
+		SearchAttributeTranslation NameTranslationConfig `yaml:"searchAttributeTranslation"`
+		Metrics                    *MetricsConfig        `yaml:"metrics"`
+		ProfilingConfig            ProfilingConfig       `yaml:"profiling"`
 	}
 
 	ProfilingConfig struct {
 		PProfHTTPAddress string `yaml:"pprofAddress"`
 	}
 
-	NamespaceNameTranslationConfig struct {
+	NameTranslationConfig struct {
 		Mappings []NameMappingConfig `yaml:"mappings"`
 	}
 
@@ -283,7 +284,7 @@ func (mc *MockConfigProvider) GetS2SProxyConfig() S2SProxyConfig {
 }
 
 // ToMaps returns request and response mappings.
-func (n NamespaceNameTranslationConfig) ToMaps(inBound bool) (map[string]string, map[string]string) {
+func (n NameTranslationConfig) ToMaps(inBound bool) (map[string]string, map[string]string) {
 	reqMap := make(map[string]string)
 	respMap := make(map[string]string)
 	if inBound {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/gogo/status v1.1.1
+	github.com/golang/mock v1.7.0-rc.1
 	github.com/hashicorp/yamux v0.1.2
 	github.com/keilerkonzept/visit v1.1.1
 	github.com/stretchr/testify v1.10.0
@@ -34,7 +35,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/mock v1.7.0-rc.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect

--- a/interceptor/access_control.go
+++ b/interceptor/access_control.go
@@ -40,7 +40,7 @@ func NewAccessControlInterceptor(
 	}
 }
 
-func createNamespaceAccessControl(access *auth.AccessControl) matcher {
+func createNamespaceAccessControl(access *auth.AccessControl) stringMatcher {
 	return func(name string) (string, bool) {
 		var notAllowed bool
 		if access != nil {

--- a/interceptor/access_control_test.go
+++ b/interceptor/access_control_test.go
@@ -160,7 +160,7 @@ func testNamespaceAccessControl(t *testing.T, objCases []objCase) {
 						require.ErrorContains(t, err, c.expError)
 					} else {
 						require.NoError(t, err)
-						if c.containsNamespace {
+						if c.containsObj {
 							require.Equal(t, ts.expAllowed, allowed)
 						} else {
 							require.True(t, allowed)

--- a/interceptor/namespace_translator_test.go
+++ b/interceptor/namespace_translator_test.go
@@ -540,7 +540,7 @@ func testTranslateObj(
 					expOutput := c.makeType(ts.outputName)
 					expChanged := ts.inputName != ts.outputName
 
-					changed, err := visitor(input, createNameMatcher(ts.mapping))
+					changed, err := visitor(input, createStringMatcher(ts.mapping))
 					if len(c.expError) != 0 {
 						require.ErrorContains(t, err, c.expError)
 					} else {

--- a/interceptor/namespace_translator_test.go
+++ b/interceptor/namespace_translator_test.go
@@ -43,32 +43,32 @@ type (
 	}
 
 	objCase struct {
-		objName           string
-		containsNamespace bool
-		makeType          func(ns string) any
-		expError          string
+		objName     string
+		containsObj bool
+		makeType    func(ns string) any
+		expError    string
 	}
 )
 
 func generateNamespaceObjCases() []objCase {
 	return []objCase{
 		{
-			objName:           "Namespace field",
-			containsNamespace: true,
+			objName:     "Namespace field",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &StructWithNamespaceField{Namespace: ns}
 			},
 		},
 		{
-			objName:           "WorkflowNamespace field",
-			containsNamespace: true,
+			objName:     "WorkflowNamespace field",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &StructWithWorkflowNamespaceField{WorkflowNamespace: ns}
 			},
 		},
 		{
-			objName:           "Nested Namespace field",
-			containsNamespace: true,
+			objName:     "Nested Namespace field",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &StructWithNestedNamespaceField{
 					Other: "do not change",
@@ -79,8 +79,8 @@ func generateNamespaceObjCases() []objCase {
 			},
 		},
 		{
-			objName:           "list of structs",
-			containsNamespace: true,
+			objName:     "list of structs",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &StructWithListOfNestedNamespaceField{
 					Other: "do not change",
@@ -93,8 +93,8 @@ func generateNamespaceObjCases() []objCase {
 			},
 		},
 		{
-			objName:           "list of ptrs",
-			containsNamespace: true,
+			objName:     "list of ptrs",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &StructWithListOfNestedPtrs{
 					Other: "do not change",
@@ -107,8 +107,8 @@ func generateNamespaceObjCases() []objCase {
 			},
 		},
 		{
-			objName:           "RespondWorkflowTaskCompletedRequest",
-			containsNamespace: true,
+			objName:     "RespondWorkflowTaskCompletedRequest",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &workflowservice.RespondWorkflowTaskCompletedRequest{
 					TaskToken: []byte{},
@@ -138,8 +138,8 @@ func generateNamespaceObjCases() []objCase {
 			},
 		},
 		{
-			objName:           "PollWorkflowTaskQueueResponse",
-			containsNamespace: true,
+			objName:     "PollWorkflowTaskQueueResponse",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &workflowservice.PollWorkflowTaskQueueResponse{
 					TaskToken:              []byte{},
@@ -168,22 +168,22 @@ func generateNamespaceObjCases() []objCase {
 			},
 		},
 		{
-			objName:           "GetWorkflowExecutionRawHistoryV2Response",
-			containsNamespace: true,
+			objName:     "GetWorkflowExecutionRawHistoryV2Response",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &adminservice.GetWorkflowExecutionRawHistoryV2Response{
 					NextPageToken: []byte("some-token"),
 					HistoryBatches: []*common.DataBlob{
-						makeHistoryEventsBlob(ns),
-						makeHistoryEventsBlob(ns),
+						makeHistoryEventsBlobWithNamespaceField(ns),
+						makeHistoryEventsBlobWithNamespaceField(ns),
 					},
 					HistoryNodeIds: []int64{123},
 				}
 			},
 		},
 		{
-			objName:           "DescribeNamespaceResponse",
-			containsNamespace: true,
+			objName:     "DescribeNamespaceResponse",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return workflowservice.DescribeNamespaceResponse{
 					NamespaceInfo: &namespace.NamespaceInfo{
@@ -194,8 +194,8 @@ func generateNamespaceObjCases() []objCase {
 			expError: "",
 		},
 		{
-			objName:           "UpdateNamespaceResponse",
-			containsNamespace: true,
+			objName:     "UpdateNamespaceResponse",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return workflowservice.UpdateNamespaceResponse{
 					NamespaceInfo: &namespace.NamespaceInfo{
@@ -217,8 +217,8 @@ func generateNamespaceObjCases() []objCase {
 			expError: "",
 		},
 		{
-			objName:           "ListNamespacesResponse",
-			containsNamespace: true,
+			objName:     "ListNamespacesResponse",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &workflowservice.ListNamespacesResponse{
 					Namespaces: []*workflowservice.DescribeNamespaceResponse{
@@ -232,8 +232,8 @@ func generateNamespaceObjCases() []objCase {
 			expError: "",
 		},
 		{
-			objName:           "StreamWorkflowReplicationMessagesResponse",
-			containsNamespace: true,
+			objName:     "StreamWorkflowReplicationMessagesResponse",
+			containsObj: true,
 			makeType: func(ns string) any {
 				return &adminservice.StreamWorkflowReplicationMessagesResponse{
 					Attributes: &adminservice.StreamWorkflowReplicationMessagesResponse_Messages{
@@ -245,8 +245,8 @@ func generateNamespaceObjCases() []objCase {
 											NamespaceId:  "some-ns-id",
 											WorkflowId:   "some-wf-id",
 											RunId:        "some-run-id",
-											Events:       makeHistoryEventsBlob(ns),
-											NewRunEvents: makeHistoryEventsBlob(ns),
+											Events:       makeHistoryEventsBlobWithNamespaceField(ns),
+											NewRunEvents: makeHistoryEventsBlobWithNamespaceField(ns),
 										},
 									},
 								},
@@ -256,8 +256,8 @@ func generateNamespaceObjCases() []objCase {
 											NamespaceId:  "some-ns-id",
 											WorkflowId:   "some-wf-id-2",
 											RunId:        "some-run-id-2",
-											Events:       makeHistoryEventsBlob(ns),
-											NewRunEvents: makeHistoryEventsBlob(ns),
+											Events:       makeHistoryEventsBlobWithNamespaceField(ns),
+											NewRunEvents: makeHistoryEventsBlobWithNamespaceField(ns),
 										},
 									},
 								},
@@ -296,12 +296,12 @@ func generateNamespaceObjCases() []objCase {
 											WorkflowId:  "some-wf-id",
 											RunId:       "some-run-id",
 											EventBatches: []*common.DataBlob{
-												makeHistoryEventsBlob(ns),
-												makeHistoryEventsBlob(ns),
+												makeHistoryEventsBlobWithNamespaceField(ns),
+												makeHistoryEventsBlobWithNamespaceField(ns),
 											},
 											NewRunInfo: &replicationspb.NewRunInfo{
 												RunId:      "some-new-run-id",
-												EventBatch: makeHistoryEventsBlob(ns),
+												EventBatch: makeHistoryEventsBlobWithNamespaceField(ns),
 											},
 										},
 									},
@@ -312,12 +312,12 @@ func generateNamespaceObjCases() []objCase {
 											VersionedTransitionArtifact: &replicationspb.VersionedTransitionArtifact{
 												StateAttributes: nil,
 												EventBatches: []*common.DataBlob{
-													makeHistoryEventsBlob(ns),
-													makeHistoryEventsBlob(ns),
+													makeHistoryEventsBlobWithNamespaceField(ns),
+													makeHistoryEventsBlobWithNamespaceField(ns),
 												},
 												NewRunInfo: &replicationspb.NewRunInfo{
 													RunId:      "some-run-id",
-													EventBatch: makeHistoryEventsBlob(ns),
+													EventBatch: makeHistoryEventsBlobWithNamespaceField(ns),
 												},
 											},
 											NamespaceId: "some-ns-id",
@@ -331,8 +331,8 @@ func generateNamespaceObjCases() []objCase {
 			},
 		},
 		{
-			objName:           "circular pointer",
-			containsNamespace: true,
+			objName:     "circular pointer",
+			containsObj: true,
 			makeType: func(ns string) any {
 				a := &StructWithCircularPointer{
 					Namespace: ns,
@@ -473,64 +473,65 @@ func generateNamespaceReplicationMessages() []objCase {
 			},
 		},
 		{
-			objName:           "full type",
-			makeType:          makeFullType,
-			containsNamespace: true,
+			objName:     "full type",
+			makeType:    makeFullType,
+			containsObj: true,
 		},
 	}
 }
 
-func testTranslateNamespace(t *testing.T, objCases []objCase) {
+func testTranslateObj(t *testing.T, visitor visitor, objCases []objCase) {
 	testcases := []struct {
-		testName     string
-		inputNSName  string
-		outputNSName string
-		mapping      map[string]string
+		testName   string
+		inputName  string
+		outputName string
+		mapping    map[string]string
 	}{
 		{
-			testName:     "name changed",
-			inputNSName:  "orig",
-			outputNSName: "orig.cloud",
-			mapping:      map[string]string{"orig": "orig.cloud"},
+			testName:   "name changed",
+			inputName:  "orig",
+			outputName: "orig.cloud",
+			mapping:    map[string]string{"orig": "orig.cloud"},
 		},
 		{
-			testName:     "name unchanged",
-			inputNSName:  "orig",
-			outputNSName: "orig",
-			mapping:      map[string]string{"other": "other.cloud"},
+			testName:   "name unchanged",
+			inputName:  "orig",
+			outputName: "orig",
+			mapping:    map[string]string{"other": "other.cloud"},
 		},
 		{
-			testName:     "empty mapping",
-			inputNSName:  "orig",
-			outputNSName: "orig",
-			mapping:      map[string]string{},
+			testName:   "empty mapping",
+			inputName:  "orig",
+			outputName: "orig",
+			mapping:    map[string]string{},
 		},
 		{
-			testName:     "nil mapping",
-			inputNSName:  "orig",
-			outputNSName: "orig",
-			mapping:      nil,
+			testName:   "nil mapping",
+			inputName:  "orig",
+			outputName: "orig",
+			mapping:    nil,
 		},
 	}
 	for _, c := range objCases {
 		t.Run(c.objName, func(t *testing.T) {
 			for _, ts := range testcases {
 				t.Run(ts.testName, func(t *testing.T) {
-					input := c.makeType(ts.inputNSName)
-					expOutput := c.makeType(ts.outputNSName)
-					expChanged := ts.inputNSName != ts.outputNSName
+					input := c.makeType(ts.inputName)
+					expOutput := c.makeType(ts.outputName)
+					expChanged := ts.inputName != ts.outputName
 
-					changed, err := visitNamespace(input, createNameTranslator(ts.mapping))
+					changed, err := visitor(input, createNameMatcher(ts.mapping))
 					if len(c.expError) != 0 {
 						require.ErrorContains(t, err, c.expError)
 					} else {
 						require.NoError(t, err)
-						if c.containsNamespace {
+						if c.containsObj {
+							//require.Empty(t, cmp.Diff(expOutput, input))
 							require.Equal(t, expOutput, input)
 							require.Equal(t, expChanged, changed)
 						} else {
 							// input doesn't contain namespace, no change is expected.
-							require.Equal(t, c.makeType(ts.inputNSName), input)
+							require.Equal(t, c.makeType(ts.inputName), input)
 							require.False(t, changed)
 						}
 					}
@@ -540,7 +541,7 @@ func testTranslateNamespace(t *testing.T, objCases []objCase) {
 	}
 }
 
-func makeHistoryEventsBlob(ns string) *common.DataBlob {
+func makeHistoryEventsBlobWithNamespaceField(ns string) *common.DataBlob {
 	evts := []*history.HistoryEvent{
 		{
 			EventId:   1,
@@ -575,9 +576,9 @@ func makeHistoryEventsBlob(ns string) *common.DataBlob {
 }
 
 func TestTranslateNamespaceName(t *testing.T) {
-	testTranslateNamespace(t, generateNamespaceObjCases())
+	testTranslateObj(t, visitNamespace, generateNamespaceObjCases())
 }
 
 func TestTranslateNamespaceReplicationMessages(t *testing.T) {
-	testTranslateNamespace(t, generateNamespaceReplicationMessages())
+	testTranslateObj(t, visitNamespace, generateNamespaceReplicationMessages())
 }

--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -33,19 +33,19 @@ var (
 	}
 )
 
-// matcher returns 2 values:
+// stringMatcher returns 2 values:
 //  1. new name. If there is no change, new name equals to input name
 //  2. whether or not the input name matches the defined rule(s).
-type matcher func(name string) (string, bool)
+type stringMatcher func(name string) (string, bool)
 
 // visitor visits each field in obj matching the matcher.
 // It returns whether anything was matched and any error it encountered.
-type visitor func(obj any, match matcher) (bool, error)
+type visitor func(obj any, match stringMatcher) (bool, error)
 
 // visitNamespace uses reflection to recursively visit all fields
 // in the given object. When it finds namespace string fields, it invokes
 // the provided match function.
-func visitNamespace(obj any, match matcher) (bool, error) {
+func visitNamespace(obj any, match stringMatcher) (bool, error) {
 	var matched bool
 
 	// The visitor function can return Skip, Stop, or Continue to control recursion.
@@ -97,7 +97,7 @@ func visitNamespace(obj any, match matcher) (bool, error) {
 // visitSearchAttributes uses reflection to recursively visit all fields
 // in the given object. When it finds namespace string fields, it invokes
 // the provided match function.
-func visitSearchAttributes(obj any, match matcher) (bool, error) {
+func visitSearchAttributes(obj any, match stringMatcher) (bool, error) {
 	var matched bool
 
 	// The visitor function can return Skip, Stop, or Continue to control recursion.
@@ -141,7 +141,7 @@ func visitSearchAttributes(obj any, match matcher) (bool, error) {
 	return matched, err
 }
 
-func translateIndexedFields(fields map[string]*common.Payload, match matcher) (map[string]*common.Payload, bool) {
+func translateIndexedFields(fields map[string]*common.Payload, match stringMatcher) (map[string]*common.Payload, bool) {
 	if fields == nil {
 		return fields, false
 	}
@@ -171,7 +171,7 @@ func getParentFieldType(vwp visit.ValueWithParent) (result reflect.StructField, 
 	return fieldType, action
 }
 
-func visitDataBlobs(vwp visit.ValueWithParent, match matcher, visitor visitor) (bool, error) {
+func visitDataBlobs(vwp visit.ValueWithParent, match stringMatcher, visitor visitor) (bool, error) {
 	switch evt := vwp.Interface().(type) {
 	case []*common.DataBlob:
 		newEvts, matched, err := translateDataBlobs(match, visitor, evt...)
@@ -200,7 +200,7 @@ func visitDataBlobs(vwp visit.ValueWithParent, match matcher, visitor visitor) (
 	}
 }
 
-func translateDataBlobs(match matcher, visitor visitor, blobs ...*common.DataBlob) ([]*common.DataBlob, bool, error) {
+func translateDataBlobs(match stringMatcher, visitor visitor, blobs ...*common.DataBlob) ([]*common.DataBlob, bool, error) {
 	var anyChanged bool
 	for i, blob := range blobs {
 		newBlob, changed, err := translateOneDataBlob(match, visitor, blob)
@@ -213,7 +213,7 @@ func translateDataBlobs(match matcher, visitor visitor, blobs ...*common.DataBlo
 	return blobs, anyChanged, nil
 }
 
-func translateOneDataBlob(match matcher, visitor visitor, blob *common.DataBlob) (*common.DataBlob, bool, error) {
+func translateOneDataBlob(match stringMatcher, visitor visitor, blob *common.DataBlob) (*common.DataBlob, bool, error) {
 	if blob == nil || len(blob.Data) == 0 {
 		return blob, false, nil
 

--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -29,7 +29,14 @@ var (
 	}
 
 	searchAttributeFieldNames = map[string]bool{
-		"SearchAttributes": true, // UpsertWorkflowSearchAttributesEventAttributes, WorkflowExecutionStartedEventAttributes
+		// common.SearchAttributes
+		// - WorkflowExecutionStartedEventAttributes
+		// - WorkflowExecutionContinuedAsNewEventAttributes
+		// - UpsertWorkflowSearchAttributesEventAttributes
+		// - StartChildWorkflowExecutionInitiatedEventAttributes
+		// map[string]*Payload:
+		// - WorkflowExecutionInfo
+		"SearchAttributes": true,
 	}
 )
 
@@ -126,9 +133,7 @@ func visitSearchAttributes(obj any, match stringMatcher) (bool, error) {
 					visit.Assign(vwp, reflect.ValueOf(attrs))
 				}
 			default:
-				// TODO(pglass): Panic to make missing cases very obvious while we test.
-				// Replace this with a log statement after testing.
-				panic(fmt.Sprintf("unhandled search attribute type %T", attrs))
+				return visit.Stop, fmt.Errorf("unhandled search attribute type: %T", attrs)
 			}
 			matched = matched || changed
 

--- a/interceptor/reflection_test.go
+++ b/interceptor/reflection_test.go
@@ -26,7 +26,7 @@ func BenchmarkVisitNamespace(b *testing.B) {
 	for _, c := range cases {
 		b.Run(c.objName, func(b *testing.B) {
 			for _, variant := range variants {
-				translator := createNameMatcher(variant.mapping)
+				translator := createStringMatcher(variant.mapping)
 				b.Run(variant.testName, func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						b.StopTimer()

--- a/interceptor/reflection_test.go
+++ b/interceptor/reflection_test.go
@@ -26,7 +26,7 @@ func BenchmarkVisitNamespace(b *testing.B) {
 	for _, c := range cases {
 		b.Run(c.objName, func(b *testing.B) {
 			for _, variant := range variants {
-				translator := createNameTranslator(variant.mapping)
+				translator := createNameMatcher(variant.mapping)
 				b.Run(variant.testName, func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						b.StopTimer()

--- a/interceptor/search_attribute_translator_test.go
+++ b/interceptor/search_attribute_translator_test.go
@@ -3,6 +3,7 @@ package interceptor
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/history/v1"
@@ -15,7 +16,11 @@ import (
 )
 
 func TestTranslateSearchAttribute(t *testing.T) {
-	testTranslateObj(t, visitSearchAttributes, []objCase{
+	testTranslateObj(t, visitSearchAttributes, generateSearchAttributeObjs(), require.EqualExportedValues)
+}
+
+func generateSearchAttributeObjs() []objCase {
+	return []objCase{
 		{
 			objName:     "HistoryTaskAttributes",
 			containsObj: true,
@@ -79,7 +84,7 @@ func TestTranslateSearchAttribute(t *testing.T) {
 				}
 			},
 		},
-	})
+	}
 
 }
 
@@ -87,7 +92,7 @@ func makeHistoryEventsBlobWithSearchAttribute(name string) *common.DataBlob {
 	evts := []*history.HistoryEvent{
 		{
 			EventId:   1,
-			EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			EventType: enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED,
 			Version:   1,
 			TaskId:    100,
 			Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
@@ -121,9 +126,5 @@ func makeTestIndexedFieldMap(name string) map[string]*common.Payload {
 			Metadata: map[string][]byte{"preserve": []byte("this")},
 			Data:     []byte("and this"),
 		},
-		//"unchanged-name": {
-		//	Metadata: map[string][]byte{"preserve": []byte("this 2")},
-		//	Data:     []byte("and this 2"),
-		//},
 	}
 }

--- a/interceptor/search_attribute_translator_test.go
+++ b/interceptor/search_attribute_translator_test.go
@@ -1,0 +1,129 @@
+package interceptor
+
+import (
+	"testing"
+
+	"go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
+	"go.temporal.io/api/sdk/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/persistence/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/persistence/serialization"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestTranslateSearchAttribute(t *testing.T) {
+	testTranslateObj(t, visitSearchAttributes, []objCase{
+		{
+			objName:     "HistoryTaskAttributes",
+			containsObj: true,
+			makeType: func(name string) any {
+				return &adminservice.StreamWorkflowReplicationMessagesResponse{
+					Attributes: &adminservice.StreamWorkflowReplicationMessagesResponse_Messages{
+						Messages: &replicationspb.WorkflowReplicationMessages{
+							ReplicationTasks: []*replicationspb.ReplicationTask{
+								{
+									Attributes: &replicationspb.ReplicationTask_HistoryTaskAttributes{
+										HistoryTaskAttributes: &replicationspb.HistoryTaskAttributes{
+											NamespaceId:  "some-ns-id",
+											WorkflowId:   "some-wf-id",
+											RunId:        "some-run-id",
+											Events:       makeHistoryEventsBlobWithSearchAttribute(name),
+											NewRunEvents: makeHistoryEventsBlobWithSearchAttribute(name),
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
+			objName:     "SyncVersionedTransitionTaskAttributes",
+			containsObj: true,
+			makeType: func(name string) any {
+				return &adminservice.StreamWorkflowReplicationMessagesResponse{
+					Attributes: &adminservice.StreamWorkflowReplicationMessagesResponse_Messages{
+						Messages: &replicationspb.WorkflowReplicationMessages{
+							ReplicationTasks: []*replicationspb.ReplicationTask{
+								{
+									Attributes: &replicationspb.ReplicationTask_SyncVersionedTransitionTaskAttributes{
+										SyncVersionedTransitionTaskAttributes: &replicationspb.SyncVersionedTransitionTaskAttributes{
+											VersionedTransitionArtifact: &replicationspb.VersionedTransitionArtifact{
+												StateAttributes: &replicationspb.VersionedTransitionArtifact_SyncWorkflowStateMutationAttributes{
+													SyncWorkflowStateMutationAttributes: &replicationspb.SyncWorkflowStateMutationAttributes{
+														StateMutation: &persistence.WorkflowMutableStateMutation{
+															ExecutionInfo: &persistence.WorkflowExecutionInfo{
+																NamespaceId:      "some-ns",
+																WorkflowId:       "some-wf",
+																SearchAttributes: makeTestIndexedFieldMap(name),
+																Memo: map[string]*common.Payload{
+																	"orig": {
+																		Data: []byte("the Memo field is the exacty same type as SearchAttributes but don't change it"),
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+	})
+
+}
+
+func makeHistoryEventsBlobWithSearchAttribute(name string) *common.DataBlob {
+	evts := []*history.HistoryEvent{
+		{
+			EventId:   1,
+			EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			Version:   1,
+			TaskId:    100,
+			Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
+					WorkflowType: &common.WorkflowType{
+						Name: "some-wf-type",
+					},
+					SearchAttributes: &common.SearchAttributes{
+						IndexedFields: makeTestIndexedFieldMap(name),
+					},
+				},
+			},
+			EventTime:       &timestamppb.Timestamp{},
+			WorkerMayIgnore: false,
+			UserMetadata:    &sdk.UserMetadata{},
+			Links:           []*common.Link{},
+		},
+	}
+
+	s := serialization.NewSerializer()
+	blob, err := s.SerializeEvents(evts, enums.ENCODING_TYPE_PROTO3)
+	if err != nil {
+		panic(err)
+	}
+	return blob
+}
+
+func makeTestIndexedFieldMap(name string) map[string]*common.Payload {
+	return map[string]*common.Payload{
+		name: {
+			Metadata: map[string][]byte{"preserve": []byte("this")},
+			Data:     []byte("and this"),
+		},
+		//"unchanged-name": {
+		//	Metadata: map[string][]byte{"preserve": []byte("this 2")},
+		//	Data:     []byte("and this 2"),
+		//},
+	}
+}

--- a/interceptor/translation_interceptor.go
+++ b/interceptor/translation_interceptor.go
@@ -45,15 +45,19 @@ func (i *TranslationInterceptor) Intercept(
 		i.logger.Debug("intercepted request", tag.NewStringTag("method", methodName))
 
 		for _, tr := range i.translators {
-			changed, trErr := tr.TranslateRequest(req)
-			logTranslateResult(i.logger, changed, trErr, methodName+"Request", req)
+			if tr.MatchMethod(info.FullMethod) {
+				changed, trErr := tr.TranslateRequest(req)
+				logTranslateResult(i.logger, changed, trErr, methodName+"Request", req)
+			}
 		}
 
 		resp, err := handler(ctx, req)
 
 		for _, tr := range i.translators {
-			changed, trErr := tr.TranslateResponse(resp)
-			logTranslateResult(i.logger, changed, trErr, methodName+"Response", resp)
+			if tr.MatchMethod(info.FullMethod) {
+				changed, trErr := tr.TranslateResponse(resp)
+				logTranslateResult(i.logger, changed, trErr, methodName+"Response", resp)
+			}
 		}
 
 		return resp, err

--- a/interceptor/translator.go
+++ b/interceptor/translator.go
@@ -33,6 +33,8 @@ func NewNamespaceNameTranslator(reqMap, respMap map[string]string) Translator {
 func NewSearchAttributeTranslator(reqMap, respMap map[string]string) Translator {
 	return &translatorImpl{
 		matchMethod: func(method string) bool {
+			// In workflowservice APIs, responses only contain the search attribute alias.
+			// We should never translate these responses to the search attribute's indexed field.
 			return !strings.HasPrefix(method, api.WorkflowServicePrefix)
 		},
 		matchReq:  createStringMatcher(reqMap),

--- a/interceptor/translator.go
+++ b/interceptor/translator.go
@@ -15,9 +15,17 @@ type (
 
 func NewNamespaceNameTranslator(reqMap, respMap map[string]string) Translator {
 	return &translatorImpl{
-		matchReq:  createNameTranslator(reqMap),
-		matchResp: createNameTranslator(respMap),
+		matchReq:  createNameMatcher(reqMap),
+		matchResp: createNameMatcher(respMap),
 		visitor:   visitNamespace,
+	}
+}
+
+func NewSearchAttributeTranslator(reqMap, respMap map[string]string) Translator {
+	return &translatorImpl{
+		matchReq:  createNameMatcher(reqMap),
+		matchResp: createNameMatcher(respMap),
+		visitor:   visitSearchAttributes,
 	}
 }
 
@@ -29,7 +37,7 @@ func (n *translatorImpl) TranslateResponse(resp any) (bool, error) {
 	return n.visitor(resp, n.matchResp)
 }
 
-func createNameTranslator(mapping map[string]string) matcher {
+func createNameMatcher(mapping map[string]string) matcher {
 	return func(name string) (string, bool) {
 		newName, ok := mapping[name]
 		return newName, ok

--- a/interceptor/translator.go
+++ b/interceptor/translator.go
@@ -7,24 +7,24 @@ type (
 	}
 
 	translatorImpl struct {
-		matchReq  matcher
-		matchResp matcher
+		matchReq  stringMatcher
+		matchResp stringMatcher
 		visitor   visitor
 	}
 )
 
 func NewNamespaceNameTranslator(reqMap, respMap map[string]string) Translator {
 	return &translatorImpl{
-		matchReq:  createNameMatcher(reqMap),
-		matchResp: createNameMatcher(respMap),
+		matchReq:  createStringMatcher(reqMap),
+		matchResp: createStringMatcher(respMap),
 		visitor:   visitNamespace,
 	}
 }
 
 func NewSearchAttributeTranslator(reqMap, respMap map[string]string) Translator {
 	return &translatorImpl{
-		matchReq:  createNameMatcher(reqMap),
-		matchResp: createNameMatcher(respMap),
+		matchReq:  createStringMatcher(reqMap),
+		matchResp: createStringMatcher(respMap),
 		visitor:   visitSearchAttributes,
 	}
 }
@@ -37,7 +37,7 @@ func (n *translatorImpl) TranslateResponse(resp any) (bool, error) {
 	return n.visitor(resp, n.matchResp)
 }
 
-func createNameMatcher(mapping map[string]string) matcher {
+func createStringMatcher(mapping map[string]string) stringMatcher {
 	return func(name string) (string, bool) {
 		newName, ok := mapping[name]
 		return newName, ok

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -53,14 +53,14 @@ func makeServerOptions(
 	streamInterceptors := []grpc.StreamServerInterceptor{}
 
 	var translators []interceptor.Translator
-	if tln := proxyOpts.Config.NamespaceNameTranslation; len(tln.Mappings) > 0 {
+	if tln := proxyOpts.Config.NamespaceNameTranslation; tln.IsEnabled() {
 		// NamespaceNameTranslator needs to be called before namespace access control so that
 		// local name can be used in namespace allowed list.
 		translators = append(translators,
 			interceptor.NewNamespaceNameTranslator(tln.ToMaps(proxyOpts.IsInbound)))
 	}
 
-	if tln := proxyOpts.Config.SearchAttributeTranslation; len(tln.Mappings) > 0 {
+	if tln := proxyOpts.Config.SearchAttributeTranslation; tln.IsEnabled() {
 		logger.Info("search attribute translation enabled", tag.NewAnyTag("mappings", tln.Mappings))
 		translators = append(translators,
 			interceptor.NewSearchAttributeTranslator(tln.ToMaps(proxyOpts.IsInbound)))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -44,17 +44,26 @@ type (
 	}
 )
 
-func makeServerOptions(logger log.Logger, cfg config.ProxyConfig, isInbound bool, nameTranslations config.NamespaceNameTranslationConfig) ([]grpc.ServerOption, error) {
+func makeServerOptions(
+	logger log.Logger,
+	cfg config.ProxyConfig,
+	proxyOpts proxyOptions,
+) ([]grpc.ServerOption, error) {
 	unaryInterceptors := []grpc.UnaryServerInterceptor{}
 	streamInterceptors := []grpc.StreamServerInterceptor{}
 
 	var translators []interceptor.Translator
-	if len(nameTranslations.Mappings) > 0 {
+	if tln := proxyOpts.Config.NamespaceNameTranslation; len(tln.Mappings) > 0 {
 		// NamespaceNameTranslator needs to be called before namespace access control so that
 		// local name can be used in namespace allowed list.
 		translators = append(translators,
-			interceptor.NewNamespaceNameTranslator(nameTranslations.ToMaps(isInbound)),
-		)
+			interceptor.NewNamespaceNameTranslator(tln.ToMaps(proxyOpts.IsInbound)))
+	}
+
+	if tln := proxyOpts.Config.SearchAttributeTranslation; len(tln.Mappings) > 0 {
+		logger.Info("search attribute translation enabled", tag.NewAnyTag("mappings", tln.Mappings))
+		translators = append(translators,
+			interceptor.NewSearchAttributeTranslator(tln.ToMaps(proxyOpts.IsInbound)))
 	}
 
 	if len(translators) > 0 {
@@ -63,7 +72,7 @@ func makeServerOptions(logger log.Logger, cfg config.ProxyConfig, isInbound bool
 		streamInterceptors = append(streamInterceptors, tr.InterceptStream)
 	}
 
-	if isInbound && cfg.ACLPolicy != nil {
+	if proxyOpts.IsInbound && cfg.ACLPolicy != nil {
 		aclInterceptor := interceptor.NewAccessControlInterceptor(logger, cfg.ACLPolicy)
 		unaryInterceptors = append(unaryInterceptors, aclInterceptor.Intercept)
 		streamInterceptors = append(streamInterceptors, aclInterceptor.StreamIntercept)
@@ -100,7 +109,7 @@ func (ps *ProxyServer) startServer(
 	opts := ps.opts
 	logger := ps.logger
 
-	serverOpts, err := makeServerOptions(logger, cfg, opts.IsInbound, opts.Config.NamespaceNameTranslation)
+	serverOpts, err := makeServerOptions(logger, cfg, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What was changed

Add ability to translate the search attribute indexed field name. 

This works for **one namespace** at a time, because the search attribute mapping is (likely) different for each namespace.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Locally

* Build latest main of [temporal/cli](https://github.com/temporalio/cli)
* Setup clusters
  * Run cluster-a with no SA mapper (cassandra / elastic search)
  * Run cluster-b with SA mapper (sqlite)
* Setup a replicated namespace with search attributes
  * Connect clusters
  * Create a namespace with search attributes on cluster-a
  * Add cluster-b to the ns PassiveClusters
  * Add search attributes to the ns on cluster-b (before any replication occurs)
* Run proxy-a (no special config)
* Configure and run proxy-b
  * Discover the search attribute mapping on cluster 

    ```
    $ ~/code/cli/temporal --address localhost:8233 operator namespace describe -n myns.cloud --grpc-meta xdc-redirection=false -o json
    {
      "namespaceInfo": {
        "name": "myns.cloud",
        "state": "NAMESPACE_STATE_REGISTERED",
        "id": "11dd59e1-f9e4-4f01-a365-3adc8c6a7d7b",
        ...
      },
      "config": {
        "workflowExecutionRetentionTtl": "259200s",
        "badBinaries": {},
        "historyArchivalState": "ARCHIVAL_STATE_DISABLED",
        "visibilityArchivalState": "ARCHIVAL_STATE_DISABLED",
        "customSearchAttributeAliases": {
          "Keyword04": "CustomKeywordField",
          "Text02": "CustomStringField"
        }
      },
      ...
    }
    ```

  * Update yaml config for proxy-b
 
    ```
    searchAttributeTranslation:
      mappings:
      - localName: "Keyword04"
        remoteName: "CustomKeywordField"
      - localName: "Text02"
        remoteName: "CustomStringField"
    ```

* Run test workflows on cluster-b

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
