### PR TITLE
Multi-namespace search attribute config format

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,9 +111,24 @@ type (
 		MuxTransports              []MuxTransportConfig  `yaml:"mux"`
 		HealthCheck                *HealthCheckConfig    `yaml:"healthCheck"`
 		NamespaceNameTranslation   NameTranslationConfig `yaml:"namespaceNameTranslation"`
-		SearchAttributeTranslation NameTranslationConfig `yaml:"searchAttributeTranslation"`
+		SearchAttributeTranslation SATranslationConfig   `yaml:"searchAttributeTranslation"`
 		Metrics                    *MetricsConfig        `yaml:"metrics"`
 		ProfilingConfig            ProfilingConfig       `yaml:"profiling"`
+	}
+
+	SATranslationConfig struct {
+		NamespaceMappings []SANamespaceMapping `yaml:"namespaceMappings"`
+	}
+
+	SANamespaceMapping struct {
+		Name        string      `yaml:"name"`
+		NamespaceId string      `yaml:"namespaceId"`
+		Mappings    []SAMapping `yaml:"mappings"`
+	}
+
+	SAMapping struct {
+		LocalName  string `yaml:"localFieldName"`
+		RemoteName string `yaml:"remoteFieldName"`
 	}
 
 	ProfilingConfig struct {
@@ -319,4 +334,37 @@ func (c *ProfilingConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	// Alias to avoid infinite recursion
 	type plain ProfilingConfig
 	return unmarshal((*plain)(c))
+}
+
+func (s SATranslationConfig) IsEnabled() bool {
+	return len(s.NamespaceMappings) > 0
+}
+
+// ToMaps returns request and response mappings.
+func (s SATranslationConfig) ToMaps(inBound bool) (map[string]map[string]string, map[string]map[string]string) {
+	reqMap := make(map[string]map[string]string)
+	respMap := make(map[string]map[string]string)
+	for _, ns := range s.NamespaceMappings {
+		reqMap[ns.NamespaceId] = make(map[string]string, len(ns.Mappings))
+		respMap[ns.NamespaceId] = make(map[string]string, len(ns.Mappings))
+
+		if inBound {
+			// For inbound listener,
+			//   - incoming requests from remote server are modifed to match local server
+			//   - outgoing responses to local server are modified to match remote server
+			for _, tr := range ns.Mappings {
+				reqMap[ns.NamespaceId][tr.RemoteName] = tr.LocalName
+				respMap[ns.NamespaceId][tr.LocalName] = tr.RemoteName
+			}
+		} else {
+			// For outbound listener,
+			//   - incoming requests from local server are modifed to match remote server
+			//   - outgoing responses to remote server are modified to match local server
+			for _, tr := range ns.Mappings {
+				reqMap[ns.NamespaceId][tr.LocalName] = tr.RemoteName
+				respMap[ns.NamespaceId][tr.RemoteName] = tr.LocalName
+			}
+		}
+	}
+	return reqMap, respMap
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -61,7 +61,7 @@ func makeServerOptions(
 	}
 
 	if tln := proxyOpts.Config.SearchAttributeTranslation; tln.IsEnabled() {
-		logger.Info("search attribute translation enabled", tag.NewAnyTag("mappings", tln.Mappings))
+		logger.Info("search attribute translation enabled", tag.NewAnyTag("mappings", tln.NamespaceMappings))
 		translators = append(translators,
 			interceptor.NewSearchAttributeTranslator(tln.ToMaps(proxyOpts.IsInbound)))
 	}


### PR DESCRIPTION
## What was changed

Change the config format for search attribute translation to support per-namespace config. Example:

```
searchAttributeTranslation:
  namespaceMappings:
  - name: "myns.cloud"
    namespaceId: "91705e41-1b3d-4d4c-9a5d-33149131cf2a"
    mappings:
    - localFieldName: "Keyword05"
      remoteFieldName: "CustomKeywordField"
    - localFieldName: "Text01"
      remoteFieldName: "CustomStringField"
```

In this PR, search attribute translation still only works for **one namespace**. (Another PR will implement support for per-namespace translations).

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Locally, similar steps as in https://github.com/temporalio/s2s-proxy/pull/93

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
