### PR TITLE
Implement multi-namespace search attribute translation

### DIFF
--- a/interceptor/access_control.go
+++ b/interceptor/access_control.go
@@ -52,7 +52,8 @@ func createNamespaceAccessControl(access *auth.AccessControl) stringMatcher {
 }
 
 func isNamespaceAccessAllowed(obj any, access *auth.AccessControl) (bool, error) {
-	notAllowed, err := visitNamespace(obj, createNamespaceAccessControl(access))
+	v := NewNamespaceVisitor(createNamespaceAccessControl(access))
+	notAllowed, err := v.Visit(obj)
 	if err != nil {
 		return false, err
 	}

--- a/interceptor/reflection_test.go
+++ b/interceptor/reflection_test.go
@@ -26,14 +26,14 @@ func BenchmarkVisitNamespace(b *testing.B) {
 	for _, c := range cases {
 		b.Run(c.objName, func(b *testing.B) {
 			for _, variant := range variants {
-				translator := createStringMatcher(variant.mapping)
+				visitor := NewNamespaceVisitor(createStringMatcher(variant.mapping))
 				b.Run(variant.testName, func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						b.StopTimer()
 						input := c.makeType(variant.inputNSName)
 
 						b.StartTimer()
-						visitNamespace(input, translator)
+						visitor.Visit(input)
 					}
 				})
 			}

--- a/interceptor/search_attribute_translator_test.go
+++ b/interceptor/search_attribute_translator_test.go
@@ -16,10 +16,23 @@ import (
 )
 
 func TestTranslateSearchAttribute(t *testing.T) {
-	testTranslateObj(t, visitSearchAttributes, generateSearchAttributeObjs(), require.EqualExportedValues)
+	namespaceId := "ns-1234"
+	testTranslateObj(t, generateSearchAttributeObjs(namespaceId), require.EqualExportedValues,
+		func(mapping map[string]string) Visitor {
+			v := MakeSearchAttributeVisitor(
+				func(nsId string) stringMatcher {
+					if nsId != namespaceId {
+						return nil
+					}
+					return createStringMatcher(mapping)
+				},
+			)
+			return &v
+		},
+	)
 }
 
-func generateSearchAttributeObjs() []objCase {
+func generateSearchAttributeObjs(nsId string) []objCase {
 	return []objCase{
 		{
 			objName:     "HistoryTaskAttributes",
@@ -32,7 +45,7 @@ func generateSearchAttributeObjs() []objCase {
 								{
 									Attributes: &replicationspb.ReplicationTask_HistoryTaskAttributes{
 										HistoryTaskAttributes: &replicationspb.HistoryTaskAttributes{
-											NamespaceId:  "some-ns-id",
+											NamespaceId:  nsId,
 											WorkflowId:   "some-wf-id",
 											RunId:        "some-run-id",
 											Events:       makeHistoryEventsBlobWithSearchAttribute(name),
@@ -62,7 +75,7 @@ func generateSearchAttributeObjs() []objCase {
 													SyncWorkflowStateMutationAttributes: &replicationspb.SyncWorkflowStateMutationAttributes{
 														StateMutation: &persistence.WorkflowMutableStateMutation{
 															ExecutionInfo: &persistence.WorkflowExecutionInfo{
-																NamespaceId:      "some-ns",
+																NamespaceId:      nsId,
 																WorkflowId:       "some-wf",
 																SearchAttributes: makeTestIndexedFieldMap(name),
 																Memo: map[string]*common.Payload{

--- a/interceptor/translation_interceptor.go
+++ b/interceptor/translation_interceptor.go
@@ -55,7 +55,7 @@ func (i *TranslationInterceptor) Intercept(
 
 		for _, tr := range i.translators {
 			if tr.MatchMethod(info.FullMethod) {
-				changed, trErr := tr.TranslateResponse(resp)
+				changed, trErr := tr.TranslateResponse(req, resp)
 				logTranslateResult(i.logger, changed, trErr, methodName+"Response", resp)
 			}
 		}
@@ -98,7 +98,7 @@ func (w *streamTranslator) RecvMsg(m any) error {
 func (w *streamTranslator) SendMsg(m any) error {
 	w.logger.Debug("Intercept SendMsg", tag.NewStringTag("type", fmt.Sprintf("%T", m)), tag.NewAnyTag("message", m))
 	for _, tr := range w.translators {
-		changed, trErr := tr.TranslateResponse(m)
+		changed, trErr := tr.TranslateResponse(nil, m)
 		logTranslateResult(w.logger, changed, trErr, "SendMsg", m)
 	}
 	return w.ServerStream.SendMsg(m)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -62,9 +62,6 @@ func makeServerOptions(
 
 	if tln := proxyOpts.Config.SearchAttributeTranslation; tln.IsEnabled() {
 		logger.Info("search attribute translation enabled", tag.NewAnyTag("mappings", tln.NamespaceMappings))
-		if len(tln.NamespaceMappings) > 1 {
-			panic("multiple namespace search attribute mappings are not supported")
-		}
 		translators = append(translators,
 			interceptor.NewSearchAttributeTranslator(tln.ToMaps(proxyOpts.IsInbound)))
 	}


### PR DESCRIPTION
## What was changed

Implement search attribute translation for multiple namespaces.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Similar to steps in https://github.com/temporalio/s2s-proxy/pull/93, but:

* Create 2 replicated namespaces
* In proxy-a, add namespace translation (optional)

  ```yaml
  namespaceNameTranslation:
    mappings:
      - localName: "myns"
        remoteName: "myns.cloud"
      - localName: "myns2"
        remoteName: "myns2.cloud"
  ```

* In proxy-b configure the search attributes. To discover the search attribute mapping, `~/code/cli/temporal --address localhost:8233 operator namespace describe -n $NS --grpc-meta xdc-redirection=false -o json`

  ```yaml
  searchAttributeTranslation:
    namespaceMappings:
    - name: "myns.cloud"
      namespaceId: "d3054098-3edb-4242-93e1-dbc15f097cb5"
      mappings:
      - localFieldName: "Keyword06"
        remoteFieldName: "CustomKeywordField"
      - localFieldName: "Text01"
        remoteFieldName: "CustomStringField"
  
    - name: "myns2.cloud"
      namespaceId: "f935a879-2b28-4ea8-9e64-c25f020962fe"
      mappings:
      - localFieldName: "Keyword03"
        remoteFieldName: "CustomKeywordField"
      - localFieldName: "Text01"
        remoteFieldName: "CustomStringField"
  
    - name: "bogus"
      namespaceId: "00001111-0000-1111-0000-111100001111"
      mappings:
      - localFieldName: "Keyword99"
        remoteFieldName: "CustomKeywordField"
      - localFieldName: "Text99"
        remoteFieldName: "CustomStringField"
  ```

* Start workers for both namespaces
* Run workflows in both namespaces simultaneously
* Run force replication in both namespaces
* Test handover
*  Check that queries with search attributes work on the target cluster, and return same results as source

  ```
  NS=myns
  temporal workflow count -n $NS -q 'CustomKeywordField IS NOT NULL' --grpc-meta xdc-redirection=false
  temporal --address localhost:8233 workflow count -n myns2.cloud -q 'CustomKeywordField IS NOT NULL' --grpc-meta xdc-redirection=false
  ```

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
