### PR TITLE
Add metrics on yamux sessions and active AdminStreamReplicationMessages

### DIFF
--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -3,15 +3,31 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	// Proxy-server metrics
+	// This file is structured by package first, then by file.
+	//So /proxy/health_check.go, /proxy/proxy.go, and then /transport/mux_connection_manager.go
 
-	ProxyStartCount   = DefaultCounter("proxy_start_count", "Emitted once per startup")
-	GRPCServerMetrics = GetStandardGRPCInterceptor()
+	// /proxy/adminservice.go
 
-	// Health Check metrics
+	AdminServiceStreamsActive = DefaultGauge("admin_service_streams_active", "Number of admin service streams open")
+
+	// /proxy/health_check.go
 
 	HealthCheckIsHealthy    = DefaultGauge("health_check_success", "s2s-proxy service is healthy")
 	HealthCheckHealthyCount = DefaultCounter("health_check_success_count", "Number of healthy checks from s2s-proxy since service start")
+
+	// /proxy/proxy.go
+
+	GRPCServerMetrics = GetStandardGRPCInterceptor()
+	ProxyStartCount   = DefaultCounter("proxy_start_count", "Emitted once per startup")
+
+	// /transport/mux_connection_manager.go
+
+	// Every yamux session has these available, so let's use them in the prometheus tags so we can clearly see each connection
+	muxSessionLabels = []string{"local_addr", "remote_addr", "mode", "config_name"}
+	MuxSessionOpen   = DefaultGaugeVec("mux_connection_active", "Yes/no gauge displaying whether yamux server is connected",
+		muxSessionLabels...)
+	MuxStreamsActive = DefaultGaugeVec("mux_streams_active", "Immediate count of the current streams open",
+		muxSessionLabels...)
 )
 
 func init() {
@@ -19,4 +35,5 @@ func init() {
 	prometheus.MustRegister(GRPCServerMetrics)
 	prometheus.MustRegister(HealthCheckIsHealthy)
 	prometheus.MustRegister(HealthCheckHealthyCount)
+	prometheus.MustRegister(AdminServiceStreamsActive)
 }

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"github.com/temporalio/s2s-proxy/metrics"
 	"io"
 	"sync"
 
@@ -249,7 +250,10 @@ func (s *adminServiceProxyServer) StreamWorkflowReplicationMessages(
 		tag.NewStringTag("source", ClusterShardIDtoString(sourceClusterShardID)),
 		tag.NewStringTag("target", ClusterShardIDtoString(targetClusterShardID)))
 
+	// Record streams active
 	logger.Info("AdminStreamReplicationMessages started.")
+	metrics.AdminServiceStreamsActive.Inc()
+	defer metrics.AdminServiceStreamsActive.Dec()
 	defer logger.Info("AdminStreamReplicationMessages stopped.")
 
 	// simply forwarding target metadata

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -299,7 +299,7 @@ func (s *Proxy) startHealthCheckHandler(cfg config.HealthCheckConfig) error {
 func (s *Proxy) startMetricsHandler(cfg config.MetricsConfig) error {
 	// Why not default? So that it can be used in unit tests
 	mux := http.NewServeMux()
-	mux.Handle("/metrics", metrics.GetMetricsHandler(s.logger))
+	mux.Handle("/metrics", metrics.NewMetricsHandler(s.logger))
 	s.metricsServer = &http.Server{
 		Addr:    cfg.Prometheus.ListenAddress,
 		Handler: mux,

--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -254,10 +254,10 @@ func observeYamuxSession(session *yamux.Session, config config.MuxTransportConfi
 		metrics.MuxStreamsActive.WithLabelValues(labels...).Set(float64(0))
 		return
 	}
+	ticker := time.NewTicker(time.Minute)
 	for !session.IsClosed() {
 		// Prometheus gauges are cheap, but Session.NumStreams() takes a mutex in the session! Only check once per minute
 		// to minimize overhead
-		ticker := time.NewTicker(time.Minute)
 		select {
 		case <-session.CloseChan():
 			serverActive = 0

--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -255,7 +255,7 @@ func observeYamuxSession(session *yamux.Session, config config.MuxTransportConfi
 		return
 	}
 	ticker := time.NewTicker(time.Minute)
-	for sessionActive == 0 {
+	for sessionActive == 1 {
 		// Prometheus gauges are cheap, but Session.NumStreams() takes a mutex in the session! Only check once per minute
 		// to minimize overhead
 		select {

--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -248,11 +248,6 @@ func observeYamuxSession(session *yamux.Session, config config.MuxTransportConfi
 		config.Name,
 	}
 	var sessionActive int8 = 1
-	// It's possible the server was never opened, make sure we emit a 0 in that case
-	if session.IsClosed() {
-		metrics.MuxSessionOpen.WithLabelValues(labels...).Set(0)
-		metrics.MuxStreamsActive.WithLabelValues(labels...).Set(float64(0))
-	}
 	ticker := time.NewTicker(time.Minute)
 	for sessionActive == 1 {
 		// Prometheus gauges are cheap, but Session.NumStreams() takes a mutex in the session! Only check once per minute

--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -247,12 +247,11 @@ func observeYamuxSession(session *yamux.Session, config config.MuxTransportConfi
 		string(config.Mode),
 		config.Name,
 	}
-	var sessionActive float64 = 1
+	var sessionActive int8 = 1
 	// It's possible the server was never opened, make sure we emit a 0 in that case
 	if session.IsClosed() {
 		metrics.MuxSessionOpen.WithLabelValues(labels...).Set(0)
 		metrics.MuxStreamsActive.WithLabelValues(labels...).Set(float64(0))
-		return
 	}
 	ticker := time.NewTicker(time.Minute)
 	for sessionActive == 1 {
@@ -264,7 +263,7 @@ func observeYamuxSession(session *yamux.Session, config config.MuxTransportConfi
 		case <-ticker.C:
 			// wake up so we can report NumStreams
 		}
-		metrics.MuxSessionOpen.WithLabelValues(labels...).Set(sessionActive)
+		metrics.MuxSessionOpen.WithLabelValues(labels...).Set(float64(sessionActive))
 		metrics.MuxStreamsActive.WithLabelValues(labels...).Set(float64(session.NumStreams()))
 	}
 }


### PR DESCRIPTION
## What was changed
Added some gauges to report the current state of the underlying yamux sessions and the application-level AdminStreamReplicationMessages connections. The gauges for the yamux session have labels for the config name, local and remote address, and session type. 

## Why?
This should help us validate that the proxy is alive and running correctly. 

## Checklist

1. Part of https://temporalio.atlassian.net/browse/CGS-839

2. How was this tested:
No unit tests yet. These changes should help improve observability in test while I backfill them. 