### PR TITLE
chore: Bump Go version to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/temporalio/s2s-proxy
 
-go 1.23.2
-
-toolchain go1.23.4
+go 1.24.4
 
 require (
 	github.com/gogo/status v1.1.1


### PR DESCRIPTION
## What was changed

Bump the go version to 1.24.4

```
go get go@1.24.4
go mod tidy
```

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Existing tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
