### PR TITLE
Add liveness reporting for the yamux observer

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -62,7 +62,7 @@ func DefaultGauge(name string, help string) prometheus.Gauge {
 }
 
 // DefaultGaugeVec provides a prometheus GaugeVec for the requested name. The name will be sanitized, and the recommended
-// namespace and subsystem will be set. Vector metrics allow the use of labels, so if you need a label, then use this.
+// namespace and subsystem will be set. Vector metrics allow the use of labels, so if you need labels on your metrics, then use this.
 func DefaultGaugeVec(name string, help string, labels ...string) *prometheus.GaugeVec {
 	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "temporal",
@@ -81,6 +81,17 @@ func DefaultCounter(name string, help string) prometheus.Counter {
 		Name:      SanitizeForPrometheus(name),
 		Help:      help,
 	})
+}
+
+// DefaultCounterVec provides a prometheus CounterVec for the requested name. The name will be sanitized, and the recommended
+// namespace and subsystem will be set. Vector metrics allow the use of labels, so if you need labels on your metrics, then use this.
+func DefaultCounterVec(name string, help string, labels ...string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "temporal",
+		Subsystem: "s2s_proxy",
+		Name:      SanitizeForPrometheus(name),
+		Help:      help,
+	}, labels)
 }
 
 // wrapLoggerForPrometheus is necessary to adapt our temporal Logger to Prometheus's Println interface

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -28,6 +28,8 @@ var (
 		muxSessionLabels...)
 	MuxStreamsActive = DefaultGaugeVec("mux_streams_active", "Immediate count of the current streams open",
 		muxSessionLabels...)
+	MuxObserverReportCount = DefaultCounterVec("mux_observer_report_count", "Number of observer executions",
+		muxSessionLabels...)
 )
 
 func init() {
@@ -36,4 +38,5 @@ func init() {
 	prometheus.MustRegister(HealthCheckIsHealthy)
 	prometheus.MustRegister(HealthCheckHealthyCount)
 	prometheus.MustRegister(AdminServiceStreamsActive)
+	prometheus.MustRegister(MuxObserverReportCount)
 }

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -38,5 +38,7 @@ func init() {
 	prometheus.MustRegister(HealthCheckIsHealthy)
 	prometheus.MustRegister(HealthCheckHealthyCount)
 	prometheus.MustRegister(AdminServiceStreamsActive)
+	prometheus.MustRegister(MuxSessionOpen)
+	prometheus.MustRegister(MuxStreamsActive)
 	prometheus.MustRegister(MuxObserverReportCount)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
On panic, log a warning containing whatever went wrong

## Why?
If there's any panic-errors, it would be good to have a log line describing what happened. Followup to https://github.com/temporalio/s2s-proxy/pull/97#discussion_r2162332752
