### PR TITLE
Fix nil pointer during SearchAttribute translation

### DIFF
--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -57,6 +57,10 @@ func visitNamespace(obj any, match stringMatcher) (bool, error) {
 
 	// The visitor function can return Skip, Stop, or Continue to control recursion.
 	err := visit.Values(obj, func(vwp visit.ValueWithParent) (visit.Action, error) {
+		if vwp.Kind() == reflect.Ptr && vwp.IsNil() {
+			return visit.Skip, nil
+		}
+
 		// Grab name of this struct field from the parent.
 		fieldType, action := getParentFieldType(vwp)
 		if action != "" {
@@ -109,12 +113,15 @@ func visitSearchAttributes(obj any, match stringMatcher) (bool, error) {
 
 	// The visitor function can return Skip, Stop, or Continue to control recursion.
 	err := visit.Values(obj, func(vwp visit.ValueWithParent) (visit.Action, error) {
+		if vwp.Kind() == reflect.Ptr && vwp.IsNil() {
+			return visit.Skip, nil
+		}
+
 		// Grab name of this struct field from the parent.
 		fieldType, action := getParentFieldType(vwp)
 		if action != "" {
 			return action, nil
 		}
-
 		if dataBlobFieldNames[fieldType.Name] {
 			changed, err := visitDataBlobs(vwp, match, visitSearchAttributes)
 			matched = matched || changed

--- a/interceptor/search_attribute_translator_test.go
+++ b/interceptor/search_attribute_translator_test.go
@@ -14,14 +14,33 @@ import (
 )
 
 type (
-	Other struct{}
-	SA1   struct {
+	Other           struct{}
+	SAWithTwoFields struct {
 		Other            *Other
 		SearchAttributes *common.SearchAttributes
 	}
 
-	SA2 struct {
+	SAWithTwoFieldsSwapped struct {
 		SearchAttributes *common.SearchAttributes
+		Other            *Other
+	}
+
+	SAWithOneField struct {
+		SearchAttributes *common.SearchAttributes
+	}
+
+	SAWithOneMap struct {
+		SearchAttributes map[string]*common.Payload
+	}
+
+	SAWithOneMapAndOneField struct {
+		Other            *Other
+		SearchAttributes map[string]*common.Payload
+	}
+
+	SAWithOneMapAndOneFieldSwapped struct {
+		SearchAttributes map[string]*common.Payload
+		Other            *Other
 	}
 )
 
@@ -49,18 +68,28 @@ func generateSearchAttributeObjs() []objCase {
 			},
 		},
 		{
-			objName:     "nil contrived SA1",
-			containsObj: false,
-			makeType: func(name string) any {
-				return &SA1{}
-			},
+			objName:  "nil two fields",
+			makeType: func(name string) any { return &SAWithTwoFields{} },
 		},
 		{
-			objName:     "nil contrived SA2",
-			containsObj: false,
-			makeType: func(name string) any {
-				return &SA2{}
-			},
+			objName:  "nil two fields different order",
+			makeType: func(name string) any { return &SAWithTwoFieldsSwapped{} },
+		},
+		{
+			objName:  "nil one field",
+			makeType: func(name string) any { return &SAWithOneField{} },
+		},
+		{
+			objName:  "nil map",
+			makeType: func(name string) any { return &SAWithOneMap{} },
+		},
+		{
+			objName:  "nil map and field",
+			makeType: func(name string) any { return &SAWithOneMapAndOneField{} },
+		},
+		{
+			objName:  "nil map and field different order",
+			makeType: func(name string) any { return &SAWithOneMapAndOneFieldSwapped{} },
 		},
 		{
 			objName:     "nil value in SearchAttributes",

--- a/interceptor/search_attribute_translator_test.go
+++ b/interceptor/search_attribute_translator_test.go
@@ -13,6 +13,18 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 )
 
+type (
+	Other struct{}
+	SA1   struct {
+		Other            *Other
+		SearchAttributes *common.SearchAttributes
+	}
+
+	SA2 struct {
+		SearchAttributes *common.SearchAttributes
+	}
+)
+
 func TestTranslateSearchAttribute(t *testing.T) {
 	testTranslateObj(t, visitSearchAttributes, generateSearchAttributeObjs(), require.EqualExportedValues)
 }
@@ -31,8 +43,23 @@ func generateSearchAttributeObjs() []objCase {
 			containsObj: false,
 			makeType: func(name string) any {
 				return &persistence.WorkflowExecutionInfo{
-					SearchAttributes: nil,
+					NamespaceId:      name,
+					SearchAttributes: map[string]*common.Payload(nil),
 				}
+			},
+		},
+		{
+			objName:     "nil contrived SA1",
+			containsObj: false,
+			makeType: func(name string) any {
+				return &SA1{}
+			},
+		},
+		{
+			objName:     "nil contrived SA2",
+			containsObj: false,
+			makeType: func(name string) any {
+				return &SA2{}
 			},
 		},
 		{

--- a/interceptor/search_attribute_translator_test.go
+++ b/interceptor/search_attribute_translator_test.go
@@ -7,12 +7,10 @@ import (
 	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/history/v1"
-	"go.temporal.io/api/sdk/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/persistence/serialization"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestTranslateSearchAttribute(t *testing.T) {
@@ -21,6 +19,33 @@ func TestTranslateSearchAttribute(t *testing.T) {
 
 func generateSearchAttributeObjs() []objCase {
 	return []objCase{
+		{
+			objName:     "nil",
+			containsObj: false,
+			makeType: func(name string) any {
+				return nil
+			},
+		},
+		{
+			objName:     "nil SearchAttributes",
+			containsObj: false,
+			makeType: func(name string) any {
+				return &persistence.WorkflowExecutionInfo{
+					SearchAttributes: nil,
+				}
+			},
+		},
+		{
+			objName:     "nil value in SearchAttributes",
+			containsObj: true,
+			makeType: func(name string) any {
+				return &persistence.WorkflowExecutionInfo{
+					SearchAttributes: map[string]*common.Payload{
+						name: nil,
+					},
+				}
+			},
+		},
 		{
 			objName:     "HistoryTaskAttributes",
 			containsObj: true,
@@ -97,18 +122,42 @@ func makeHistoryEventsBlobWithSearchAttribute(name string) *common.DataBlob {
 			TaskId:    100,
 			Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
 				WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
-					WorkflowType: &common.WorkflowType{
-						Name: "some-wf-type",
-					},
+					WorkflowType: &common.WorkflowType{Name: "some-wf-type-1"},
 					SearchAttributes: &common.SearchAttributes{
 						IndexedFields: makeTestIndexedFieldMap(name),
 					},
 				},
 			},
-			EventTime:       &timestamppb.Timestamp{},
-			WorkerMayIgnore: false,
-			UserMetadata:    &sdk.UserMetadata{},
-			Links:           []*common.Link{},
+		},
+		{
+			Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
+					WorkflowType:     &common.WorkflowType{Name: "some-wf-type-2"},
+					SearchAttributes: nil,
+				},
+			},
+		},
+		{
+			Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
+					WorkflowType: &common.WorkflowType{Name: "some-wf-type-2"},
+					SearchAttributes: &common.SearchAttributes{
+						IndexedFields: nil,
+					},
+				},
+			},
+		},
+		{
+			Attributes: &history.HistoryEvent_WorkflowExecutionStartedEventAttributes{
+				WorkflowExecutionStartedEventAttributes: &history.WorkflowExecutionStartedEventAttributes{
+					WorkflowType: &common.WorkflowType{Name: "some-wf-type-3"},
+					SearchAttributes: &common.SearchAttributes{
+						IndexedFields: map[string]*common.Payload{
+							name: nil,
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
## What was changed

Avoid a nil pointer during search attribute translation.

This wasn't caught by existing tests because the `visit` library we use for reflection maintains [a seen set based on pointer addresses](https://github.com/keilerkonzept/visit/blob/ad4728e8f0081e8da8f23d55ce2bafffc8da55db/visit.go#L28-L29). If a type contains two fields that are both pointer types, and both fields are nil, then it will only visit the first nil field. The next time it encounters a nil field, `nil` is already marked as a seen address and it skips that field without visiting it.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

* New unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
