### PR TITLE
Add labels to distinguish inbound and outbound

### DIFF
--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -8,7 +8,8 @@ var (
 
 	// /proxy/adminservice.go
 
-	AdminServiceStreamsActive = DefaultGauge("admin_service_streams_active", "Number of admin service streams open")
+	AdminServiceStreamsActive = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open",
+		[]string{"stream_direction", "outbound", "inbound"}...)
 
 	// /proxy/health_check.go
 

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -9,7 +9,7 @@ var (
 	// /proxy/adminservice.go
 
 	AdminServiceStreamsActive = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open",
-		[]string{"stream_direction", "outbound", "inbound"}...)
+		"stream_direction")
 
 	// /proxy/health_check.go
 

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -381,5 +381,5 @@ func (s *adminServiceProxyServer) prometheusLabelValues() []string {
 	if s.Config.Inbound != nil {
 		inboundLabel = s.Config.Inbound.Name
 	}
-	return []string{"stream_direction", directionLabel, "outbound", outboundLabel, "inbound", inboundLabel}
+	return []string{directionLabel, outboundLabel, inboundLabel}
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added some labels to allow separating the inbound and outbound AdminStream calls

## Why?
Better observability helps build confidence in the system state
