### PR TITLE
helm: Default replicaCount to 3

### DIFF
--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -103,7 +103,7 @@ metadata:
     app.kubernetes.io/version: "0.1.0"
     app.kubernetes.io/managed-by: Helm
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/name: s2s-proxy

--- a/charts/s2s-proxy/values.yaml
+++ b/charts/s2s-proxy/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
-replicaCount: 1
+replicaCount: 3
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:


### PR DESCRIPTION
## What was changed

Default the helm replica count to 3

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

`make helm-example helm-test`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
