### PR TITLE
Trim unnecessary tools from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM --platform=$BUILDPLATFORM temporalio/base-builder:1.15.3 AS builder
+FROM --platform=$BUILDPLATFORM temporalio/base-builder:1.15.5 AS builder
 
 ARG TARGETARCH
 
@@ -22,22 +22,12 @@ COPY . .
 # need to make clean first in case binaries to be built are stale
 RUN make clean && CGO_ENABLED=0 make bins
 
-# Add temporal admin tools
-FROM temporalio/admin-tools:1.22 AS temporal-admin-tools
-
 # Stage 2: Create image
-
 FROM alpine:3.17 AS base
-
-# Install tools
-RUN apk add bash ca-certificates openssh jq
 
 COPY --from=builder /s2s-proxy/bins/s2s-proxy /usr/local/bin/
 COPY --from=builder /s2s-proxy/scripts/entrypoint.sh /opt/entrypoint.sh
 COPY --from=builder /s2s-proxy/scripts/start.sh /opt/start.sh
-COPY --from=temporal-admin-tools /usr/local/bin/tctl /usr/local/bin/tctl
-COPY --from=temporal-admin-tools /usr/local/bin/temporal /usr/local/bin/temporal
-COPY --from=temporal-admin-tools /usr/local/bin/tdbg /usr/local/bin/tdbg
 
 ENTRYPOINT ["/opt/entrypoint.sh"]
 CMD ["/opt/start.sh"]


### PR DESCRIPTION
## What was changed

* Remove tools (tctl, temporal, tdbg) from docker image
* Bump builder image to `temporalio/base-builder:1.15.5` which will enable Go 1.24 builds

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
