### PR TITLE
Add client gRPC metrics

### DIFF
--- a/client/temporal_client.go
+++ b/client/temporal_client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common/log"
@@ -20,6 +21,7 @@ type (
 	}
 
 	clientFactory struct {
+		metricLabels    prometheus.Labels
 		clientTransport transport.ClientTransport
 		logger          log.Logger
 	}
@@ -93,6 +95,7 @@ func (c *clientProvider) GetWorkflowServiceClient() (workflowservice.WorkflowSer
 // NewFactory creates an instance of client factory that knows how to dispatch RPC calls.
 func NewClientFactory(
 	clientTransport transport.ClientTransport,
+	metricLabels prometheus.Labels,
 	logger log.Logger,
 ) ClientFactory {
 	return &clientFactory{
@@ -104,7 +107,7 @@ func NewClientFactory(
 func (cf *clientFactory) NewRemoteAdminClient(
 	clientConfig config.ProxyClientConfig, // TODO: not used. remove it.
 ) (adminservice.AdminServiceClient, error) {
-	connection, err := cf.clientTransport.Connect()
+	connection, err := cf.clientTransport.Connect(cf.metricLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +118,7 @@ func (cf *clientFactory) NewRemoteAdminClient(
 func (cf *clientFactory) NewRemoteWorkflowServiceClient(
 	clientConfig config.ProxyClientConfig,
 ) (workflowservice.WorkflowServiceClient, error) {
-	connection, err := cf.clientTransport.Connect()
+	connection, err := cf.clientTransport.Connect(cf.metricLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -51,6 +51,19 @@ func GetStandardGRPCInterceptor(labelNamesInContext ...string) *grpcprom.ServerM
 	)
 }
 
+func GetStandardGRPCClientInterceptor() *grpcprom.ClientMetrics {
+	return grpcprom.NewClientMetrics(
+		grpcprom.WithClientHandlingTimeHistogram(
+			grpcprom.WithHistogramNamespace("temporal"),
+			grpcprom.WithHistogramSubsystem("s2s_proxy"),
+		),
+		grpcprom.WithClientCounterOptions(
+			grpcprom.WithNamespace("temporal"),
+			grpcprom.WithSubsystem("s2s_proxy"),
+		),
+	)
+}
+
 // DefaultGauge provides a prometheus Gauge for the requested name. The name will be sanitized, and the recommended
 // namespace and subsystem will be set.
 func DefaultGauge(name string, help string) prometheus.Gauge {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -51,15 +51,17 @@ func GetStandardGRPCInterceptor(labelNamesInContext ...string) *grpcprom.ServerM
 	)
 }
 
-func GetStandardGRPCClientInterceptor() *grpcprom.ClientMetrics {
+func GetStandardGRPCClientInterceptor(direction string) *grpcprom.ClientMetrics {
 	return grpcprom.NewClientMetrics(
 		grpcprom.WithClientHandlingTimeHistogram(
 			grpcprom.WithHistogramNamespace("temporal"),
-			grpcprom.WithHistogramSubsystem("s2s_proxy"),
+			// TODO: Gratuitous hack until https://github.com/grpc-ecosystem/go-grpc-middleware/issues/783
+			grpcprom.WithHistogramSubsystem("s2s_proxy_"+direction),
 		),
 		grpcprom.WithClientCounterOptions(
 			grpcprom.WithNamespace("temporal"),
-			grpcprom.WithSubsystem("s2s_proxy"),
+			// TODO: Gratuitous hack until https://github.com/grpc-ecosystem/go-grpc-middleware/issues/783
+			grpcprom.WithSubsystem("s2s_proxy_"+direction),
 		),
 	)
 }

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -24,6 +24,9 @@ var (
 	GRPCServerMetrics = GetStandardGRPCInterceptor("direction")
 	ProxyStartCount   = DefaultCounter("proxy_start_count", "Emitted once per startup")
 
+	// /transport/grpc.go
+	GRPCClientMetrics = GetStandardGRPCClientInterceptor()
+
 	// /transport/mux_connection_manager.go
 
 	// Every yamux session has these available, so let's use them in the prometheus tags so we can clearly see each connection
@@ -43,6 +46,7 @@ func init() {
 	prometheus.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
 		collectors.WithoutGoCollectorRuntimeMetrics(collectors.MetricsDebug.Matcher)))
 	prometheus.MustRegister(ProxyStartCount)
+	prometheus.MustRegister(GRPCClientMetrics)
 	prometheus.MustRegister(GRPCServerMetrics)
 	prometheus.MustRegister(HealthCheckIsHealthy)
 	prometheus.MustRegister(HealthCheckHealthyCount)

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -12,7 +12,7 @@ var (
 	// /proxy/adminservice.go
 
 	AdminServiceStreamsActive = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open",
-		"stream_direction")
+		"direction")
 
 	// /proxy/health_check.go
 
@@ -25,7 +25,11 @@ var (
 	ProxyStartCount   = DefaultCounter("proxy_start_count", "Emitted once per startup")
 
 	// /transport/grpc.go
-	GRPCClientMetrics = GetStandardGRPCClientInterceptor()
+	// Gratuitous hack: Until https://github.com/grpc-ecosystem/go-grpc-middleware/issues/783 is addressed,
+	// we need to register a dependent registry with constant labels applied.
+
+	GRPCOutboundClientMetrics = GetStandardGRPCClientInterceptor("outbound")
+	GRPCInboundClientMetrics  = GetStandardGRPCClientInterceptor("inbound")
 
 	// /transport/mux_connection_manager.go
 
@@ -46,8 +50,9 @@ func init() {
 	prometheus.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
 		collectors.WithoutGoCollectorRuntimeMetrics(collectors.MetricsDebug.Matcher)))
 	prometheus.MustRegister(ProxyStartCount)
-	prometheus.MustRegister(GRPCClientMetrics)
 	prometheus.MustRegister(GRPCServerMetrics)
+	prometheus.MustRegister(GRPCOutboundClientMetrics)
+	prometheus.MustRegister(GRPCInboundClientMetrics)
 	prometheus.MustRegister(HealthCheckIsHealthy)
 	prometheus.MustRegister(HealthCheckHealthyCount)
 	prometheus.MustRegister(AdminServiceStreamsActive)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -129,7 +129,12 @@ func (ps *ProxyServer) startServer(
 		return err
 	}
 
-	clientFactory := client.NewClientFactory(clientTransport, prometheus.Labels{"direction": ps.opts.directionLabel()}, logger)
+	clientMetrics := metrics.GRPCOutboundClientMetrics
+	if ps.opts.IsInbound {
+		clientMetrics = metrics.GRPCOutboundClientMetrics
+	}
+
+	clientFactory := client.NewClientFactory(clientTransport, clientMetrics, logger)
 	ps.server = NewTemporalAPIServer(
 		cfg.Name,
 		cfg.Server,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -131,7 +131,7 @@ func (ps *ProxyServer) startServer(
 
 	clientMetrics := metrics.GRPCOutboundClientMetrics
 	if ps.opts.IsInbound {
-		clientMetrics = metrics.GRPCOutboundClientMetrics
+		clientMetrics = metrics.GRPCInboundClientMetrics
 	}
 
 	clientFactory := client.NewClientFactory(clientTransport, clientMetrics, logger)

--- a/proxy/test/echo_server.go
+++ b/proxy/test/echo_server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/temporalio/s2s-proxy/client"
 	"github.com/temporalio/s2s-proxy/common"
 	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/metrics"
 	s2sproxy "github.com/temporalio/s2s-proxy/proxy"
 	"github.com/temporalio/s2s-proxy/transport"
 )
@@ -169,7 +170,7 @@ func newEchoServer(
 		proxy:             proxy,
 		clusterInfo:       localClusterInfo,
 		remoteClusterInfo: remoteClusterInfo,
-		clientProvider:    client.NewClientProvider(clientConfig, client.NewClientFactory(clientTransport, prometheus.Labels{}, logger), logger),
+		clientProvider:    client.NewClientProvider(clientConfig, client.NewClientFactory(clientTransport, metrics.GRPCOutboundClientMetrics, logger), logger),
 		logger:            logger,
 	}
 }

--- a/transport/grpc.go
+++ b/transport/grpc.go
@@ -7,13 +7,10 @@ import (
 	"time"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
-	prometheus "github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-
-	"github.com/temporalio/s2s-proxy/metrics"
 )
 
 const (
@@ -36,7 +33,7 @@ const (
 // The hostName syntax is defined in
 // https://github.com/grpc/grpc/blob/master/doc/naming.md.
 // e.g. to use dns resolver, a "dns:///" prefix should be applied to the target.
-func dial(hostName string, tlsConfig *tls.Config, labels prometheus.Labels, dialer func(ctx context.Context, addr string) (net.Conn, error)) (*grpc.ClientConn, error) {
+func dial(hostName string, tlsConfig *tls.Config, clientMetrics *grpcprom.ClientMetrics, dialer func(ctx context.Context, addr string) (net.Conn, error)) (*grpc.ClientConn, error) {
 	var grpcSecureOpt grpc.DialOption
 	if tlsConfig == nil {
 		grpcSecureOpt = grpc.WithTransportCredentials(insecure.NewCredentials())
@@ -55,17 +52,14 @@ func dial(hostName string, tlsConfig *tls.Config, labels prometheus.Labels, dial
 	}
 	cp.Backoff.MaxDelay = MaxBackoffDelay
 
-	labelsFromContext := grpcprom.WithLabelsFromContext(func(metadata context.Context) prometheus.Labels {
-		return labels
-	})
 	dialOptions := []grpc.DialOption{
 		grpcSecureOpt,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxInternodeRecvPayloadSize)),
 		grpc.WithDefaultServiceConfig(DefaultServiceConfig),
 		grpc.WithDisableServiceConfig(),
 		grpc.WithConnectParams(cp),
-		grpc.WithUnaryInterceptor(metrics.GRPCClientMetrics.UnaryClientInterceptor(labelsFromContext)),
-		grpc.WithStreamInterceptor(metrics.GRPCClientMetrics.StreamClientInterceptor(labelsFromContext)),
+		grpc.WithUnaryInterceptor(clientMetrics.UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(clientMetrics.StreamClientInterceptor()),
 	}
 
 	if dialer != nil {

--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/yamux"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -161,7 +162,7 @@ func (m *muxConnectMananger) serverLoop(setting config.TCPServerSetting) error {
 					m.logger.Fatal("yamux.Server failed", tag.Error(err))
 				}
 
-				m.muxTransport = newMuxTransport(conn, session)
+				m.muxTransport = newMuxTransport(conn, session, prometheus.Labels{"direction": "outbound"})
 				m.waitForReconnect()
 			}
 		}
@@ -225,7 +226,7 @@ func (m *muxConnectMananger) clientLoop(setting config.TCPClientSetting) error {
 					m.logger.Fatal("yamux.Client failed", tag.Error(err))
 				}
 
-				m.muxTransport = newMuxTransport(conn, session)
+				m.muxTransport = newMuxTransport(conn, session, prometheus.Labels{"direction": "inbound"})
 				m.waitForReconnect()
 			}
 		}

--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/yamux"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -162,7 +161,7 @@ func (m *muxConnectMananger) serverLoop(setting config.TCPServerSetting) error {
 					m.logger.Fatal("yamux.Server failed", tag.Error(err))
 				}
 
-				m.muxTransport = newMuxTransport(conn, session, prometheus.Labels{"direction": "outbound"})
+				m.muxTransport = newMuxTransport(conn, session)
 				m.waitForReconnect()
 			}
 		}
@@ -226,7 +225,7 @@ func (m *muxConnectMananger) clientLoop(setting config.TCPClientSetting) error {
 					m.logger.Fatal("yamux.Client failed", tag.Error(err))
 				}
 
-				m.muxTransport = newMuxTransport(conn, session, prometheus.Labels{"direction": "inbound"})
+				m.muxTransport = newMuxTransport(conn, session)
 				m.waitForReconnect()
 			}
 		}

--- a/transport/mux_connection_manager_test.go
+++ b/transport/mux_connection_manager_test.go
@@ -77,7 +77,7 @@ func startServer(t *testing.T, serverTs ServerTransport) *grpc.Server {
 }
 
 func testClient(t *testing.T, clientTs ClientTransport) {
-	conn, err := clientTs.Connect()
+	conn, err := clientTs.Connect(make(map[string]string))
 	require.NoError(t, err)
 	adminClient := adminservice.NewAdminServiceClient(conn)
 

--- a/transport/mux_connection_manager_test.go
+++ b/transport/mux_connection_manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/temporalio/s2s-proxy/config"
 	"github.com/temporalio/s2s-proxy/encryption"
+	"github.com/temporalio/s2s-proxy/metrics"
 )
 
 const (
@@ -77,7 +78,7 @@ func startServer(t *testing.T, serverTs ServerTransport) *grpc.Server {
 }
 
 func testClient(t *testing.T, clientTs ClientTransport) {
-	conn, err := clientTs.Connect(make(map[string]string))
+	conn, err := clientTs.Connect(metrics.GRPCInboundClientMetrics)
 	require.NoError(t, err)
 	adminClient := adminservice.NewAdminServiceClient(conn)
 

--- a/transport/mux_transport.go
+++ b/transport/mux_transport.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/hashicorp/yamux"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 )
 
@@ -14,7 +15,7 @@ type muxTransportImpl struct {
 	closeCh chan struct{} // if closed, means transport is closed (or disconnected).
 }
 
-func newMuxTransport(conn net.Conn, session *yamux.Session) *muxTransportImpl {
+func newMuxTransport(conn net.Conn, session *yamux.Session, labels prometheus.Labels) *muxTransportImpl {
 	return &muxTransportImpl{
 		conn:    conn,
 		session: session,
@@ -22,13 +23,13 @@ func newMuxTransport(conn net.Conn, session *yamux.Session) *muxTransportImpl {
 	}
 }
 
-func (s *muxTransportImpl) Connect() (*grpc.ClientConn, error) {
+func (s *muxTransportImpl) Connect(metricLabels prometheus.Labels) (*grpc.ClientConn, error) {
 	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
 		return s.session.Open()
 	}
 
 	// Set hostname to unused since custom dialer is used.
-	return dial("unused", nil, dialer)
+	return dial("unused", nil, metricLabels, dialer)
 }
 
 func (s *muxTransportImpl) Serve(server *grpc.Server) error {

--- a/transport/tcp_transport.go
+++ b/transport/tcp_transport.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 
-	"github.com/prometheus/client_golang/prometheus"
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"google.golang.org/grpc"
 
 	"github.com/temporalio/s2s-proxy/config"
@@ -21,7 +21,7 @@ type (
 	}
 )
 
-func (c *tcpClient) Connect(metricLabels prometheus.Labels) (*grpc.ClientConn, error) {
+func (c *tcpClient) Connect(clientMetrics *grpcprom.ClientMetrics) (*grpc.ClientConn, error) {
 	var tlsConfig *tls.Config
 	var err error
 	if tls := c.config.TLS; tls.IsEnabled() {
@@ -31,7 +31,7 @@ func (c *tcpClient) Connect(metricLabels prometheus.Labels) (*grpc.ClientConn, e
 		}
 	}
 
-	return dial(c.config.ServerAddress, tlsConfig, metricLabels, nil)
+	return dial(c.config.ServerAddress, tlsConfig, clientMetrics, nil)
 }
 
 func (s *tcpServer) Serve(server *grpc.Server) error {

--- a/transport/tcp_transport.go
+++ b/transport/tcp_transport.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 
 	"github.com/temporalio/s2s-proxy/config"
@@ -20,7 +21,7 @@ type (
 	}
 )
 
-func (c *tcpClient) Connect() (*grpc.ClientConn, error) {
+func (c *tcpClient) Connect(metricLabels prometheus.Labels) (*grpc.ClientConn, error) {
 	var tlsConfig *tls.Config
 	var err error
 	if tls := c.config.TLS; tls.IsEnabled() {
@@ -30,7 +31,7 @@ func (c *tcpClient) Connect() (*grpc.ClientConn, error) {
 		}
 	}
 
-	return dial(c.config.ServerAddress, tlsConfig, nil)
+	return dial(c.config.ServerAddress, tlsConfig, metricLabels, nil)
 }
 
 func (s *tcpServer) Serve(server *grpc.Server) error {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"fmt"
 
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	prometheus "github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/server/common/log"
 	"google.golang.org/grpc"
@@ -12,7 +13,7 @@ import (
 
 type (
 	ClientTransport interface {
-		Connect(metricLabels prometheus.Labels) (*grpc.ClientConn, error)
+		Connect(clientMetrics *grpcprom.ClientMetrics) (*grpc.ClientConn, error)
 	}
 
 	ServerTransport interface {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"fmt"
 
+	prometheus "github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/server/common/log"
 	"google.golang.org/grpc"
 
@@ -11,7 +12,7 @@ import (
 
 type (
 	ClientTransport interface {
-		Connect() (*grpc.ClientConn, error)
+		Connect(metricLabels prometheus.Labels) (*grpc.ClientConn, error)
 	}
 
 	ServerTransport interface {
@@ -61,7 +62,7 @@ func (tm *TransportManager) openMuxTransport(transportName string) (MuxTransport
 	return mux.open()
 }
 
-func (tm *TransportManager) OpenClient(clientConfig config.ProxyClientConfig) (ClientTransport, error) {
+func (tm *TransportManager) OpenClient(metricLabels prometheus.Labels, clientConfig config.ProxyClientConfig) (ClientTransport, error) {
 	if clientConfig.Type == config.MuxTransport {
 		return tm.openMuxTransport(clientConfig.MuxTransportName)
 	}


### PR DESCRIPTION
## What was changed
The gRPC Client Metrics interceptor has been configured on both inbound and outbound clients

## Why?
This helps to debug connection problems between the proxy and the remote servers, specifically, it allows us to isolate whether the problem is in the local proxy, or in connecting to the remote proxy. On the remote proxy, it allows us to tell if the problem is internal to that proxy, or from the remote temporal instance.

## Testing
Following up with test results soon