### PR TITLE
Preserve xdc-redirection header

### DIFF
--- a/proxy/workflowservice.go
+++ b/proxy/workflowservice.go
@@ -5,6 +5,7 @@ import (
 
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/common/log"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/temporalio/s2s-proxy/auth"
 	"github.com/temporalio/s2s-proxy/client"
@@ -12,6 +13,8 @@ import (
 	"github.com/temporalio/s2s-proxy/common"
 	"github.com/temporalio/s2s-proxy/config"
 )
+
+const DCRedirectionContextHeaderName = "xdc-redirection" // https://github.com/temporalio/temporal/blob/9a1060c4162ff62576cb899d7e5b1bae179af814/common/rpc/interceptor/redirection.go#L27
 
 type (
 	workflowServiceProxyServer struct {
@@ -45,7 +48,7 @@ func NewWorkflowServiceProxyServer(
 // In particular, this version checks the returned namespaces against the configured ACL and makes sure we're not
 // returning disallowed namespaces to the customer.
 func (s *workflowServiceProxyServer) ListNamespaces(ctx context.Context, req *workflowservice.ListNamespacesRequest) (*workflowservice.ListNamespacesResponse, error) {
-	response, err := s.workflowServiceClient.ListNamespaces(ctx, req)
+	response, err := s.workflowServiceClient.ListNamespaces(copyContext(ctx), req)
 	if response != nil && response.Namespaces != nil && s.namespaceAccess != nil {
 		// Even in the case of error, if there is a Namespaces list to iterate we want to remove any partial success data
 		newNamespaceList := make([]*workflowservice.DescribeNamespaceResponse, 0, len(response.Namespaces))
@@ -62,250 +65,258 @@ func (s *workflowServiceProxyServer) ListNamespaces(ctx context.Context, req *wo
 // Passthrough APIs below this point
 
 func (s *workflowServiceProxyServer) CountWorkflowExecutions(ctx context.Context, in0 *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
-	return s.workflowServiceClient.CountWorkflowExecutions(ctx, in0)
+	return s.workflowServiceClient.CountWorkflowExecutions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) CreateSchedule(ctx context.Context, in0 *workflowservice.CreateScheduleRequest) (*workflowservice.CreateScheduleResponse, error) {
-	return s.workflowServiceClient.CreateSchedule(ctx, in0)
+	return s.workflowServiceClient.CreateSchedule(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DeleteSchedule(ctx context.Context, in0 *workflowservice.DeleteScheduleRequest) (*workflowservice.DeleteScheduleResponse, error) {
-	return s.workflowServiceClient.DeleteSchedule(ctx, in0)
+	return s.workflowServiceClient.DeleteSchedule(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DeleteWorkflowExecution(ctx context.Context, in0 *workflowservice.DeleteWorkflowExecutionRequest) (*workflowservice.DeleteWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.DeleteWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.DeleteWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DeprecateNamespace(ctx context.Context, in0 *workflowservice.DeprecateNamespaceRequest) (*workflowservice.DeprecateNamespaceResponse, error) {
-	return s.workflowServiceClient.DeprecateNamespace(ctx, in0)
+	return s.workflowServiceClient.DeprecateNamespace(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DescribeBatchOperation(ctx context.Context, in0 *workflowservice.DescribeBatchOperationRequest) (*workflowservice.DescribeBatchOperationResponse, error) {
-	return s.workflowServiceClient.DescribeBatchOperation(ctx, in0)
+	return s.workflowServiceClient.DescribeBatchOperation(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DescribeNamespace(ctx context.Context, in0 *workflowservice.DescribeNamespaceRequest) (*workflowservice.DescribeNamespaceResponse, error) {
-	return s.workflowServiceClient.DescribeNamespace(ctx, in0)
+	return s.workflowServiceClient.DescribeNamespace(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DescribeSchedule(ctx context.Context, in0 *workflowservice.DescribeScheduleRequest) (*workflowservice.DescribeScheduleResponse, error) {
-	return s.workflowServiceClient.DescribeSchedule(ctx, in0)
+	return s.workflowServiceClient.DescribeSchedule(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DescribeTaskQueue(ctx context.Context, in0 *workflowservice.DescribeTaskQueueRequest) (*workflowservice.DescribeTaskQueueResponse, error) {
-	return s.workflowServiceClient.DescribeTaskQueue(ctx, in0)
+	return s.workflowServiceClient.DescribeTaskQueue(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) DescribeWorkflowExecution(ctx context.Context, in0 *workflowservice.DescribeWorkflowExecutionRequest) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.DescribeWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.DescribeWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ExecuteMultiOperation(ctx context.Context, in0 *workflowservice.ExecuteMultiOperationRequest) (*workflowservice.ExecuteMultiOperationResponse, error) {
-	return s.workflowServiceClient.ExecuteMultiOperation(ctx, in0)
+	return s.workflowServiceClient.ExecuteMultiOperation(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetClusterInfo(ctx context.Context, in0 *workflowservice.GetClusterInfoRequest) (*workflowservice.GetClusterInfoResponse, error) {
-	return s.workflowServiceClient.GetClusterInfo(ctx, in0)
+	return s.workflowServiceClient.GetClusterInfo(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetSearchAttributes(ctx context.Context, in0 *workflowservice.GetSearchAttributesRequest) (*workflowservice.GetSearchAttributesResponse, error) {
-	return s.workflowServiceClient.GetSearchAttributes(ctx, in0)
+	return s.workflowServiceClient.GetSearchAttributes(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetSystemInfo(ctx context.Context, in0 *workflowservice.GetSystemInfoRequest) (*workflowservice.GetSystemInfoResponse, error) {
-	return s.workflowServiceClient.GetSystemInfo(ctx, in0)
+	return s.workflowServiceClient.GetSystemInfo(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetWorkerBuildIdCompatibility(ctx context.Context, in0 *workflowservice.GetWorkerBuildIdCompatibilityRequest) (*workflowservice.GetWorkerBuildIdCompatibilityResponse, error) {
-	return s.workflowServiceClient.GetWorkerBuildIdCompatibility(ctx, in0)
+	return s.workflowServiceClient.GetWorkerBuildIdCompatibility(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetWorkerTaskReachability(ctx context.Context, in0 *workflowservice.GetWorkerTaskReachabilityRequest) (*workflowservice.GetWorkerTaskReachabilityResponse, error) {
-	return s.workflowServiceClient.GetWorkerTaskReachability(ctx, in0)
+	return s.workflowServiceClient.GetWorkerTaskReachability(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetWorkerVersioningRules(ctx context.Context, in0 *workflowservice.GetWorkerVersioningRulesRequest) (*workflowservice.GetWorkerVersioningRulesResponse, error) {
-	return s.workflowServiceClient.GetWorkerVersioningRules(ctx, in0)
+	return s.workflowServiceClient.GetWorkerVersioningRules(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetWorkflowExecutionHistory(ctx context.Context, in0 *workflowservice.GetWorkflowExecutionHistoryRequest) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
-	return s.workflowServiceClient.GetWorkflowExecutionHistory(ctx, in0)
+	return s.workflowServiceClient.GetWorkflowExecutionHistory(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) GetWorkflowExecutionHistoryReverse(ctx context.Context, in0 *workflowservice.GetWorkflowExecutionHistoryReverseRequest) (*workflowservice.GetWorkflowExecutionHistoryReverseResponse, error) {
-	return s.workflowServiceClient.GetWorkflowExecutionHistoryReverse(ctx, in0)
+	return s.workflowServiceClient.GetWorkflowExecutionHistoryReverse(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListArchivedWorkflowExecutions(ctx context.Context, in0 *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
-	return s.workflowServiceClient.ListArchivedWorkflowExecutions(ctx, in0)
+	return s.workflowServiceClient.ListArchivedWorkflowExecutions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListBatchOperations(ctx context.Context, in0 *workflowservice.ListBatchOperationsRequest) (*workflowservice.ListBatchOperationsResponse, error) {
-	return s.workflowServiceClient.ListBatchOperations(ctx, in0)
+	return s.workflowServiceClient.ListBatchOperations(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListClosedWorkflowExecutions(ctx context.Context, in0 *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
-	return s.workflowServiceClient.ListClosedWorkflowExecutions(ctx, in0)
+	return s.workflowServiceClient.ListClosedWorkflowExecutions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListOpenWorkflowExecutions(ctx context.Context, in0 *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
-	return s.workflowServiceClient.ListOpenWorkflowExecutions(ctx, in0)
+	return s.workflowServiceClient.ListOpenWorkflowExecutions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListScheduleMatchingTimes(ctx context.Context, in0 *workflowservice.ListScheduleMatchingTimesRequest) (*workflowservice.ListScheduleMatchingTimesResponse, error) {
-	return s.workflowServiceClient.ListScheduleMatchingTimes(ctx, in0)
+	return s.workflowServiceClient.ListScheduleMatchingTimes(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListSchedules(ctx context.Context, in0 *workflowservice.ListSchedulesRequest) (*workflowservice.ListSchedulesResponse, error) {
-	return s.workflowServiceClient.ListSchedules(ctx, in0)
+	return s.workflowServiceClient.ListSchedules(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListTaskQueuePartitions(ctx context.Context, in0 *workflowservice.ListTaskQueuePartitionsRequest) (*workflowservice.ListTaskQueuePartitionsResponse, error) {
-	return s.workflowServiceClient.ListTaskQueuePartitions(ctx, in0)
+	return s.workflowServiceClient.ListTaskQueuePartitions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ListWorkflowExecutions(ctx context.Context, in0 *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
-	return s.workflowServiceClient.ListWorkflowExecutions(ctx, in0)
+	return s.workflowServiceClient.ListWorkflowExecutions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) PatchSchedule(ctx context.Context, in0 *workflowservice.PatchScheduleRequest) (*workflowservice.PatchScheduleResponse, error) {
-	return s.workflowServiceClient.PatchSchedule(ctx, in0)
+	return s.workflowServiceClient.PatchSchedule(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) PollActivityTaskQueue(ctx context.Context, in0 *workflowservice.PollActivityTaskQueueRequest) (*workflowservice.PollActivityTaskQueueResponse, error) {
-	return s.workflowServiceClient.PollActivityTaskQueue(ctx, in0)
+	return s.workflowServiceClient.PollActivityTaskQueue(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) PollNexusTaskQueue(ctx context.Context, in0 *workflowservice.PollNexusTaskQueueRequest) (*workflowservice.PollNexusTaskQueueResponse, error) {
-	return s.workflowServiceClient.PollNexusTaskQueue(ctx, in0)
+	return s.workflowServiceClient.PollNexusTaskQueue(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) PollWorkflowExecutionUpdate(ctx context.Context, in0 *workflowservice.PollWorkflowExecutionUpdateRequest) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
-	return s.workflowServiceClient.PollWorkflowExecutionUpdate(ctx, in0)
+	return s.workflowServiceClient.PollWorkflowExecutionUpdate(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) PollWorkflowTaskQueue(ctx context.Context, in0 *workflowservice.PollWorkflowTaskQueueRequest) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
-	return s.workflowServiceClient.PollWorkflowTaskQueue(ctx, in0)
+	return s.workflowServiceClient.PollWorkflowTaskQueue(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) QueryWorkflow(ctx context.Context, in0 *workflowservice.QueryWorkflowRequest) (*workflowservice.QueryWorkflowResponse, error) {
-	return s.workflowServiceClient.QueryWorkflow(ctx, in0)
+	return s.workflowServiceClient.QueryWorkflow(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RecordActivityTaskHeartbeat(ctx context.Context, in0 *workflowservice.RecordActivityTaskHeartbeatRequest) (*workflowservice.RecordActivityTaskHeartbeatResponse, error) {
-	return s.workflowServiceClient.RecordActivityTaskHeartbeat(ctx, in0)
+	return s.workflowServiceClient.RecordActivityTaskHeartbeat(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RecordActivityTaskHeartbeatById(ctx context.Context, in0 *workflowservice.RecordActivityTaskHeartbeatByIdRequest) (*workflowservice.RecordActivityTaskHeartbeatByIdResponse, error) {
-	return s.workflowServiceClient.RecordActivityTaskHeartbeatById(ctx, in0)
+	return s.workflowServiceClient.RecordActivityTaskHeartbeatById(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RegisterNamespace(ctx context.Context, in0 *workflowservice.RegisterNamespaceRequest) (*workflowservice.RegisterNamespaceResponse, error) {
-	return s.workflowServiceClient.RegisterNamespace(ctx, in0)
+	return s.workflowServiceClient.RegisterNamespace(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RequestCancelWorkflowExecution(ctx context.Context, in0 *workflowservice.RequestCancelWorkflowExecutionRequest) (*workflowservice.RequestCancelWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.RequestCancelWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.RequestCancelWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ResetStickyTaskQueue(ctx context.Context, in0 *workflowservice.ResetStickyTaskQueueRequest) (*workflowservice.ResetStickyTaskQueueResponse, error) {
-	return s.workflowServiceClient.ResetStickyTaskQueue(ctx, in0)
+	return s.workflowServiceClient.ResetStickyTaskQueue(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) ResetWorkflowExecution(ctx context.Context, in0 *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.ResetWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.ResetWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondActivityTaskCanceled(ctx context.Context, in0 *workflowservice.RespondActivityTaskCanceledRequest) (*workflowservice.RespondActivityTaskCanceledResponse, error) {
-	return s.workflowServiceClient.RespondActivityTaskCanceled(ctx, in0)
+	return s.workflowServiceClient.RespondActivityTaskCanceled(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondActivityTaskCanceledById(ctx context.Context, in0 *workflowservice.RespondActivityTaskCanceledByIdRequest) (*workflowservice.RespondActivityTaskCanceledByIdResponse, error) {
-	return s.workflowServiceClient.RespondActivityTaskCanceledById(ctx, in0)
+	return s.workflowServiceClient.RespondActivityTaskCanceledById(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondActivityTaskCompleted(ctx context.Context, in0 *workflowservice.RespondActivityTaskCompletedRequest) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
-	return s.workflowServiceClient.RespondActivityTaskCompleted(ctx, in0)
+	return s.workflowServiceClient.RespondActivityTaskCompleted(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondActivityTaskCompletedById(ctx context.Context, in0 *workflowservice.RespondActivityTaskCompletedByIdRequest) (*workflowservice.RespondActivityTaskCompletedByIdResponse, error) {
-	return s.workflowServiceClient.RespondActivityTaskCompletedById(ctx, in0)
+	return s.workflowServiceClient.RespondActivityTaskCompletedById(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondActivityTaskFailed(ctx context.Context, in0 *workflowservice.RespondActivityTaskFailedRequest) (*workflowservice.RespondActivityTaskFailedResponse, error) {
-	return s.workflowServiceClient.RespondActivityTaskFailed(ctx, in0)
+	return s.workflowServiceClient.RespondActivityTaskFailed(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondActivityTaskFailedById(ctx context.Context, in0 *workflowservice.RespondActivityTaskFailedByIdRequest) (*workflowservice.RespondActivityTaskFailedByIdResponse, error) {
-	return s.workflowServiceClient.RespondActivityTaskFailedById(ctx, in0)
+	return s.workflowServiceClient.RespondActivityTaskFailedById(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondNexusTaskCompleted(ctx context.Context, in0 *workflowservice.RespondNexusTaskCompletedRequest) (*workflowservice.RespondNexusTaskCompletedResponse, error) {
-	return s.workflowServiceClient.RespondNexusTaskCompleted(ctx, in0)
+	return s.workflowServiceClient.RespondNexusTaskCompleted(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondNexusTaskFailed(ctx context.Context, in0 *workflowservice.RespondNexusTaskFailedRequest) (*workflowservice.RespondNexusTaskFailedResponse, error) {
-	return s.workflowServiceClient.RespondNexusTaskFailed(ctx, in0)
+	return s.workflowServiceClient.RespondNexusTaskFailed(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondQueryTaskCompleted(ctx context.Context, in0 *workflowservice.RespondQueryTaskCompletedRequest) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
-	return s.workflowServiceClient.RespondQueryTaskCompleted(ctx, in0)
+	return s.workflowServiceClient.RespondQueryTaskCompleted(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondWorkflowTaskCompleted(ctx context.Context, in0 *workflowservice.RespondWorkflowTaskCompletedRequest) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
-	return s.workflowServiceClient.RespondWorkflowTaskCompleted(ctx, in0)
+	return s.workflowServiceClient.RespondWorkflowTaskCompleted(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) RespondWorkflowTaskFailed(ctx context.Context, in0 *workflowservice.RespondWorkflowTaskFailedRequest) (*workflowservice.RespondWorkflowTaskFailedResponse, error) {
-	return s.workflowServiceClient.RespondWorkflowTaskFailed(ctx, in0)
+	return s.workflowServiceClient.RespondWorkflowTaskFailed(copyContext(ctx), in0)
 }
 
 // nolint:staticcheck // SA1019: workflowservice.ScanWorkflowExecutionsRequest is deprecated: Use with `ListWorkflowExecutions`
 func (s *workflowServiceProxyServer) ScanWorkflowExecutions(ctx context.Context, in0 *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
-	return s.workflowServiceClient.ScanWorkflowExecutions(ctx, in0)
+	return s.workflowServiceClient.ScanWorkflowExecutions(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) SignalWithStartWorkflowExecution(ctx context.Context, in0 *workflowservice.SignalWithStartWorkflowExecutionRequest) (*workflowservice.SignalWithStartWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.SignalWithStartWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.SignalWithStartWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) SignalWorkflowExecution(ctx context.Context, in0 *workflowservice.SignalWorkflowExecutionRequest) (*workflowservice.SignalWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.SignalWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.SignalWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) StartBatchOperation(ctx context.Context, in0 *workflowservice.StartBatchOperationRequest) (*workflowservice.StartBatchOperationResponse, error) {
-	return s.workflowServiceClient.StartBatchOperation(ctx, in0)
+	return s.workflowServiceClient.StartBatchOperation(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) StartWorkflowExecution(ctx context.Context, in0 *workflowservice.StartWorkflowExecutionRequest) (*workflowservice.StartWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.StartWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.StartWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) StopBatchOperation(ctx context.Context, in0 *workflowservice.StopBatchOperationRequest) (*workflowservice.StopBatchOperationResponse, error) {
-	return s.workflowServiceClient.StopBatchOperation(ctx, in0)
+	return s.workflowServiceClient.StopBatchOperation(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) TerminateWorkflowExecution(ctx context.Context, in0 *workflowservice.TerminateWorkflowExecutionRequest) (*workflowservice.TerminateWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.TerminateWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.TerminateWorkflowExecution(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) UpdateNamespace(ctx context.Context, in0 *workflowservice.UpdateNamespaceRequest) (*workflowservice.UpdateNamespaceResponse, error) {
-	return s.workflowServiceClient.UpdateNamespace(ctx, in0)
+	return s.workflowServiceClient.UpdateNamespace(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) UpdateSchedule(ctx context.Context, in0 *workflowservice.UpdateScheduleRequest) (*workflowservice.UpdateScheduleResponse, error) {
-	return s.workflowServiceClient.UpdateSchedule(ctx, in0)
+	return s.workflowServiceClient.UpdateSchedule(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) UpdateWorkerBuildIdCompatibility(ctx context.Context, in0 *workflowservice.UpdateWorkerBuildIdCompatibilityRequest) (*workflowservice.UpdateWorkerBuildIdCompatibilityResponse, error) {
-	return s.workflowServiceClient.UpdateWorkerBuildIdCompatibility(ctx, in0)
+	return s.workflowServiceClient.UpdateWorkerBuildIdCompatibility(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) UpdateWorkerVersioningRules(ctx context.Context, in0 *workflowservice.UpdateWorkerVersioningRulesRequest) (*workflowservice.UpdateWorkerVersioningRulesResponse, error) {
-	return s.workflowServiceClient.UpdateWorkerVersioningRules(ctx, in0)
+	return s.workflowServiceClient.UpdateWorkerVersioningRules(copyContext(ctx), in0)
 }
 
 func (s *workflowServiceProxyServer) UpdateWorkflowExecution(ctx context.Context, in0 *workflowservice.UpdateWorkflowExecutionRequest) (*workflowservice.UpdateWorkflowExecutionResponse, error) {
-	return s.workflowServiceClient.UpdateWorkflowExecution(ctx, in0)
+	return s.workflowServiceClient.UpdateWorkflowExecution(copyContext(ctx), in0)
+}
+
+func copyContext(src context.Context) context.Context {
+	val := metadata.ValueFromIncomingContext(src, DCRedirectionContextHeaderName)
+	if len(val) > 0 {
+		src = metadata.AppendToOutgoingContext(src, DCRedirectionContextHeaderName, val[0])
+	}
+	return src
 }

--- a/proxy/workflowservice_test.go
+++ b/proxy/workflowservice_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	gomockold "github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
 	"go.temporal.io/server/common/log"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/temporalio/s2s-proxy/auth"
@@ -60,27 +61,43 @@ var (
 	}
 )
 
-// Simple test for the workflow client filtering: This mocks out the underlying WorkflowServiceClient and returns
-// a predefined set of namespaces to the proxy layer. Then we check to make sure the proxy kept the allowed namespace
-// and rejected the disallowed namespace.
-func TestNamespaceFiltering(t *testing.T) {
-	clientFactoryController := gomock.NewController(t)
-	// workflowservicemock is still using golang-mock and not uber-mock, so we get to have two controllers here
-	wfServiceController := gomockold.NewController(t)
-	mockServiceClient := workflowservicemock.NewMockWorkflowServiceClient(wfServiceController)
-	mockServiceClient.EXPECT().ListNamespaces(gomock.Any(), gomock.Any()).Return(listNamespacesResponse, nil)
+type workflowServiceTestSuite struct {
+	suite.Suite
 
-	mockClientFactory := clientmock.NewMockClientFactory(clientFactoryController)
-	clientConfig := config.ProxyClientConfig{
+	ctrl              *gomock.Controller
+	ctrlold           *gomockold.Controller
+	clientMock        *workflowservicemock.MockWorkflowServiceClient
+	clientFactoryMock *clientmock.MockClientFactory
+	clientConfig      config.ProxyClientConfig
+}
+
+func TestWorkflowService(t *testing.T) {
+	suite.Run(t, new(workflowServiceTestSuite))
+}
+
+func (s *workflowServiceTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+	s.ctrlold = gomockold.NewController(s.T())
+	s.clientMock = workflowservicemock.NewMockWorkflowServiceClient(s.ctrlold)
+	s.clientFactoryMock = clientmock.NewMockClientFactory(s.ctrl)
+
+	s.clientConfig = config.ProxyClientConfig{
 		TCPClientSetting: config.TCPClientSetting{
 			ServerAddress: "fake-forward-address",
 			TLS:           encryption.ClientTLSConfig{},
 		},
 	}
-	mockClientFactory.EXPECT().NewRemoteWorkflowServiceClient(clientConfig).Return(mockServiceClient, nil).Times(1)
-	wfProxy := NewWorkflowServiceProxyServer("My cool test server", clientConfig, mockClientFactory,
+	s.clientFactoryMock.EXPECT().NewRemoteWorkflowServiceClient(s.clientConfig).Return(s.clientMock, nil).Times(1)
+}
+
+// Simple test for the workflow client filtering: This mocks out the underlying WorkflowServiceClient and returns
+// a predefined set of namespaces to the proxy layer. Then we check to make sure the proxy kept the allowed namespace
+// and rejected the disallowed namespace.
+func (s *workflowServiceTestSuite) TestNamespaceFiltering() {
+	wfProxy := NewWorkflowServiceProxyServer("My cool test server", s.clientConfig, s.clientFactoryMock,
 		auth.NewAccesControl([]string{"Bob Ross's Paint Shop"}), log.NewTestLogger())
 
+	s.clientMock.EXPECT().ListNamespaces(gomock.Any(), gomock.Any()).Return(listNamespacesResponse, nil)
 	res, _ := wfProxy.ListNamespaces(metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{})),
 		&workflowservice.ListNamespacesRequest{
 			PageSize:        10,
@@ -88,7 +105,7 @@ func TestNamespaceFiltering(t *testing.T) {
 			NamespaceFilter: &namespace.NamespaceFilter{IncludeDeleted: true},
 		})
 
-	assert.NotEqualf(t, -1, slices.IndexFunc(res.Namespaces, func(ns *workflowservice.DescribeNamespaceResponse) bool {
+	s.NotEqualf(-1, slices.IndexFunc(res.Namespaces, func(ns *workflowservice.DescribeNamespaceResponse) bool {
 		return ns.NamespaceInfo.Name == "Bob Ross's Paint Shop"
 	}), "Couldn't find \"%s\" in the response! It should have matched the ACL.\nResponse: %s", "Bob Ross's Paint Shop", res.Namespaces)
 	steveIndex := slices.IndexFunc(res.Namespaces, func(ns *workflowservice.DescribeNamespaceResponse) bool {
@@ -98,5 +115,27 @@ func TestNamespaceFiltering(t *testing.T) {
 	if steveIndex > 0 {
 		matchingNS = res.Namespaces[steveIndex].NamespaceInfo
 	}
-	assert.Equalf(t, -1, steveIndex, "Shouldn't have found namespace %s\n in list response: %s", matchingNS, res.Namespaces)
+	s.Equalf(-1, steveIndex, "Shouldn't have found namespace %s\n in list response: %s", matchingNS, res.Namespaces)
+}
+
+func (s *workflowServiceTestSuite) TestPreserveRedirectionHeader() {
+	wfProxy := NewWorkflowServiceProxyServer("My cool test server", s.clientConfig, s.clientFactoryMock, nil, log.NewTestLogger())
+
+	// Client should be called with xdc-redirection=false header
+	for _, headerValue := range []string{"true", "false", ""} {
+		s.clientMock.EXPECT().DescribeWorkflowExecution(gomockold.Any(), gomockold.Any()).DoAndReturn(
+			func(ctx context.Context, request *workflowservice.DescribeWorkflowExecutionRequest, opts ...grpc.CallOption) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+				md, ok := metadata.FromOutgoingContext(ctx)
+				s.True(ok)
+				s.Equal(md.Get(DCRedirectionContextHeaderName), []string{headerValue})
+				return &workflowservice.DescribeWorkflowExecutionResponse{}, nil
+			},
+		).Times(1)
+
+		// API is passed xdc-redirection=false header
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{DCRedirectionContextHeaderName: headerValue}))
+		res, err := wfProxy.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{})
+		s.NoError(err)
+		s.NotNil(res)
+	}
 }


### PR DESCRIPTION
## What was changed

Preserve the [`xdc-redirection`](https://github.com/temporalio/temporal/blob/9a1060c4162ff62576cb899d7e5b1bae179af814/common/rpc/interceptor/redirection.go#L27) header during proxied requests in the workflow service

## Why?

This header disables redirection from passive to active cluster on a per-request bases, which is important to ensure we can determine whether a workflow is replicated to the passive cluster.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

* Unit tests
* Local test with extra log: https://github.com/temporalio/s2s-proxy/commit/00e1648dde3ee229455f6d71c49e3aef1e5b0d48

Request with `xdc-redirection=f`

```
 temporal --address localhost:5333 workflow describe -w bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8 --grpc-meta xdc-redirection=f -n myns
```

On source and target proxy, I see `"xdc-redirection":["f"]` in log

SOURCE:
```
{"level":"info","ts":"2025-07-29T16:42:24.433-0500","msg":"workflowservice.DescribeWorkflowExecution","service":"outbound-server","req":"execution_config:{task_queue:{name:\"temporal-bench\"  kind:TASK_QUEUE_KIND_NORMAL}  workflow_execution_timeout:{seconds:5999  nanos:999224000}  workflow_run_timeout:{seconds:5999  nanos:999224000}  default_workflow_task_timeout:{seconds:10}}  workflow_execution_info:{execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  type:{name:\"config-driven-workflow\"}  start_time:{seconds:1753820831  nanos:255542000}  close_time:{seconds:1753820877  nanos:11297000}  status:WORKFLOW_EXECUTION_STATUS_COMPLETED  history_length:1059  execution_time:{seconds:1753820831  nanos:255542000}  memo:{}  search_attributes:{indexed_fields:{key:\"BuildIds\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"KeywordList\"}  data:\"[\\\"unversioned\\\",\\\"unversioned:c833950374cdf2b838f763e1be233d7f\\\"]\"}}  indexed_fields:{key:\"CustomKeywordField\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"Keyword\"}  data:\"\\\"configdriven-bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7\\\"\"}}}  auto_reset_points:{points:{build_id:\"c833950374cdf2b838f763e1be233d7f\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"  first_workflow_task_completed_id:5  create_time:{seconds:1753820831  nanos:313933000}  resettable:true}}  task_queue:\"temporal-bench\"  state_transition_count:414  history_size_bytes:226292  most_recent_worker_version_stamp:{build_id:\"c833950374cdf2b838f763e1be233d7f\"}  execution_duration:{seconds:45  nanos:755755000}  root_execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  first_run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  workflow_extended_info:{execution_expiration_time:{seconds:1753826831  nanos:255000000}  run_expiration_time:{seconds:1753826831  nanos:254766000}  original_start_time:{seconds:1753820831  nanos:255542000}  7:\"\\n$bb7b26d0-a3bb-42db-b202-1219cd80f465\\x12\\x04\\x08\\x01\\x10\\x01\"}","resp":"execution_config:{task_queue:{name:\"temporal-bench\"  kind:TASK_QUEUE_KIND_NORMAL}  workflow_execution_timeout:{seconds:5999  nanos:999224000}  workflow_run_timeout:{seconds:5999  nanos:999224000}  default_workflow_task_timeout:{seconds:10}}  workflow_execution_info:{execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  type:{name:\"config-driven-workflow\"}  start_time:{seconds:1753820831  nanos:255542000}  close_time:{seconds:1753820877  nanos:11297000}  status:WORKFLOW_EXECUTION_STATUS_COMPLETED  history_length:1059  execution_time:{seconds:1753820831  nanos:255542000}  memo:{}  search_attributes:{indexed_fields:{key:\"BuildIds\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"KeywordList\"}  data:\"[\\\"unversioned\\\",\\\"unversioned:c833950374cdf2b838f763e1be233d7f\\\"]\"}}  indexed_fields:{key:\"CustomKeywordField\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"Keyword\"}  data:\"\\\"configdriven-bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7\\\"\"}}}  auto_reset_points:{points:{build_id:\"c833950374cdf2b838f763e1be233d7f\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"  first_workflow_task_completed_id:5  create_time:{seconds:1753820831  nanos:313933000}  resettable:true}}  task_queue:\"temporal-bench\"  state_transition_count:414  history_size_bytes:226292  most_recent_worker_version_stamp:{build_id:\"c833950374cdf2b838f763e1be233d7f\"}  execution_duration:{seconds:45  nanos:755755000}  root_execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  first_run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  workflow_extended_info:{execution_expiration_time:{seconds:1753826831  nanos:255000000}  run_expiration_time:{seconds:1753826831  nanos:254766000}  original_start_time:{seconds:1753820831  nanos:255542000}  7:\"\\n$bb7b26d0-a3bb-42db-b202-1219cd80f465\\x12\\x04\\x08\\x01\\x10\\x01\"}","xdc-redirection":["f"],"logging-call-at":"/Users/pglass/code/s2s-proxy/proxy/workflowservice.go:337"}
```

TARGET:
```
{"level":"info","ts":"2025-07-29T16:42:24.433-0500","msg":"workflowservice.DescribeWorkflowExecution","service":"inbound-server","req":"execution_config:{task_queue:{name:\"temporal-bench\"  kind:TASK_QUEUE_KIND_NORMAL}  workflow_execution_timeout:{seconds:5999  nanos:999224000}  workflow_run_timeout:{seconds:5999  nanos:999224000}  default_workflow_task_timeout:{seconds:10}}  workflow_execution_info:{execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  type:{name:\"config-driven-workflow\"}  start_time:{seconds:1753820831  nanos:255542000}  close_time:{seconds:1753820877  nanos:11297000}  status:WORKFLOW_EXECUTION_STATUS_COMPLETED  history_length:1059  execution_time:{seconds:1753820831  nanos:255542000}  memo:{}  search_attributes:{indexed_fields:{key:\"BuildIds\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"KeywordList\"}  data:\"[\\\"unversioned\\\",\\\"unversioned:c833950374cdf2b838f763e1be233d7f\\\"]\"}}  indexed_fields:{key:\"CustomKeywordField\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"Keyword\"}  data:\"\\\"configdriven-bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7\\\"\"}}}  auto_reset_points:{points:{build_id:\"c833950374cdf2b838f763e1be233d7f\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"  first_workflow_task_completed_id:5  create_time:{seconds:1753820831  nanos:313933000}  resettable:true}}  task_queue:\"temporal-bench\"  state_transition_count:414  history_size_bytes:226292  most_recent_worker_version_stamp:{build_id:\"c833950374cdf2b838f763e1be233d7f\"}  execution_duration:{seconds:45  nanos:755755000}  root_execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  first_run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  workflow_extended_info:{execution_expiration_time:{seconds:1753826831  nanos:255000000}  run_expiration_time:{seconds:1753826831  nanos:254766000}  original_start_time:{seconds:1753820831  nanos:255542000}  7:\"\\n$bb7b26d0-a3bb-42db-b202-1219cd80f465\\x12\\x04\\x08\\x01\\x10\\x01\"}","resp":"execution_config:{task_queue:{name:\"temporal-bench\"  kind:TASK_QUEUE_KIND_NORMAL}  workflow_execution_timeout:{seconds:5999  nanos:999224000}  workflow_run_timeout:{seconds:5999  nanos:999224000}  default_workflow_task_timeout:{seconds:10}}  workflow_execution_info:{execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  type:{name:\"config-driven-workflow\"}  start_time:{seconds:1753820831  nanos:255542000}  close_time:{seconds:1753820877  nanos:11297000}  status:WORKFLOW_EXECUTION_STATUS_COMPLETED  history_length:1059  execution_time:{seconds:1753820831  nanos:255542000}  memo:{}  search_attributes:{indexed_fields:{key:\"BuildIds\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"KeywordList\"}  data:\"[\\\"unversioned\\\",\\\"unversioned:c833950374cdf2b838f763e1be233d7f\\\"]\"}}  indexed_fields:{key:\"CustomKeywordField\"  value:{metadata:{key:\"encoding\"  value:\"json/plain\"}  metadata:{key:\"type\"  value:\"Keyword\"}  data:\"\\\"configdriven-bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7\\\"\"}}}  auto_reset_points:{points:{build_id:\"c833950374cdf2b838f763e1be233d7f\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"  first_workflow_task_completed_id:5  create_time:{seconds:1753820831  nanos:313933000}  resettable:true}}  task_queue:\"temporal-bench\"  state_transition_count:414  history_size_bytes:226292  most_recent_worker_version_stamp:{build_id:\"c833950374cdf2b838f763e1be233d7f\"}  execution_duration:{seconds:45  nanos:755755000}  root_execution:{workflow_id:\"bench-throughputstress-pglass-local:019857de-0e5f-73bd-8fcf-fae3eedf95d7-config-driven-throughputstress-8\"  run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  first_run_id:\"daad8655-d719-473c-af13-83146469dccd\"}  workflow_extended_info:{execution_expiration_time:{seconds:1753826831  nanos:255000000}  run_expiration_time:{seconds:1753826831  nanos:254766000}  original_start_time:{seconds:1753820831  nanos:255542000}  7:\"\\n$bb7b26d0-a3bb-42db-b202-1219cd80f465\\x12\\x04\\x08\\x01\\x10\\x01\"}","xdc-redirection":["f"],"logging-call-at":"/Users/pglass/code/s2s-proxy/proxy/workflowservice.go:337"}
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
