### PR TITLE
Refactor stream connections for better readability, add stream metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -41,7 +41,11 @@ func GetStandardGRPCInterceptor(labelNamesInContext ...string) *grpcprom.ServerM
 		grpcprom.WithServerHandlingTimeHistogram(
 			grpcprom.WithHistogramNamespace("temporal"),
 			grpcprom.WithHistogramSubsystem("s2s_proxy"),
-			// TODO: Use Native histograms or configure the buckets here?
+			grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
+				// Only Buckets, NativeHistogramBucketFactor, and other NativeHistogram options are supported here.
+				// Other histogram options should be supplied with grpcprom.WithXXXX
+				NativeHistogramBucketFactor: 1.1,
+			}),
 		),
 		grpcprom.WithServerCounterOptions(
 			grpcprom.WithNamespace("temporal"),
@@ -57,6 +61,11 @@ func GetStandardGRPCClientInterceptor(direction string) *grpcprom.ClientMetrics 
 			grpcprom.WithHistogramNamespace("temporal"),
 			// TODO: Gratuitous hack until https://github.com/grpc-ecosystem/go-grpc-middleware/issues/783
 			grpcprom.WithHistogramSubsystem("s2s_proxy_"+direction),
+			grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
+				// Only Buckets, NativeHistogramBucketFactor, and other NativeHistogram options are supported here.
+				// Other histogram options should be supplied with grpcprom.WithXXXX
+				NativeHistogramBucketFactor: 1.1,
+			}),
 		),
 		grpcprom.WithClientCounterOptions(
 			grpcprom.WithNamespace("temporal"),
@@ -85,6 +94,18 @@ func DefaultGaugeVec(name string, help string, labels ...string) *prometheus.Gau
 		Subsystem: "s2s_proxy",
 		Name:      SanitizeForPrometheus(name),
 		Help:      help,
+	}, labels)
+}
+
+// DefaultHistogramVec provides a prometheus HistogramVec for the requested name. The name will be sanitized, and the recommended
+// namespace and subsystem will be set. Vector metrics allow the use of labels, so if you need labels on your metrics, then use this.
+func DefaultHistogramVec(name string, help string, labels ...string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                   "temporal",
+		Subsystem:                   "s2s_proxy",
+		Name:                        SanitizeForPrometheus(name),
+		Help:                        help,
+		NativeHistogramBucketFactor: 1.1,
 	}, labels)
 }
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -41,11 +41,13 @@ func GetStandardGRPCInterceptor(labelNamesInContext ...string) *grpcprom.ServerM
 		grpcprom.WithServerHandlingTimeHistogram(
 			grpcprom.WithHistogramNamespace("temporal"),
 			grpcprom.WithHistogramSubsystem("s2s_proxy"),
-			grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
-				// Only Buckets, NativeHistogramBucketFactor, and other NativeHistogram options are supported here.
-				// Other histogram options should be supplied with grpcprom.WithXXXX
-				NativeHistogramBucketFactor: 1.1,
-			}),
+			// TODO: Enable native histograms later
+			//grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
+			//	// Only Buckets, NativeHistogramBucketFactor, and other NativeHistogram options are supported here.
+			//	// Other histogram options should be supplied with grpcprom.WithXXXX
+			//	NativeHistogramBucketFactor:    1.1,
+			//	NativeHistogramMaxBucketNumber: 10,
+			//}),
 		),
 		grpcprom.WithServerCounterOptions(
 			grpcprom.WithNamespace("temporal"),
@@ -61,11 +63,12 @@ func GetStandardGRPCClientInterceptor(direction string) *grpcprom.ClientMetrics 
 			grpcprom.WithHistogramNamespace("temporal"),
 			// TODO: Gratuitous hack until https://github.com/grpc-ecosystem/go-grpc-middleware/issues/783
 			grpcprom.WithHistogramSubsystem("s2s_proxy_"+direction),
-			grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
-				// Only Buckets, NativeHistogramBucketFactor, and other NativeHistogram options are supported here.
-				// Other histogram options should be supplied with grpcprom.WithXXXX
-				NativeHistogramBucketFactor: 1.1,
-			}),
+			// TODO: Enable native histograms later
+			//grpcprom.WithHistogramOpts(&prometheus.HistogramOpts{
+			//	// Only Buckets, NativeHistogramBucketFactor, and other NativeHistogram options are supported here.
+			//	// Other histogram options should be supplied with grpcprom.WithXXXX
+			//	NativeHistogramBucketFactor: 1.1,
+			//}),
 		),
 		grpcprom.WithClientCounterOptions(
 			grpcprom.WithNamespace("temporal"),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -104,11 +104,12 @@ func DefaultGaugeVec(name string, help string, labels ...string) *prometheus.Gau
 // namespace and subsystem will be set. Vector metrics allow the use of labels, so if you need labels on your metrics, then use this.
 func DefaultHistogramVec(name string, help string, labels ...string) *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace:                   "temporal",
-		Subsystem:                   "s2s_proxy",
-		Name:                        SanitizeForPrometheus(name),
-		Help:                        help,
-		NativeHistogramBucketFactor: 1.1,
+		Namespace: "temporal",
+		Subsystem: "s2s_proxy",
+		Name:      SanitizeForPrometheus(name),
+		Help:      help,
+		// TODO: Native histograms aren't supported in our Grafana just yet
+		//NativeHistogramBucketFactor: 1.1,
 	}, labels)
 }
 

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -11,8 +11,14 @@ var (
 
 	// /proxy/adminservice.go
 
-	AdminServiceStreamsActive = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open",
-		"direction")
+	AdminServiceStreamsActive      = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open", "direction")
+	AdminServiceStreamDuration     = DefaultHistogramVec("admin_service_stream_duration", "The length of time each stream was open", "direction")
+	AdminServiceStreamsOpenedCount = DefaultCounterVec("admin_service_streams_opened_count", "Number of streams opened", "direction")
+	AdminServiceStreamsClosedCount = DefaultCounterVec("admin_service_streams_closed_count", "Number of streams closed", "direction")
+	AdminServiceStreamReqCount     = DefaultCounterVec("admin_service_stream_request_count", "Number of messages received", "direction")
+	AdminServiceStreamRespCount    = DefaultCounterVec("admin_service_stream_response_count", "Number of messages received", "direction")
+	// AdminServiceStreamTerminatedCount's labels are direction (inbound/outbound) and terminated_by (source/target)
+	AdminServiceStreamTerminatedCount = DefaultCounterVec("admin_service_stream_terminated_count", "Stream was terminated by remote server", "direction", "terminated_by")
 
 	// /proxy/health_check.go
 
@@ -49,13 +55,23 @@ func init() {
 	// Re-register the go collector with all non-debug metrics. See: https://pkg.go.dev/runtime/metrics
 	prometheus.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
 		collectors.WithoutGoCollectorRuntimeMetrics(collectors.MetricsDebug.Matcher)))
-	prometheus.MustRegister(ProxyStartCount)
-	prometheus.MustRegister(GRPCServerMetrics)
-	prometheus.MustRegister(GRPCOutboundClientMetrics)
-	prometheus.MustRegister(GRPCInboundClientMetrics)
+	prometheus.MustRegister(AdminServiceStreamsActive)
+	prometheus.MustRegister(AdminServiceStreamDuration)
+	prometheus.MustRegister(AdminServiceStreamsOpenedCount)
+	prometheus.MustRegister(AdminServiceStreamsClosedCount)
+	prometheus.MustRegister(AdminServiceStreamReqCount)
+	prometheus.MustRegister(AdminServiceStreamRespCount)
+	prometheus.MustRegister(AdminServiceStreamTerminatedCount)
+
 	prometheus.MustRegister(HealthCheckIsHealthy)
 	prometheus.MustRegister(HealthCheckHealthyCount)
-	prometheus.MustRegister(AdminServiceStreamsActive)
+
+	prometheus.MustRegister(GRPCServerMetrics)
+	prometheus.MustRegister(ProxyStartCount)
+
+	prometheus.MustRegister(GRPCOutboundClientMetrics)
+	prometheus.MustRegister(GRPCInboundClientMetrics)
+
 	prometheus.MustRegister(MuxSessionOpen)
 	prometheus.MustRegister(MuxStreamsActive)
 	prometheus.MustRegister(MuxObserverReportCount)

--- a/proxy/admin_stream_transfer.go
+++ b/proxy/admin_stream_transfer.go
@@ -69,7 +69,6 @@ func transferSourceToTarget(
 		case dataWithError := <-dataChan:
 			resp = dataWithError.val
 			err = dataWithError.err
-			break
 		}
 		if err == io.EOF {
 			logger.Debug("sourceStreamClient.Recv encountered EOF", tag.Error(err))
@@ -150,7 +149,6 @@ func transferTargetToSource(
 		case valueWithError := <-dataChan:
 			req = valueWithError.val
 			err = valueWithError.err
-			break
 		}
 		if err == io.EOF {
 			logger.Debug("targetStreamServer.Recv encountered EOF", tag.Error(err))

--- a/proxy/admin_stream_transfer.go
+++ b/proxy/admin_stream_transfer.go
@@ -1,0 +1,189 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/channel"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+
+	"github.com/temporalio/s2s-proxy/metrics"
+)
+
+type StreamRequestOrResponse interface {
+	adminservice.StreamWorkflowReplicationMessagesRequest | adminservice.StreamWorkflowReplicationMessagesResponse
+}
+type ValueWithError[T StreamRequestOrResponse] struct {
+	val *T
+	err error
+}
+type recvable[T StreamRequestOrResponse] interface {
+	Recv() (*T, error)
+}
+
+// startListener creates a channel of Recv() from the provided source. It is the job of the caller to cancel the context
+// that will stop Recv(), or the goroutine created by this will block forever
+func startListener[T StreamRequestOrResponse](
+	receiver recvable[T],
+	shutdownChan channel.ShutdownOnce,
+) chan ValueWithError[T] {
+	targetStreamServerData := make(chan ValueWithError[T])
+	go func() {
+		for !shutdownChan.IsShutdown() {
+			req, err := receiver.Recv()
+			targetStreamServerData <- ValueWithError[T]{val: req, err: err}
+		}
+	}()
+	return targetStreamServerData
+}
+
+func transferSourceToTarget(
+	sourceStreamClient adminservice.AdminService_StreamWorkflowReplicationMessagesClient,
+	targetStreamServer adminservice.AdminService_StreamWorkflowReplicationMessagesServer,
+	wg *sync.WaitGroup,
+	shutdownChan channel.ShutdownOnce,
+	sendEOFToServer *atomic.Bool,
+	directionLabel string,
+	logger log.Logger,
+) {
+	defer func() {
+		logger.Debug("Shutdown sourceStreamClient.Recv loop.")
+		shutdownChan.Shutdown()
+		wg.Done()
+	}()
+
+	dataChan := startListener(sourceStreamClient, shutdownChan)
+
+	for {
+		var resp *adminservice.StreamWorkflowReplicationMessagesResponse
+		var err error
+		select {
+		case <-shutdownChan.Channel():
+			return
+		case dataWithError := <-dataChan:
+			resp = dataWithError.val
+			err = dataWithError.err
+			break
+		}
+		if err == io.EOF {
+			logger.Debug("sourceStreamClient.Recv encountered EOF", tag.Error(err))
+			metrics.AdminServiceStreamTerminatedCount.WithLabelValues(directionLabel, "source").Inc()
+			sendEOFToServer.Store(true)
+			return
+		}
+
+		if err != nil {
+			logger.Error("sourceStreamClient.Recv encountered error", tag.Error(err))
+			sendEOFToServer.Store(true)
+			return
+		}
+		switch attr := resp.GetAttributes().(type) {
+		case *adminservice.StreamWorkflowReplicationMessagesResponse_Messages:
+			logger.Debug(fmt.Sprintf("forwarding ReplicationMessages: exclusive %v", attr.Messages.ExclusiveHighWatermark))
+			if err = targetStreamServer.Send(resp); err != nil {
+				if err != io.EOF {
+					logger.Error("targetStreamServer.Send encountered error", tag.Error(err))
+				} else {
+					logger.Debug("targetStreamServer.Send encountered EOF", tag.Error(err))
+					metrics.AdminServiceStreamTerminatedCount.WithLabelValues(directionLabel, "target").Inc()
+				}
+				sendEOFToServer.Store(true)
+				return
+			}
+			metrics.AdminServiceStreamReqCount.WithLabelValues(directionLabel).Inc()
+		default:
+			logger.Error("sourceStreamClient.Recv encountered error", tag.Error(serviceerror.NewInternal(fmt.Sprintf(
+				"StreamWorkflowReplicationMessages encountered unknown type: %T %v", attr, attr,
+			))))
+			sendEOFToServer.Store(true)
+			return
+		}
+	}
+}
+
+func transferTargetToSource(
+	sourceStreamClient adminservice.AdminService_StreamWorkflowReplicationMessagesClient,
+	targetStreamServer adminservice.AdminService_StreamWorkflowReplicationMessagesServer,
+	wg *sync.WaitGroup,
+	shutdownChan channel.ShutdownOnce,
+	sendEOFToServer *atomic.Bool,
+	directionLabel string,
+	logger log.Logger,
+) {
+	defer func() {
+		logger.Debug("Shutdown targetStreamServer.Recv loop.")
+		shutdownChan.Shutdown()
+		var err error
+		closeSent := make(chan struct{})
+		go func() {
+			err = sourceStreamClient.CloseSend()
+			closeSent <- struct{}{}
+		}()
+		timeout := time.After(time.Second)
+		select {
+		case <-closeSent:
+			break
+		case <-timeout:
+			err = fmt.Errorf("timed out waiting for source stream to close")
+		}
+
+		if err != nil {
+			logger.Error("Failed to close sourceStreamClient", tag.Error(err))
+		}
+		wg.Done()
+	}()
+
+	dataChan := startListener(targetStreamServer, shutdownChan)
+
+	for {
+		var req *adminservice.StreamWorkflowReplicationMessagesRequest
+		var err error
+		select {
+		case <-shutdownChan.Channel():
+			return
+		case valueWithError := <-dataChan:
+			req = valueWithError.val
+			err = valueWithError.err
+			break
+		}
+		if err == io.EOF {
+			logger.Debug("targetStreamServer.Recv encountered EOF", tag.Error(err))
+			metrics.AdminServiceStreamTerminatedCount.WithLabelValues(directionLabel, "target").Inc()
+			sendEOFToServer.Store(true)
+			return
+		}
+
+		if err != nil {
+			logger.Error("targetStreamServer.Recv encountered error", tag.Error(err))
+			return
+		}
+
+		switch attr := req.GetAttributes().(type) {
+		case *adminservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState:
+			logger.Debug(fmt.Sprintf("forwarding SyncReplicationState: inclusive %v", attr.SyncReplicationState.InclusiveLowWatermark))
+			if err = sourceStreamClient.Send(req); err != nil {
+				if err != io.EOF {
+					logger.Error("sourceStreamClient.Send encountered error", tag.Error(err))
+				} else {
+					logger.Debug("sourceStreamClient.Send encountered EOF", tag.Error(err))
+					metrics.AdminServiceStreamTerminatedCount.WithLabelValues(directionLabel, "source").Inc()
+				}
+				sendEOFToServer.Store(true)
+				return
+			}
+			metrics.AdminServiceStreamRespCount.WithLabelValues(directionLabel).Inc()
+		default:
+			logger.Error("targetStreamServer.Recv encountered error", tag.Error(serviceerror.NewInternal(fmt.Sprintf(
+				"StreamWorkflowReplicationMessages encountered unknown type: %T %v", attr, attr,
+			))))
+			sendEOFToServer.Store(true)
+			return
+		}
+	}
+}

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
@@ -230,6 +232,10 @@ func ClusterShardIDtoString(sd history.ClusterShardID) string {
 	return fmt.Sprintf("(id: %d, shard: %d)", sd.ClusterID, sd.ShardID)
 }
 
+// StreamWorkflowReplicationMessages establishes an HTTP/2 stream. gRPC passes us a stream that represents the initiating server,
+// and we can freely Send and Recv on that "server". Because this is a proxy, we also establish a bidirectional
+// stream using our configured adminClient. When we Recv on the initiator, we Send to the client.
+// When we Recv on the client, we Send to the initiator
 func (s *adminServiceProxyServer) StreamWorkflowReplicationMessages(
 	targetStreamServer adminservice.AdminService_StreamWorkflowReplicationMessagesServer,
 ) (retError error) {
@@ -258,6 +264,7 @@ func (s *adminServiceProxyServer) StreamWorkflowReplicationMessages(
 	logger.Info("AdminStreamReplicationMessages started.")
 	streamsActiveGauge := metrics.AdminServiceStreamsActive.WithLabelValues(directionLabel)
 	streamsActiveGauge.Inc()
+	metrics.AdminServiceStreamsOpenedCount.WithLabelValues(directionLabel).Inc()
 	defer streamsActiveGauge.Dec()
 	defer logger.Info("AdminStreamReplicationMessages stopped.")
 
@@ -271,100 +278,39 @@ func (s *adminServiceProxyServer) StreamWorkflowReplicationMessages(
 		logger.Error("remoteAdminServiceClient.StreamWorkflowReplicationMessages encountered error", tag.Error(err))
 		return err
 	}
+	streamStartTime := time.Now()
 
-	shutdownChan := channel.NewShutdownOnce()
-
-	// Downstream (targetStreamServer) recv loop
-	go func() {
-		defer func() {
-			logger.Info("Shutdown targetStreamServer.Recv loop.")
-			shutdownChan.Shutdown()
-
-			err = sourceStreamClient.CloseSend()
-			if err != nil {
-				logger.Error("Failed to close sourceStreamClient", tag.Error(err))
-			}
-		}()
-
-		for !shutdownChan.IsShutdown() {
-			req, err := targetStreamServer.Recv()
-			if err == io.EOF {
-				logger.Info("targetStreamServer.Recv encountered EOF", tag.Error(err))
-				return
-			}
-
-			if err != nil {
-				logger.Error("targetStreamServer.Recv encountered error", tag.Error(err))
-				return
-			}
-
-			switch attr := req.GetAttributes().(type) {
-			case *adminservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState:
-				logger.Debug(fmt.Sprintf("forwarding SyncReplicationState: inclusive %v", attr.SyncReplicationState.InclusiveLowWatermark))
-				if err = sourceStreamClient.Send(req); err != nil {
-					if err != io.EOF {
-						logger.Error("sourceStreamClient.Send encountered error", tag.Error(err))
-					} else {
-						logger.Info("sourceStreamClient.Send encountered EOF", tag.Error(err))
-					}
-					return
-				}
-			default:
-				logger.Error("targetStreamServer.Recv encountered error", tag.Error(serviceerror.NewInternal(fmt.Sprintf(
-					"StreamWorkflowReplicationMessages encountered unknown type: %T %v", attr, attr,
-				))))
-				return
-			}
-		}
-	}()
-
-	// Upstream (sourceStreamClient) recv loop
-	// If Upstream recv loop failed (sourceStream server restart for example), StreamWorkflowReplicationMessages
-	// returns without waiting for Downstream loop to stop. This is because Downstream loop can be blocked at
-	// targetStreamServer.Recv, which prevent StreamWorkflowReplicationMessages from returning.
-	// Once StreamWorkflowReplicationMessages returns, targetStreamServer.Recv will be unblocked
+	// When one side of the stream dies, we want to tell the other side to hang up
 	// (see https://stackoverflow.com/questions/68218469/how-to-un-wedge-go-grpc-bidi-streaming-server-from-the-blocking-recv-call)
+	// One call to StreamWorkflowReplicationMessages establishes a one-way channel through the proxy from one server to another.
+	// For an outbound stream, we have:
+	// StreamWorkflowReplicationMessagesRequest
+	// Local.Recv ===> Proxy ===> Remote.Send
+	//  ^targetStreamServer    ^sourceStreamClient
+	//
+	// StreamWorkflowReplicationMessagesResponse
+	// Local.Send <=== Proxy <=== Remote.Recv
+	//  ^targetStreamServer   ^sourceStreamClient
+	//
+	// We can freely close sourceStreamClient with closeSend. gRPC will only cancel targetStreamServer when we return from
+	// this function.
+	// Scenario 1: Remote disconnects. sourceStreamClient.Recv will return EOF. This unblocks transferSourceToTarget and sets shutdownChan.
+	//             transferTargetToSource needs to be unblocked from targetStreamServer.Recv
+	// Scenario 2: Local disconnects. targetStreamServer.Recv will return EOF. This unblocks transferTargetToSource and sets shutdownChan.
+	//             transferSourceToTarget needs to be unblocked from sourceStreamClient.Recv
+	shutdownChan := channel.NewShutdownOnce()
+	sendEOFToServer := atomic.Bool{}
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer func() {
-			logger.Info("Shutdown sourceStreamClient.Recv loop.")
-
-			shutdownChan.Shutdown()
-			wg.Done()
-		}()
-
-		for !shutdownChan.IsShutdown() {
-			resp, err := sourceStreamClient.Recv()
-			if err == io.EOF {
-				logger.Info("sourceStreamClient.Recv encountered EOF", tag.Error(err))
-				return
-			}
-
-			if err != nil {
-				logger.Error("sourceStreamClient.Recv encountered error", tag.Error(err))
-				return
-			}
-			switch attr := resp.GetAttributes().(type) {
-			case *adminservice.StreamWorkflowReplicationMessagesResponse_Messages:
-				logger.Debug(fmt.Sprintf("forwarding ReplicationMessages: exclusive %v", attr.Messages.ExclusiveHighWatermark))
-				if err = targetStreamServer.Send(resp); err != nil {
-					if err != io.EOF {
-						logger.Error("targetStreamServer.Send encountered error", tag.Error(err))
-					} else {
-						logger.Info("targetStreamServer.Send encountered EOF", tag.Error(err))
-					}
-					return
-				}
-			default:
-				logger.Error("sourceStreamClient.Recv encountered error", tag.Error(serviceerror.NewInternal(fmt.Sprintf(
-					"StreamWorkflowReplicationMessages encountered unknown type: %T %v", attr, attr,
-				))))
-				return
-			}
-		}
-	}()
-
+	wg.Add(2)
+	go transferTargetToSource(sourceStreamClient, targetStreamServer, &wg, shutdownChan, &sendEOFToServer, directionLabel, logger)
+	go transferSourceToTarget(sourceStreamClient, targetStreamServer, &wg, shutdownChan, &sendEOFToServer, directionLabel, logger)
 	wg.Wait()
+
+	streamDuration := time.Since(streamStartTime)
+	metrics.AdminServiceStreamDuration.WithLabelValues(directionLabel).Observe(streamDuration.Seconds())
+	metrics.AdminServiceStreamsClosedCount.WithLabelValues(directionLabel).Inc()
+	if sendEOFToServer.Load() {
+		return io.EOF
+	}
 	return nil
 }


### PR DESCRIPTION
## What was changed
Added a bunch of metrics:
- AdminServiceStreamDuration - Length the stream was open. If this drops to near-0, there's a problem
- AdminServiceStreamsOpenedCount - Number of new streams opened
- AdminServiceStreamsClosedCount  - Number of streams closed
- AdminServiceStreamReqCount - Number of requests sent through the stream
- AdminServiceStreamRespCount - number of responses received through the stream
- AdminServiceStreamTerminatedCount - Number of non-proxy-initiated stream terminations

Also refactored the logic in StreamWorkflowMessages to make it a little more obviously symmetric. 
