### PR TITLE
Throttle log messages

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,8 @@ const (
 	ConfigPathFlag = "config"
 	LogLevelFlag   = "level"
 
-	DefaultPProfAddress = "localhost:6060"
+	DefaultPProfAddress          = "localhost:6060"
+	DefaultLoggingThrottleMaxRPS = 10.0
 )
 
 type TransportType string
@@ -115,6 +116,7 @@ type (
 		SearchAttributeTranslation SATranslationConfig   `yaml:"searchAttributeTranslation"`
 		Metrics                    *MetricsConfig        `yaml:"metrics"`
 		ProfilingConfig            ProfilingConfig       `yaml:"profiling"`
+		Logging                    LoggingConfig         `yaml:"logging"`
 	}
 
 	SATranslationConfig struct {
@@ -166,6 +168,10 @@ type (
 
 	MetricsConfig struct {
 		Prometheus PrometheusConfig `yaml:"prometheus"`
+	}
+
+	LoggingConfig struct {
+		ThrottleMaxRPS float64 `yaml:"throttleMaxRPS"`
 	}
 )
 
@@ -368,4 +374,11 @@ func (s SATranslationConfig) ToMaps(inBound bool) (map[string]map[string]string,
 		}
 	}
 	return reqMap, respMap
+}
+
+func (l LoggingConfig) GetThrottleMaxRPS() float64 {
+	if l.ThrottleMaxRPS > 0 {
+		return l.ThrottleMaxRPS
+	}
+	return DefaultLoggingThrottleMaxRPS
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -255,7 +255,12 @@ func NewProxy(
 	proxy := &Proxy{
 		config:       s2sConfig,
 		transManager: transManager,
-		logger:       logger,
+		logger: log.NewThrottledLogger(
+			logger,
+			func() float64 {
+				return s2sConfig.Logging.GetThrottleMaxRPS()
+			},
+		),
 	}
 
 	// Proxy consists of two grpc servers: inbound and outbound. The flow looks like the following:
@@ -272,7 +277,7 @@ func NewProxy(
 				Config:    s2sConfig,
 			},
 			transManager,
-			logger,
+			proxy.logger,
 		)
 	}
 
@@ -284,7 +289,7 @@ func NewProxy(
 				Config:    s2sConfig,
 			},
 			transManager,
-			logger,
+			proxy.logger,
 		)
 	}
 


### PR DESCRIPTION
## What was changed

Throttle logs according to a single global max limit

* Use Temporal's `ThrottleLogger` to throttle log messages
* Add `logging.throttle.MaxRPS` config option, which defaults to 10 rps

## Why?

Avoid spamming millions of messages per day

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
