### PR TITLE
fix: Goroutine leak

### DIFF
--- a/proxy/admin_stream_transfer.go
+++ b/proxy/admin_stream_transfer.go
@@ -35,6 +35,7 @@ func startListener[T StreamRequestOrResponse](
 ) chan ValueWithError[T] {
 	targetStreamServerData := make(chan ValueWithError[T])
 	go func() {
+		defer close(targetStreamServerData)
 		for !shutdownChan.IsShutdown() {
 			req, err := receiver.Recv()
 			select {


### PR DESCRIPTION
## What was changed

Fix a goroutine leak caused by not checking the shutdown channel.

## Why?

This causes a memory leak due to ever increasing number of goroutines over time.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Deployed to a cluster and checked metrics.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
