### PR TITLE
Limit mux client connection retry rate

### DIFF
--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"crypto/tls"
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -227,6 +228,10 @@ func (m *muxConnectMananger) clientLoop(setting config.TCPClientSetting) error {
 
 				m.muxTransport = newMuxTransport(conn, session)
 				m.waitForReconnect()
+
+				// Don't retry more frequently than once per second.
+				// Sleep a random amount between 1s-2s.
+				time.Sleep(time.Second + time.Duration(rand.IntN(1000))*time.Millisecond)
 			}
 		}
 	}()


### PR DESCRIPTION
## What was changed

Limit mux client connection retry to at most 1 per second.

## Why?

This should help avoid a case where the client is spamming reconnect faster than the server can handle. The following logs show the server logging `Accept new connection` at a rate faster than a few ms, indicating the client is retrying without any limit. 

<details>

<summary>Sample of server logs</summary>

```
2025-08-17 07:03:35.766	2025/08/17 07:03:35 [ERR] yamux: Failed to read header: write tcp $LOCAL_IP:8233->$REMOTE_IP:30503: write: broken pipe
2025-08-17 07:03:35.760	{"level":"warn","ts":"2025-08-17T07:03:35.760Z","msg":"Yamux observer died!","Name":"muxed","Mode":"server","muxConfigName":"muxed","err":null,"logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:247"}
2025-08-17 07:03:35.760	{"level":"info","ts":"2025-08-17T07:03:35.760Z","msg":"Accept new connection","Name":"muxed","Mode":"server","remoteAddr":"$REMOTE_IP:30503","logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:156"}
2025-08-17 07:03:35.760	{"level":"warn","ts":"2025-08-17T07:03:35.760Z","msg":"Yamux observer died!","Name":"muxed","Mode":"server","muxConfigName":"muxed","err":null,"logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:247"}
2025-08-17 07:03:35.760	{"level":"info","ts":"2025-08-17T07:03:35.760Z","msg":"Accept new connection","Name":"muxed","Mode":"server","remoteAddr":"$REMOTE_IP:65390","logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:156"}
2025-08-17 07:03:35.755	{"level":"warn","ts":"2025-08-17T07:03:35.755Z","msg":"Yamux observer died!","Name":"muxed","Mode":"server","muxConfigName":"muxed","err":null,"logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:247"}
2025-08-17 07:03:35.755	{"level":"info","ts":"2025-08-17T07:03:35.755Z","msg":"Accept new connection","Name":"muxed","Mode":"server","remoteAddr":"$REMOTE_IP:63407","logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:156"}
2025-08-17 07:03:35.755	2025/08/17 07:03:35 [ERR] yamux: Failed to read header: write tcp $LOCAL_IP:8233->$REMOTE_IP:33687: write: broken pipe
2025-08-17 07:03:35.750	{"level":"warn","ts":"2025-08-17T07:03:35.750Z","msg":"Yamux observer died!","Name":"muxed","Mode":"server","muxConfigName":"muxed","err":null,"logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:247"}
2025-08-17 07:03:35.750	{"level":"info","ts":"2025-08-17T07:03:35.750Z","msg":"Accept new connection","Name":"muxed","Mode":"server","remoteAddr":"$REMOTE_IP:33687","logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:156"}
2025-08-17 07:03:35.750	{"level":"info","ts":"2025-08-17T07:03:35.750Z","msg":"Accept new connection","Name":"muxed","Mode":"server","remoteAddr":"$REMOTE_IP:16705","logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:156"}
2025-08-17 07:03:35.750	{"level":"error","ts":"2025-08-17T07:03:35.749Z","msg":"grpc server fatal error ","error":"read tcp $LOCAL_IP:8233->$REMOTE_IP:64737: read: connection reset by peer","logging-call-at":"/s2s-proxy/proxy/temporal_api_server.go:64","stacktrace":"go.temporal.io/server/common/log.(*zapLogger).Error\n\t/go/pkg/mod/go.temporal.io/server@v1.27.2/common/log/zap_logger.go:154\ngo.temporal.io/server/common/log.(*throttledLogger).Error.func1\n\t/go/pkg/mod/go.temporal.io/server@v1.27.2/common/log/throttle_logger.go:79\ngo.temporal.io/server/common/log.(*throttledLogger).rateLimit\n\t/go/pkg/mod/go.temporal.io/server@v1.27.2/common/log/throttle_logger.go:112\ngo.temporal.io/server/common/log.(*throttledLogger).Error\n\t/go/pkg/mod/go.temporal.io/server@v1.27.2/common/log/throttle_logger.go:78\ngithub.com/temporalio/s2s-proxy/proxy.(*TemporalAPIServer).Start.func1\n\t/s2s-proxy/proxy/temporal_api_server.go:64"}
2025-08-17 07:03:35.749	{"level":"warn","ts":"2025-08-17T07:03:35.749Z","msg":"Yamux observer died!","Name":"muxed","Mode":"server","muxConfigName":"muxed","err":null,"logging-call-at":"/s2s-proxy/transport/mux_connection_manager.go:247"}
2025-08-17 07:03:35.749	2025/08/17 07:03:35 [ERR] yamux: Failed to write header: use of closed network connection
2025-08-17 07:03:35.749	2025/08/17 07:03:35 [ERR] yamux: Failed to read stream data: read tcp $LOCAL_IP:8233->$REMOTE_IP:64737: read: connection reset by peer
```

</details>

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
