### PR TITLE
Cleanup logging

### DIFF
--- a/proxy/admin_stream_transfer.go
+++ b/proxy/admin_stream_transfer.go
@@ -89,7 +89,8 @@ func transferSourceToTarget(
 		}
 		switch attr := resp.GetAttributes().(type) {
 		case *adminservice.StreamWorkflowReplicationMessagesResponse_Messages:
-			logger.Debug(fmt.Sprintf("forwarding ReplicationMessages: exclusive %v", attr.Messages.ExclusiveHighWatermark))
+			logger.Debug("forwarding ReplicationMessages", tag.NewInt64("exclusive", attr.Messages.GetExclusiveHighWatermark()))
+
 			if err = targetStreamServer.Send(resp); err != nil {
 				if err != io.EOF {
 					logger.Error("targetStreamServer.Send encountered error", tag.Error(err))
@@ -169,7 +170,7 @@ func transferTargetToSource(
 
 		switch attr := req.GetAttributes().(type) {
 		case *adminservice.StreamWorkflowReplicationMessagesRequest_SyncReplicationState:
-			logger.Debug(fmt.Sprintf("forwarding SyncReplicationState: inclusive %v", attr.SyncReplicationState.InclusiveLowWatermark))
+			logger.Debug("forwarding SyncReplicationState", tag.NewInt64("inclusive", attr.SyncReplicationState.GetInclusiveLowWatermark()))
 			if err = sourceStreamClient.Send(req); err != nil {
 				if err != io.EOF {
 					logger.Error("sourceStreamClient.Send encountered error", tag.Error(err))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -317,7 +317,7 @@ func (s *Proxy) startHealthCheckHandler(cfg config.HealthCheckConfig) error {
 	go func() {
 		s.logger.Info("Starting health check server", tag.Address(cfg.ListenAddress))
 		if err := s.healthCheckServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.logger.Error("Error starting server: %v\n", tag.Error(err))
+			s.logger.Error("Error starting server", tag.Error(err))
 		}
 	}()
 
@@ -336,7 +336,7 @@ func (s *Proxy) startMetricsHandler(cfg config.MetricsConfig) error {
 	go func() {
 		s.logger.Info("Starting metrics server", tag.Address(cfg.Prometheus.ListenAddress))
 		if err := s.metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.logger.Error("Error starting server: %v\n", tag.Error(err))
+			s.logger.Error("Error starting server", tag.Error(err))
 		}
 	}()
 	return nil


### PR DESCRIPTION
## What was changed

This cleans up some logging calls.

* Remove a couple per-request logs that are noisy
* Remove unhelpful Debug logs
* Use log tags instead of Sprintf where possible
* Remove printf format strings that aren't used
* Avoid using `log.With` on a per-request path since it allocates

## Why?

Tidy up our logging a bit.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
