### PR TITLE
fix: ClientProvider locking

### DIFF
--- a/client/temporal_client.go
+++ b/client/temporal_client.go
@@ -57,34 +57,38 @@ func NewClientProvider(
 }
 
 func (c *clientProvider) GetAdminClient() (adminservice.AdminServiceClient, error) {
-	c.adminClientsLock.Lock()
-	defer c.adminClientsLock.Unlock()
-
 	if c.adminClient == nil {
-		c.logger.Info(fmt.Sprintf("Create adminclient with config: %v", c.clientConfig))
-		adminClient, err := c.clientFactory.NewRemoteAdminClient(c.clientConfig)
-		if err != nil {
-			return nil, err
-		}
+		c.adminClientsLock.Lock()
+		defer c.adminClientsLock.Unlock()
 
-		c.adminClient = adminClient
+		if c.adminClient == nil {
+			c.logger.Info(fmt.Sprintf("Create adminclient with config: %v", c.clientConfig))
+			adminClient, err := c.clientFactory.NewRemoteAdminClient(c.clientConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			c.adminClient = adminClient
+		}
 	}
 
 	return c.adminClient, nil
 }
 
 func (c *clientProvider) GetWorkflowServiceClient() (workflowservice.WorkflowServiceClient, error) {
-	c.workflowserviceClientsLock.Lock()
-	defer c.workflowserviceClientsLock.Unlock()
-
 	if c.workflowserviceClient == nil {
-		c.logger.Info(fmt.Sprintf("Create workflowservice client with config: %v", c.clientConfig))
-		workflowserviceClient, err := c.clientFactory.NewRemoteWorkflowServiceClient(c.clientConfig)
-		if err != nil {
-			return nil, err
-		}
+		c.workflowserviceClientsLock.Lock()
+		defer c.workflowserviceClientsLock.Unlock()
 
-		c.workflowserviceClient = workflowserviceClient
+		if c.workflowserviceClient == nil {
+			c.logger.Info(fmt.Sprintf("Create workflowservice client with config: %v", c.clientConfig))
+			workflowserviceClient, err := c.clientFactory.NewRemoteWorkflowServiceClient(c.clientConfig)
+			if err != nil {
+				return nil, err
+			}
+
+			c.workflowserviceClient = workflowserviceClient
+		}
 	}
 
 	return c.workflowserviceClient, nil

--- a/client/temporal_client.go
+++ b/client/temporal_client.go
@@ -57,11 +57,10 @@ func NewClientProvider(
 }
 
 func (c *clientProvider) GetAdminClient() (adminservice.AdminServiceClient, error) {
-	if c.adminClient == nil {
-		// Create admin client
-		c.adminClientsLock.Lock()
-		defer c.adminClientsLock.Unlock()
+	c.adminClientsLock.Lock()
+	defer c.adminClientsLock.Unlock()
 
+	if c.adminClient == nil {
 		c.logger.Info(fmt.Sprintf("Create adminclient with config: %v", c.clientConfig))
 		adminClient, err := c.clientFactory.NewRemoteAdminClient(c.clientConfig)
 		if err != nil {
@@ -75,11 +74,10 @@ func (c *clientProvider) GetAdminClient() (adminservice.AdminServiceClient, erro
 }
 
 func (c *clientProvider) GetWorkflowServiceClient() (workflowservice.WorkflowServiceClient, error) {
-	if c.workflowserviceClient == nil {
-		// Create admin client
-		c.workflowserviceClientsLock.Lock()
-		defer c.workflowserviceClientsLock.Unlock()
+	c.workflowserviceClientsLock.Lock()
+	defer c.workflowserviceClientsLock.Unlock()
 
+	if c.workflowserviceClient == nil {
 		c.logger.Info(fmt.Sprintf("Create workflowservice client with config: %v", c.clientConfig))
 		workflowserviceClient, err := c.clientFactory.NewRemoteWorkflowServiceClient(c.clientConfig)
 		if err != nil {


### PR DESCRIPTION
## What was changed

Correct lock usage to create only one client of a particular type.

## Why?

The current logic is not quite thread-safe. It allows many clients to be created when the proxy server is first (re)started, depending on how many requests come in. This is probably not harmful but results in a bunch of unnecessary clients, as well as a confusing metric that indicates many yamux streams are being used.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

Existing unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
