### PR TITLE
fix: stop yamux ticker

### DIFF
--- a/transport/mux_connection_manager.go
+++ b/transport/mux_connection_manager.go
@@ -265,6 +265,7 @@ func observeYamuxSession(session *yamux.Session, config config.MuxTransportConfi
 	}
 	var sessionActive int8 = 1
 	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
 	for sessionActive == 1 {
 		// Prometheus gauges are cheap, but Session.NumStreams() takes a mutex in the session! Only check once per minute
 		// to minimize overhead


### PR DESCRIPTION
## Summary
- ensure observeYamuxSession stops its ticker to avoid leaks

## Testing
- `go test ./transport -run TestMuxTransporWaitForClose -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_b_68a7490fd110832ea1d9123571e03db5