### PR TITLE
Log GOMAXPROCS at startup

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -5,6 +5,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"github.com/urfave/cli/v2"
@@ -103,6 +104,11 @@ func startProxy(c *cli.Context) error {
 	if err := app.Err(); err != nil {
 		return err
 	}
+
+	proxyParams.Logger.Info("Golang runtime info",
+		tag.NewInt("GOMAXPROCS", runtime.GOMAXPROCS(0)), // 0 returns the current value
+		tag.NewInt("NumCPU", runtime.NumCPU()),
+	)
 
 	cfg := proxyParams.ConfigProvider.GetS2SProxyConfig()
 	startPProfHTTPServer(proxyParams.Logger, cfg.ProfilingConfig)


### PR DESCRIPTION
## What was changed

Log the GOMAXPROCS value and NumCPU values.
 
## Why?

So that we can see what value it is set to on Kubernetes. 

Note: There are [changes to how GOMAXPROCS is set in Go 1.25](https://tip.golang.org/doc/go1.25#container-aware-gomaxprocs) (we are on Go 1.24 for now)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
