### PR TITLE
Add metrics on proxy service created

### DIFF
--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -29,8 +29,11 @@ var (
 
 	// /proxy/proxy.go
 
-	GRPCServerMetrics = GetStandardGRPCInterceptor("direction")
-	ProxyStartCount   = DefaultCounter("proxy_start_count", "Emitted once per startup")
+	GRPCServerMetrics     = GetStandardGRPCInterceptor("direction")
+	ProxyStartCount       = DefaultCounter("proxy_start_count", "Emitted once on Go process start")
+	ProxyServiceCreated   = DefaultCounterVec("proxy_service_created", "Emitted once per service start", "direction")
+	ProxyServiceStopped   = DefaultCounterVec("proxy_service_stopped", "Emitted on service shutdown", "direction")
+	ProxyServiceRestarted = DefaultCounterVec("proxy_service_restarted", "Emitted on service shutdown", "direction")
 
 	// /transport/grpc.go
 	// Gratuitous hack: Until https://github.com/grpc-ecosystem/go-grpc-middleware/issues/783 is addressed,
@@ -84,6 +87,9 @@ func init() {
 
 	prometheus.MustRegister(GRPCServerMetrics)
 	prometheus.MustRegister(ProxyStartCount)
+	prometheus.MustRegister(ProxyServiceCreated)
+	prometheus.MustRegister(ProxyServiceStopped)
+	prometheus.MustRegister(ProxyServiceRestarted)
 
 	prometheus.MustRegister(GRPCOutboundClientMetrics)
 	prometheus.MustRegister(GRPCInboundClientMetrics)

--- a/proxy/test/echo_server.go
+++ b/proxy/test/echo_server.go
@@ -149,7 +149,7 @@ func newEchoServer(
 		logger.Fatal("Failed to create server transport", tag.Error(err))
 	}
 
-	clientTransport, err := tm.OpenClient(prometheus.Labels{}, clientConfig)
+	clientTransport, err := tm.OpenClient(clientConfig)
 	if err != nil {
 		logger.Fatal("Failed to create client transport", tag.Error(err))
 	}

--- a/proxy/test/echo_server.go
+++ b/proxy/test/echo_server.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gogo/status"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	replicationpb "go.temporal.io/server/api/replication/v1"

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
-	prometheus "github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/server/common/log"
 	"google.golang.org/grpc"
 
@@ -66,7 +65,7 @@ func (tm *TransportManager) IsMuxActive(name string) bool {
 	return tm.muxConnManagers[name].status.Load() == int32(statusStarted)
 }
 
-func (tm *TransportManager) OpenClient(metricLabels prometheus.Labels, clientConfig config.ProxyClientConfig) (ClientTransport, error) {
+func (tm *TransportManager) OpenClient(clientConfig config.ProxyClientConfig) (ClientTransport, error) {
 	if clientConfig.Type == config.MuxTransport {
 		return tm.openMuxTransport(clientConfig.MuxTransportName)
 	}


### PR DESCRIPTION
## What was changed
Added metrics for when the proxy gRPC services were created/stopped/restarted

## Why?
This gives us more information into what's happening in tight loops when we observe the gRPC handler drop many times per second