### PR TITLE
Add translation latency metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,6 +32,12 @@ func SanitizeForPrometheus(value string) string {
 		value = "_" + value[1:]
 	}
 	return prometheusReplacePattern.ReplaceAllLiteralString(value, "_")
+}
+
+func SanitizedTypeName(m any) string {
+	name := fmt.Sprintf("%T", m)
+	name = strings.ReplaceAll(name, "*", "")
+	return SanitizeForPrometheus(name)
 }
 
 // GetStandardGRPCInterceptor returns a ServerMetrics with our preferred standard config for monitoring gRPC servers.

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -56,9 +56,10 @@ var (
 	MuxErrors              = DefaultCounterVec("mux_errors", "Number of errors observed from mux", muxManagerLabels...)
 	MuxConnectionEstablish = DefaultCounterVec("mux_connection_establish", "Number of times mux has established", muxManagerLabels...)
 
-	translationLabels = []string{"kind", "message_type"}
-	TranslationCount  = DefaultCounterVec("translation_success", "Count of message translations", translationLabels...)
-	TranslationErrors = DefaultCounterVec("translation_error", "Count of message translation errors", translationLabels...)
+	translationLabels  = []string{"kind", "message_type"}
+	TranslationCount   = DefaultCounterVec("translation_success", "Count of message translations", translationLabels...)
+	TranslationErrors  = DefaultCounterVec("translation_error", "Count of message translation errors", translationLabels...)
+	TranslationLatency = DefaultHistogramVec("translation_latency", "Latency of message translations", translationLabels...)
 
 	UTF8RepairTranslationKind = "utf8repair"
 	NamespaceTranslationKind  = "namespace"
@@ -102,4 +103,5 @@ func init() {
 
 	prometheus.MustRegister(TranslationCount)
 	prometheus.MustRegister(TranslationErrors)
+	prometheus.MustRegister(TranslationLatency)
 }


### PR DESCRIPTION
## What was changed

* Add `translation_latency` with `kind` and `message_type` labels
* Change the `message_type` values to always use a Go type name, sanitized for prometheus (e.g. `message_type="workflowservice_ListClosedWorkflowExecutionsResponse"`)

## Why?

Understand latency impact of translation

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
