### PR TITLE
Prepare mux+grpc.Clientconn investigation tests

### DIFF
--- a/proxy/test/mux_grpc_client_test.go
+++ b/proxy/test/mux_grpc_client_test.go
@@ -39,12 +39,12 @@ type muxSession struct {
 }
 
 func newMuxSession(t *testing.T, listener net.Listener) *muxSession {
-	var err error
 	s := &muxSession{}
 	s.addr = listener.Addr().String()
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
+		var err error
 		s.serverConn, err = listener.Accept()
 		require.NoError(t, err)
 		s.serverMux, err = yamux.Server(s.serverConn, nil)
@@ -52,6 +52,7 @@ func newMuxSession(t *testing.T, listener net.Listener) *muxSession {
 		wg.Done()
 	}()
 	go func() {
+		var err error
 		s.clientConn, err = net.Dial("tcp", s.addr)
 		require.NoError(t, err)
 		s.clientMux, err = yamux.Client(s.clientConn, nil)

--- a/proxy/test/mux_grpc_client_test.go
+++ b/proxy/test/mux_grpc_client_test.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/temporalio/s2s-proxy/common"
+)
+
+type muxedServer struct {
+	server  *grpc.Server
+	session *muxSession
+}
+
+func (s *muxedServer) serve(t *testing.T) {
+	err := s.server.Serve(s.session.serverMux)
+	require.NoError(t, err)
+}
+
+type muxedClient struct {
+	session    *muxSession
+	clientConn *grpc.ClientConn
+	client     adminservice.AdminServiceClient
+}
+
+type muxSession struct {
+	addr       string
+	serverConn net.Conn
+	clientConn net.Conn
+	serverMux  *yamux.Session
+	clientMux  *yamux.Session
+}
+
+type testScenario struct {
+	muxes    []*muxSession
+	servers  []*muxedServer
+	clients  []*muxedClient
+	listener net.Listener
+}
+
+func newTestScenario(t *testing.T) *testScenario {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	servers := make([]*muxedServer, 10)
+	clients := make([]*muxedClient, 10)
+	muxes := make([]*muxSession, 10)
+	for i := range 10 {
+		muxes[i] = newMuxServer(t, listener)
+		servers[i] = &muxedServer{
+			server:  grpc.NewServer(),
+			session: muxes[i],
+		}
+		serviceName := fmt.Sprintf("adminService on mux %d", i)
+		eas := &echoAdminService{
+			serviceName: serviceName,
+			logger:      log.With(logger, common.ServiceTag(serviceName), tag.Address(muxes[i].addr)),
+			namespaces:  map[string]bool{"hello": true, "world": true},
+			payloadSize: defaultPayloadSize,
+		}
+		adminservice.RegisterAdminServiceServer(servers[i].server, eas)
+		go func() {
+			err := servers[i].server.Serve(servers[i].session.serverMux)
+			require.NoError(t, err)
+		}()
+		session := servers[i].session
+		clientConn, err := grpc.NewClient("passthrough:unused",
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+				return session.clientMux.Open()
+			}),
+			grpc.WithDisableServiceConfig(),
+		)
+		require.NoError(t, err)
+		clients[i] = &muxedClient{
+			session:    muxes[i],
+			clientConn: clientConn,
+			client:     adminservice.NewAdminServiceClient(clientConn),
+		}
+	}
+	return &testScenario{
+		muxes:    muxes,
+		servers:  servers,
+		clients:  clients,
+		listener: listener,
+	}
+}
+
+func newMuxServer(t *testing.T, listener net.Listener) *muxSession {
+	var err error
+	s := &muxSession{}
+	s.addr = listener.Addr().String()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		s.serverConn, err = listener.Accept()
+		require.NoError(t, err)
+		s.serverMux, err = yamux.Server(s.serverConn, nil)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+	go func() {
+		s.clientConn, err = net.Dial("tcp", s.addr)
+		require.NoError(t, err)
+		s.clientMux, err = yamux.Client(s.clientConn, nil)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+	return s
+}
+
+// Using separate ClientConn objects created using grpc.NewClientConn "just works", but the clients are completely
+// separate and do not load-balance. We have to do the work of swapping out the client objects in the calling code.
+func TestMultiClientMultiServer(t *testing.T) {
+	scenario := newTestScenario(t)
+	for i, muxClient := range scenario.clients {
+		resp, err := muxClient.client.DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
+		require.NoError(t, err)
+		require.Equal(t, fmt.Sprintf("adminService on mux %d", i), resp.ClusterName, "Invalid or missing cluster name")
+	}
+}
+
+// Using a single ClientConn object and naively swapping in a round-robin Dialer does not work, because
+// the connection is cached.
+func TestSingleClientCustomDialer(t *testing.T) {
+	scenario := newTestScenario(t)
+	counter := &atomic.Uint32{}
+	counter.Store(0)
+	superClientConn, err := grpc.NewClient("passthrough:unused",
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			t.Log("Dialed addr", addr)
+			return scenario.muxes[counter.Add(1)%10].clientMux.Open()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	for range 10 {
+		resp, err := adminservice.NewAdminServiceClient(superClientConn).DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
+		require.NoError(t, err)
+		require.Equal(t, "adminService on mux 1", resp.ClusterName)
+	}
+}

--- a/transport/mux/multimux_test.go
+++ b/transport/mux/multimux_test.go
@@ -96,8 +96,8 @@ func TestMultiMux(t *testing.T) {
 	}
 	close(shutDownMux)
 	for _, mux := range muxes {
-		mux.muxClient.Close()
-		mux.muxServer.session.Close()
+		_ = mux.muxClient.Close()
+		_ = mux.muxServer.session.Close()
 	}
 	wg.Wait()
 }

--- a/transport/mux/multimux_test.go
+++ b/transport/mux/multimux_test.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 type muxServer struct {
 	session *yamux.Session
 	buf     []byte
+	wg      *sync.WaitGroup
 }
 type muxClientServer struct {
 	muxServer *muxServer
@@ -19,6 +21,8 @@ type muxClientServer struct {
 }
 
 func (s *muxServer) Run(t *testing.T) {
+	s.wg.Add(1)
+	defer s.wg.Done()
 	for {
 		t.Log("Listening on yamux", s.session.Addr())
 		muxconn, err := s.session.Accept()
@@ -38,6 +42,7 @@ func (s *muxServer) Run(t *testing.T) {
 }
 
 func TestMultiMux(t *testing.T) {
+	wg := &sync.WaitGroup{}
 	serverCh, shutDownMux, muxListenerAddrCh := make(chan *muxServer), make(chan struct{}), make(chan string)
 	go func() {
 		listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -62,8 +67,9 @@ func TestMultiMux(t *testing.T) {
 
 			select {
 			case <-shutDownMux:
+				_ = mux.Close()
 				return
-			case serverCh <- &muxServer{mux, make([]byte, 128)}:
+			case serverCh <- &muxServer{mux, make([]byte, 128), wg}:
 			}
 		}
 	}()
@@ -88,6 +94,12 @@ func TestMultiMux(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, num, len("Hello, World!"))
 	}
+	close(shutDownMux)
+	for _, mux := range muxes {
+		mux.muxClient.Close()
+		mux.muxServer.session.Close()
+	}
+	wg.Wait()
 }
 
 func dialUntilSuccess(t *testing.T, addr string) net.Conn {


### PR DESCRIPTION
## What was changed
Added initial test setup and investigation for using yamux together with grpc.ClientConn. 

## Why?
This file is the first step to creating a working prototype for client-side LB over multiple mux connections. If this succeeds, we will be able to avoid reimplementing the large amount of work already put into grpc.ClientConn.