### PR TITLE
First draft of multi-client-conn, widen echo_server package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,18 @@
 # Develop
 
+## Directories and contents
+
+| Package     | Purpose                                             | Start reading                            |
+|-------------|-----------------------------------------------------|------------------------------------------|
+| cmd         | Main+Tools                                          | cmd/proxy/main.go                        |
+| proxy       | Service top-level and service handlers              | proxy/proxy.go<br/>proxy/adminservice.go |
+| auth        | ACL implementation                                  | access_control.go                        |
+| interceptor | Translation and ACL<br/>interceptor implementations | interceptor/translation_interceptor.go   |
+| transport   | Mux and TCP implementation                          | transport/mux/mux_manager.go             |
+| testserver  | Local integration test fakes                        | testserver/echo_server.go                |
+| config      | Config YAML parsing and model                       | config/config.go                         |
+| metrics     | Prometheus metric defs+utils                        | metrics/prometheus_defs.go               |
+
 ## Prerequisites
 
 ### Supported platforms

--- a/proxy/test/multi_client_conn_test.go
+++ b/proxy/test/multi_client_conn_test.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/common/log"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	"github.com/temporalio/s2s-proxy/proto/1_22/server/api/adminservice/v1"
 	proxy "github.com/temporalio/s2s-proxy/testserver"
@@ -19,9 +22,7 @@ import (
 func TestMultiClientConn(t *testing.T) {
 	scenario := proxy.NewTestScenario(t, 10, log.NewTestLogger())
 	connMap := make(map[string]func() (net.Conn, error), 5)
-	connMapHolder := &connMap
 	mcc, err := grpcutil.NewMultiClientConn("testconn",
-		func() (map[string]func() (net.Conn, error), error) { return *connMapHolder, nil },
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
 	)
@@ -30,13 +31,35 @@ func TestMultiClientConn(t *testing.T) {
 		key := fmt.Sprintf("mux-%d", i)
 		connMap[key] = scenario.Muxes[i].ClientMux.Open
 	}
-	// Not functioning yet...
-	//mcc.NotifyNewConnections()
+	go func() {
+		// This call will hang until UpdateState!
+		requireCallWithNewClient(t, mcc)
+		t.Log("Delayed call eventually succeeded!")
+	}()
+	t.Log("Delayed call won't fire yet")
+	mcc.UpdateState(connMap)
 	for range scenario.Muxes {
-		client := adminservice.NewAdminServiceClient(mcc)
-		resp, err := client.DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
-		require.NoError(t, err)
-		t.Log("Connected to cluster", resp.ClusterName)
+		requireCallWithNewClient(t, mcc)
 	}
+	for i := range 10 {
+		key := fmt.Sprintf("mux-%d", i)
+		connMap[key] = scenario.Muxes[i].ClientMux.Open
+	}
+	mcc.UpdateState(connMap)
+	for range scenario.Muxes {
+		requireCallWithNewClient(t, mcc)
+	}
+	mcc.UpdateState(make(map[string]func() (net.Conn, error)))
+	timeout, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	client := adminservice.NewAdminServiceClient(mcc)
+	_, err = client.DescribeCluster(timeout, &adminservice.DescribeClusterRequest{})
+	require.Equal(t, status.Code(err), codes.Unavailable)
+	cancel()
+}
+
+func requireCallWithNewClient(t *testing.T, mcc *grpcutil.MultiClientConn) {
+	client := adminservice.NewAdminServiceClient(mcc)
+	resp, err := client.DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
 	require.NoError(t, err)
+	t.Log("Connected to cluster", resp.ClusterName)
 }

--- a/proxy/test/multi_client_conn_test.go
+++ b/proxy/test/multi_client_conn_test.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/temporalio/s2s-proxy/proto/1_22/server/api/adminservice/v1"
+	proxy "github.com/temporalio/s2s-proxy/testserver"
+	"github.com/temporalio/s2s-proxy/transport/grpcutil"
+)
+
+func TestMultiClientConn(t *testing.T) {
+	scenario := proxy.NewTestScenario(t, 10, log.NewTestLogger())
+	connMap := make(map[string]func() (net.Conn, error), 5)
+	connMapHolder := &connMap
+	mcc, err := grpcutil.NewMultiClientConn("testconn",
+		func() (map[string]func() (net.Conn, error), error) { return *connMapHolder, nil },
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+	)
+	require.NoError(t, err)
+	for i := range 5 {
+		key := fmt.Sprintf("mux-%d", i)
+		connMap[key] = scenario.Muxes[i].ClientMux.Open
+	}
+	// Not functioning yet...
+	//mcc.NotifyNewConnections()
+	for range scenario.Muxes {
+		client := adminservice.NewAdminServiceClient(mcc)
+		resp, err := client.DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
+		require.NoError(t, err)
+		t.Log("Connected to cluster", resp.ClusterName)
+	}
+	require.NoError(t, err)
+}

--- a/proxy/test/mux_grpc_client_test.go
+++ b/proxy/test/mux_grpc_client_test.go
@@ -2,161 +2,49 @@ package proxy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/resolver/manual"
 
-	"github.com/temporalio/s2s-proxy/common"
+	"github.com/temporalio/s2s-proxy/testserver"
 )
 
-type muxedServer struct {
-	server  *grpc.Server
-	session *muxSession
-}
-
-type muxedClient struct {
-	session    *muxSession
-	clientConn *grpc.ClientConn
-	client     adminservice.AdminServiceClient
-}
-
-type muxSession struct {
-	addr       string
-	serverConn net.Conn
-	clientConn net.Conn
-	serverMux  *yamux.Session
-	clientMux  *yamux.Session
-}
-
-func newMuxSession(t *testing.T, listener net.Listener) *muxSession {
-	s := &muxSession{}
-	s.addr = listener.Addr().String()
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-	go func() {
-		var err error
-		s.serverConn, err = listener.Accept()
-		require.NoError(t, err)
-		s.serverMux, err = yamux.Server(s.serverConn, nil)
-		require.NoError(t, err)
-		wg.Done()
-	}()
-	go func() {
-		var err error
-		s.clientConn, err = net.Dial("tcp", s.addr)
-		require.NoError(t, err)
-		s.clientMux, err = yamux.Client(s.clientConn, nil)
-		require.NoError(t, err)
-		wg.Done()
-	}()
-	wg.Wait()
-	return s
-}
-
-type testScenario struct {
-	muxes    []*muxSession
-	servers  []*muxedServer
-	clients  []*muxedClient
-	listener net.Listener
-}
-
-func newTestScenario(t *testing.T) *testScenario {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	servers := make([]*muxedServer, 10)
-	clients := make([]*muxedClient, 10)
-	muxes := make([]*muxSession, 10)
-	for i := range 10 {
-		muxes[i] = newMuxSession(t, listener)
-		servers[i] = &muxedServer{
-			server:  grpc.NewServer(),
-			session: muxes[i],
-		}
-		serviceName := fmt.Sprintf("adminService on mux %d", i)
-		eas := &echoAdminService{
-			serviceName: serviceName,
-			logger:      log.With(logger, common.ServiceTag(serviceName), tag.Address(muxes[i].addr)),
-			namespaces:  map[string]bool{"hello": true, "world": true},
-			payloadSize: defaultPayloadSize,
-		}
-		adminservice.RegisterAdminServiceServer(servers[i].server, eas)
-		go func() {
-			err := servers[i].server.Serve(servers[i].session.serverMux)
-			if err != nil && !errors.Is(err, yamux.ErrSessionShutdown) {
-				require.Failf(t, "Error during Serve %s", err.Error())
-			}
-		}()
-		session := servers[i].session
-		clientConn, err := grpc.NewClient("passthrough:unused",
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-				return session.clientMux.Open()
-			}),
-			grpc.WithDisableServiceConfig(),
-		)
-		require.NoError(t, err)
-		clients[i] = &muxedClient{
-			session:    muxes[i],
-			clientConn: clientConn,
-			client:     adminservice.NewAdminServiceClient(clientConn),
-		}
-	}
-	return &testScenario{
-		muxes:    muxes,
-		servers:  servers,
-		clients:  clients,
-		listener: listener,
-	}
-}
-
-func (s *testScenario) close() {
-	_ = s.listener.Close()
-	for _, mux := range s.muxes {
-		_ = mux.serverMux.Close()
-		_ = mux.clientMux.Close()
-		_ = mux.serverConn.Close()
-		_ = mux.clientConn.Close()
-	}
-}
+var testLogger = log.NewTestLogger()
 
 // Using separate ClientConn objects created using grpc.NewClientConn "just works", but the clients are completely
 // separate and do not load-balance. We have to do the work of swapping out the client objects in the calling code.
 func TestMultiClientMultiServer(t *testing.T) {
-	scenario := newTestScenario(t)
-	for i, muxClient := range scenario.clients {
-		resp, err := muxClient.client.DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
+	scenario := testserver.NewTestScenario(t, 10, testLogger)
+	for i, muxClient := range scenario.Clients {
+		resp, err := muxClient.Client.DescribeCluster(context.Background(), &adminservice.DescribeClusterRequest{})
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("adminService on mux %d", i), resp.ClusterName, "Invalid or missing cluster name")
 	}
-	scenario.close()
+	scenario.Close()
 }
 
 // Using a single ClientConn object and naively swapping in a round-robin Dialer does not work, because
 // the connection is cached.
 func TestSingleClientCustomDialer(t *testing.T) {
-	scenario := newTestScenario(t)
+	scenario := testserver.NewTestScenario(t, 10, testLogger)
 	counter := &atomic.Uint32{}
 	counter.Store(0)
 	superClientConn, err := grpc.NewClient("passthrough:unused",
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			//t.Log("Dialed addr", addr)
-			return scenario.muxes[counter.Add(1)%10].clientMux.Open()
+			return scenario.Muxes[counter.Add(1)%10].ClientMux.Open()
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
@@ -166,7 +54,7 @@ func TestSingleClientCustomDialer(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "adminService on mux 1", resp.ClusterName)
 	}
-	scenario.close()
+	scenario.Close()
 }
 
 // We require a custom dialer at all times, because our dialer needs to return the right mux connection.
@@ -175,7 +63,7 @@ func TestSingleClientCustomDialer(t *testing.T) {
 // the Dialer was constructed in, which means we can use a map from address -> mux-conn. The manual resolver will be
 // notified with one endpoint per mux map key, and those map keys will arrive at the dialer.
 func TestSingleClientCustomResolverAndDialer(t *testing.T) {
-	scenario := newTestScenario(t)
+	scenario := testserver.NewTestScenario(t, 10, testLogger)
 	manualResolver := manual.NewBuilderWithScheme("multimux")
 	// There is a note in resolver.State that mentions how Addresses and Endpoints work:
 	//  //If a resolver sets Addresses but does not set Endpoints, one Endpoint
@@ -211,7 +99,7 @@ func TestSingleClientCustomResolverAndDialer(t *testing.T) {
 			//t.Log("Dialed addr", addr)
 			require.NoError(t, err)
 			connSeen[i].Store(true)
-			return scenario.muxes[i].clientMux.Open()
+			return scenario.Muxes[i].ClientMux.Open()
 		}),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 	require.NoError(t, err)
@@ -256,11 +144,11 @@ func TestSingleClientCustomResolverAndDialer(t *testing.T) {
 	for i := range 10 {
 		assert.Truef(t, connSeen[i].Load(), "Should have seen connection on %d", i)
 	}
-	scenario.close()
+	scenario.Close()
 }
 
 func TestSingleClientCustomResolverUpdate(t *testing.T) {
-	scenario := newTestScenario(t)
+	scenario := testserver.NewTestScenario(t, 10, testLogger)
 	connSeen := make([]atomic.Bool, 10)
 	manualResolver := manual.NewBuilderWithScheme("multimux")
 	manualResolver.InitialState(resolver.State{
@@ -276,7 +164,7 @@ func TestSingleClientCustomResolverUpdate(t *testing.T) {
 			//t.Log("Dialed addr", addr)
 			require.NoError(t, err)
 			connSeen[i].Store(true)
-			return scenario.muxes[i].clientMux.Open()
+			return scenario.Muxes[i].ClientMux.Open()
 		}),
 		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`))
 	require.NoError(t, err)

--- a/testserver/echo_adminservice.go
+++ b/testserver/echo_adminservice.go
@@ -1,4 +1,4 @@
-package proxy
+package testserver
 
 import (
 	"context"

--- a/testserver/echo_server_local.go
+++ b/testserver/echo_server_local.go
@@ -1,0 +1,135 @@
+package testserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/temporalio/s2s-proxy/common"
+)
+
+// This file sets up N echo servers listening on a local pipe. You have access to both the Server and the client
+// side of the pipe, and NewTestScenario will start echoadminservices for each MuxSession.
+
+type MuxedServer struct {
+	Server           *grpc.Server
+	Session          *MuxSession
+	EchoAdminService *echoAdminService
+}
+
+type MuxedClient struct {
+	Session    *MuxSession
+	ClientConn *grpc.ClientConn
+	Client     adminservice.AdminServiceClient
+}
+
+type MuxSession struct {
+	Addr       string
+	ServerConn net.Conn
+	ClientConn net.Conn
+	ServerMux  *yamux.Session
+	ClientMux  *yamux.Session
+}
+
+func NewMuxSession(t *testing.T, listener net.Listener) *MuxSession {
+	s := &MuxSession{}
+	s.Addr = listener.Addr().String()
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		var err error
+		s.ServerConn, err = listener.Accept()
+		require.NoError(t, err)
+		s.ServerMux, err = yamux.Server(s.ServerConn, nil)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+	go func() {
+		var err error
+		s.ClientConn, err = net.Dial("tcp", s.Addr)
+		require.NoError(t, err)
+		s.ClientMux, err = yamux.Client(s.ClientConn, nil)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+	return s
+}
+
+type TestScenario struct {
+	Muxes    []*MuxSession
+	Servers  []*MuxedServer
+	Clients  []*MuxedClient
+	Listener net.Listener
+}
+
+func NewTestScenario(t *testing.T, size int, temporalLogger log.Logger) *TestScenario {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	servers := make([]*MuxedServer, size)
+	clients := make([]*MuxedClient, size)
+	muxes := make([]*MuxSession, size)
+	for i := range size {
+		muxes[i] = NewMuxSession(t, listener)
+		servers[i] = &MuxedServer{
+			Server:  grpc.NewServer(),
+			Session: muxes[i],
+		}
+		serviceName := fmt.Sprintf("adminService on mux %d", i)
+		eas := &echoAdminService{
+			serviceName: serviceName,
+			logger:      log.With(temporalLogger, common.ServiceTag(serviceName), tag.Address(muxes[i].Addr)),
+			namespaces:  map[string]bool{"hello": true, "world": true},
+			payloadSize: defaultPayloadSize,
+		}
+		servers[i].EchoAdminService = eas
+		adminservice.RegisterAdminServiceServer(servers[i].Server, eas)
+		go func() {
+			err := servers[i].Server.Serve(servers[i].Session.ServerMux)
+			if err != nil && !errors.Is(err, yamux.ErrSessionShutdown) {
+				require.Failf(t, "Error during Serve %s", err.Error())
+			}
+		}()
+		session := servers[i].Session
+		clientConn, err := grpc.NewClient("passthrough:unused",
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+				return session.ClientMux.Open()
+			}),
+			grpc.WithDisableServiceConfig(),
+		)
+		require.NoError(t, err)
+		clients[i] = &MuxedClient{
+			Session:    muxes[i],
+			ClientConn: clientConn,
+			Client:     adminservice.NewAdminServiceClient(clientConn),
+		}
+	}
+	return &TestScenario{
+		Muxes:    muxes,
+		Servers:  servers,
+		Clients:  clients,
+		Listener: listener,
+	}
+}
+
+func (s *TestScenario) Close() {
+	_ = s.Listener.Close()
+	for _, mux := range s.Muxes {
+		_ = mux.ServerMux.Close()
+		_ = mux.ClientMux.Close()
+		_ = mux.ServerConn.Close()
+		_ = mux.ClientConn.Close()
+	}
+}

--- a/testserver/echo_workflowservice.go
+++ b/testserver/echo_workflowservice.go
@@ -1,4 +1,4 @@
-package proxy
+package testserver
 
 import (
 	"context"

--- a/transport/grpcutil/multi_client_conn.go
+++ b/transport/grpcutil/multi_client_conn.go
@@ -1,0 +1,107 @@
+package grpcutil
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+)
+
+const (
+	scheme = "multiclient"
+)
+
+// MultiClientConn is a wrapper over grpc.ClientConn that allows it to be configured over a set of existing
+// connections. Each existing connection is represented as a single "Endpoint", which will load balance as expected
+// when configuring the MultiClientConn with load balancing policies like {"loadBalancingPolicy":"round_robin"}
+// Do not use the grpc.DialOption grpc.WithResolvers or grpc.WithContextDialer with MultiClientConn! We cannot detect
+// when they are used, and they will break MultiClientConn.
+// Note: This is not ready for use in production yet, ClientConn.Connect() and ClientConn.UpdateState() cannot yet be called properly.
+type MultiClientConn struct {
+	connMapLock sync.RWMutex
+	connMap     map[string]func() (net.Conn, error)
+	resolver    manual.Resolver
+	clientConn  *grpc.ClientConn
+}
+
+type ConnProvider func() (map[string]func() (net.Conn, error), error)
+
+func NewMultiClientConn(name string, connProvider ConnProvider, opts ...grpc.DialOption) (*MultiClientConn, error) {
+	mcc := &MultiClientConn{}
+	var err error
+	dialOpts := make([]grpc.DialOption, len(opts)+2)
+	manualResolver := manual.NewBuilderWithScheme(scheme)
+	manualResolver.BuildCallback = func(resolver.Target, resolver.ClientConn, resolver.BuildOptions) {
+		mcc.connMapLock.Lock()
+		defer mcc.connMapLock.Unlock()
+		mcc.connMap, err = connProvider()
+		manualResolver.InitialState(mcc.stateFromConns())
+		if err != nil {
+			panic(err)
+		}
+	}
+	dialOpts[0] = grpc.WithResolvers(manualResolver)
+	dialOpts[1] = grpc.WithContextDialer(mcc.getMapDialer())
+	copy(dialOpts[2:], opts)
+	mcc.clientConn, err = grpc.NewClient(fmt.Sprintf("%s://%s", scheme, name),
+		dialOpts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to create underlying grpc client")
+	}
+	return mcc, nil
+}
+
+func (mcc *MultiClientConn) getMapDialer() func(ctx context.Context, addr string) (net.Conn, error) {
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		mcc.connMapLock.RLock()
+		connFn, exists := mcc.connMap[addr]
+		mcc.connMapLock.RUnlock()
+		if exists {
+			return connFn()
+		}
+		return nil, fmt.Errorf("connection key %s didn't match a connection", addr)
+	}
+}
+
+func (mcc *MultiClientConn) stateFromConns() resolver.State {
+	newState := resolver.State{
+		Addresses: make([]resolver.Address, len(mcc.connMap)),
+	}
+	idx := 0
+	for addr := range mcc.connMap {
+		newState.Addresses[idx] = resolver.Address{Addr: addr}
+		idx++
+	}
+	return newState
+}
+
+func (mcc *MultiClientConn) UpdateConnections(conns map[string]func() (net.Conn, error)) error {
+	mcc.connMapLock.Lock()
+	defer mcc.connMapLock.Unlock()
+	mcc.connMap = conns
+	mcc.resolver.UpdateState(mcc.stateFromConns())
+	return nil
+}
+
+// grpc.ClientConnInterface
+
+// Invoke forwards to grpc.ClientConn
+func (mcc *MultiClientConn) Invoke(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
+	if mcc.clientConn == nil {
+		return errors.New("invoke called with uninitialized MultiClientConn")
+	}
+	return mcc.clientConn.Invoke(ctx, method, args, reply, opts...)
+}
+
+// NewStream forwards to grpc.ClientConn
+func (mcc *MultiClientConn) NewStream(ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	if mcc.clientConn == nil {
+		return nil, errors.New("newStream called with uninitialized MultiClientConn")
+	}
+	return mcc.clientConn.NewStream(ctx, desc, method, opts...)
+}


### PR DESCRIPTION
## What was changed
* Gave the "echo server" its own package so it can be reused across multiple packages. 
* Moved "newTestScenario" into a dedicated local_echo_server.go so it's easy to reuse
* First draft of MultiClientConn. This works in unit test, but needs more testing before it can go to prod

## Why?
This PR is mostly about the refactors to make the echo servers more available for testing. The MultiClientconn test is an example of why they should be moved into their own package and out of a _test.go file.
