### PR TITLE
Optimize translation for ListWorkflowExecutions and GetWorkflowExecutionRawHistoryV2

### DIFF
--- a/interceptor/namespace_translator_test.go
+++ b/interceptor/namespace_translator_test.go
@@ -603,7 +603,7 @@ func makeHistoryEventsBlobWithNamespaceField(ns string) *common.DataBlob {
 	evts := []*history.HistoryEvent{
 		{
 			EventId:   1,
-			EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			EventType: enums.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED,
 			Version:   1,
 			TaskId:    100,
 			Attributes: &history.HistoryEvent_SignalExternalWorkflowExecutionInitiatedEventAttributes{
@@ -614,7 +614,7 @@ func makeHistoryEventsBlobWithNamespaceField(ns string) *common.DataBlob {
 		},
 		{
 			EventId:   2,
-			EventType: enums.EVENT_TYPE_WORKFLOW_TASK_COMPLETED,
+			EventType: enums.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED,
 			Version:   1,
 			TaskId:    101,
 			Attributes: &history.HistoryEvent_RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{

--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -172,7 +172,7 @@ func visitNamespace(logger log.Logger, obj any, match stringMatcher) (bool, erro
 					return visit.Stop, err
 				}
 			}
-			return visit.Continue, nil
+			return visit.Skip, nil
 		} else if dataBlobFieldNames[fieldType.Name] {
 			changed, err := visitDataBlobs(logger, vwp, match, visitNamespace)
 			matched = matched || changed

--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -416,7 +416,7 @@ func isSkippableForNamespaceTranslation(vAny any) (result bool) {
 					return false
 				}
 			}
-			// Any events with a namespace fields should not skip translation.
+			// Events with a namespace field should not skip translation.
 			_, skippable := namespaceTranslationSkippableHistoryEvents[evt.GetEventType()]
 			if !skippable {
 				return false
@@ -431,7 +431,7 @@ func isSkippableForNamespaceTranslation(vAny any) (result bool) {
 				return false
 			}
 		}
-		// Any events with a namespace fields should not skip translation.
+		// Events with a namespace field should not skip translation.
 		_, skippable := namespaceTranslationSkippableHistoryEvents[v.GetEventType()]
 		return skippable
 	}

--- a/interceptor/translation_interceptor.go
+++ b/interceptor/translation_interceptor.go
@@ -123,9 +123,18 @@ func logTranslateResult(tr Translator, logger log.Logger, changed bool, err erro
 		logger.Error("translation error", methodTag, tag.Error(err), tag.NewStringTag("type", msgType))
 		metrics.TranslationErrors.WithLabelValues(tr.Kind(), msgType).Inc()
 	} else if changed {
+		if !strings.Contains(msgType, "adminservice_StreamWorkflowReplicationMessages") &&
+			!strings.Contains(msgType, "adminservice_GetNamespaceReplication") {
+
+			logger.Info("translation applied", methodTag, tag.NewAnyTag("type", msgType), tag.NewDurationTag("duration", duration))
+		}
 		logger.Debug("translation applied", methodTag, tag.NewAnyTag("obj", obj))
 		metrics.TranslationCount.WithLabelValues(tr.Kind(), msgType).Inc()
 	} else {
+		if !strings.Contains(msgType, "adminservice_StreamWorkflowReplicationMessages") &&
+			!strings.Contains(msgType, "adminservice_GetNamespaceReplication") {
+			logger.Info("translation not applied", methodTag, tag.NewAnyTag("type", msgType), tag.NewDurationTag("duration", duration))
+		}
 		logger.Debug("translation not applied", methodTag, tag.NewAnyTag("obj", obj))
 	}
 }

--- a/interceptor/translation_interceptor.go
+++ b/interceptor/translation_interceptor.go
@@ -123,18 +123,9 @@ func logTranslateResult(tr Translator, logger log.Logger, changed bool, err erro
 		logger.Error("translation error", methodTag, tag.Error(err), tag.NewStringTag("type", msgType))
 		metrics.TranslationErrors.WithLabelValues(tr.Kind(), msgType).Inc()
 	} else if changed {
-		if !strings.Contains(msgType, "adminservice_StreamWorkflowReplicationMessages") &&
-			!strings.Contains(msgType, "adminservice_GetNamespaceReplication") {
-
-			logger.Info("translation applied", methodTag, tag.NewAnyTag("type", msgType), tag.NewDurationTag("duration", duration))
-		}
 		logger.Debug("translation applied", methodTag, tag.NewAnyTag("obj", obj))
 		metrics.TranslationCount.WithLabelValues(tr.Kind(), msgType).Inc()
 	} else {
-		if !strings.Contains(msgType, "adminservice_StreamWorkflowReplicationMessages") &&
-			!strings.Contains(msgType, "adminservice_GetNamespaceReplication") {
-			logger.Info("translation not applied", methodTag, tag.NewAnyTag("type", msgType), tag.NewDurationTag("duration", duration))
-		}
 		logger.Debug("translation not applied", methodTag, tag.NewAnyTag("obj", obj))
 	}
 }


### PR DESCRIPTION
## What was changed

Optimize namespace translation in a couple of cases where we've seen high latency.

1. workflowservice.ListWorkflowExecutionsResponse - we can skip namespace translation for this type
2. adminservice.GetWorkflowExecutionRawHistoryV2Response - we can skip translation for most history event types. With a 20MB test workflow, this improves latency through the proxy from about 3s to about 1.6s.
3. workflowservice.GetWorkflowExecutionHistoryResponse - similar to (2). I see an improvement of about 2.5s to 1s on a 20MB test workflow.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

4. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

5. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
