### PR TITLE
Consolidate adminstream status reporting

### DIFF
--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -12,13 +12,12 @@ var (
 
 	// /proxy/adminservice.go
 
-	AdminServiceStreamsActive        = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open", "direction")
-	AdminServiceStreamDuration       = DefaultHistogramVec("admin_service_stream_duration", "The length of time each stream was open", "direction")
-	AdminServiceWaitingForConnection = DefaultGaugeVec("admin_service_waiting_for_connection", "Indicates the number of requests waiting on a client", "direction")
-	AdminServiceStreamsOpenedCount   = DefaultCounterVec("admin_service_streams_opened_count", "Number of streams opened", "direction")
-	AdminServiceStreamsClosedCount   = DefaultCounterVec("admin_service_streams_closed_count", "Number of streams closed", "direction")
-	AdminServiceStreamReqCount       = DefaultCounterVec("admin_service_stream_request_count", "Number of messages received", "direction")
-	AdminServiceStreamRespCount      = DefaultCounterVec("admin_service_stream_response_count", "Number of messages received", "direction")
+	AdminServiceStreamsActive      = DefaultGaugeVec("admin_service_streams_active", "Number of admin service streams open", "direction")
+	AdminServiceStreamDuration     = DefaultHistogramVec("admin_service_stream_duration", "The length of time each stream was open", "direction")
+	AdminServiceStreamsOpenedCount = DefaultCounterVec("admin_service_streams_opened_count", "Number of streams opened", "direction")
+	AdminServiceStreamsClosedCount = DefaultCounterVec("admin_service_streams_closed_count", "Number of streams closed", "direction")
+	AdminServiceStreamReqCount     = DefaultCounterVec("admin_service_stream_request_count", "Number of messages received", "direction")
+	AdminServiceStreamRespCount    = DefaultCounterVec("admin_service_stream_response_count", "Number of messages received", "direction")
 	// AdminServiceStreamTerminatedCount labels are direction (inbound/outbound) and terminated_by (source/target)
 	AdminServiceStreamTerminatedCount = DefaultCounterVec("admin_service_stream_terminated_count", "Stream was terminated by remote server", "direction", "terminated_by")
 
@@ -100,7 +99,6 @@ func init() {
 	prometheus.MustRegister(collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll),
 		collectors.WithoutGoCollectorRuntimeMetrics(collectors.MetricsDebug.Matcher)))
 	prometheus.MustRegister(AdminServiceStreamsActive)
-	prometheus.MustRegister(AdminServiceWaitingForConnection)
 	prometheus.MustRegister(AdminServiceStreamDuration)
 	prometheus.MustRegister(AdminServiceStreamsOpenedCount)
 	prometheus.MustRegister(AdminServiceStreamsClosedCount)

--- a/proxy/replication_stream_observer.go
+++ b/proxy/replication_stream_observer.go
@@ -1,0 +1,82 @@
+package proxy
+
+import (
+	"context"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/server/common/log/tag"
+)
+
+// ReplicationStreamObserver maintains a count of the active streams. It can be Start-ed to create a thread that automatically
+// logs to the provided logger.
+type ReplicationStreamObserver struct {
+	streamActive   []atomic.Int32
+	streamGrowLock sync.Mutex
+	logger         loggable
+	interval       time.Duration
+}
+
+// allow unit tests to test the log output
+type loggable interface {
+	Warn(msg string, tags ...tag.Tag)
+	Info(msg string, tags ...tag.Tag)
+}
+
+func NewReplicationStreamObserver(logger loggable) *ReplicationStreamObserver {
+	return &ReplicationStreamObserver{
+		// 1024 covers most cases without growing. If a larger history count is logged, Notify* will grow the array
+		streamActive:   make([]atomic.Int32, 1024),
+		streamGrowLock: sync.Mutex{},
+		interval:       time.Minute,
+		logger:         logger,
+	}
+}
+func (s *ReplicationStreamObserver) ReportStreamValue(idx int32, value int32) {
+	if idx < 0 {
+		s.logger.Warn("ReplicationStreamObserver NotifyConnect called with negative streamIndex")
+		return
+	}
+	s.streamGrowLock.Lock()
+	// We want to grow the minimum number of times, so
+	if idx >= int32(len(s.streamActive)) {
+		// Each index will be uniformly random in the range [0, maxStreams). Growing by a percentage of index helps
+		// minimize the amount of reallocation required. Starting with increasing to 125% of idx to keep memory waste low
+		newSize := min(int((idx+1)*9), math.MaxInt32) / 8
+		// grow and maximize
+		s.streamActive = slices.Grow(s.streamActive, newSize)[:newSize]
+	}
+	s.streamActive[idx].Add(value)
+	s.streamGrowLock.Unlock()
+}
+func (s *ReplicationStreamObserver) PrintActiveStreams() string {
+	sb := strings.Builder{}
+	sb.WriteString("[")
+	s.streamGrowLock.Lock()
+	for i := range s.streamActive {
+		if s.streamActive[i].Load() != 0 {
+			sb.WriteString(strconv.Itoa(i))
+			sb.WriteString(",")
+		}
+	}
+	s.streamGrowLock.Unlock()
+	sb.WriteString("]")
+	return sb.String()
+}
+func (s *ReplicationStreamObserver) Start(lifetime context.Context, name string, direction string) {
+	go func() {
+		for lifetime.Err() == nil {
+			s.logger.Info("Logging active AdminService history streams", tag.NewStringTag("direction", direction), tag.NewStringTag("name", name),
+				tag.NewStringTag("activeStreams", s.PrintActiveStreams()))
+			select {
+			case <-time.After(s.interval):
+			case <-lifetime.Done():
+			}
+		}
+	}()
+}

--- a/proxy/replication_stream_observer_test.go
+++ b/proxy/replication_stream_observer_test.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+func TestAdminServiceObserver(t *testing.T) {
+	observer := NewReplicationStreamObserver(log.NewTestLogger())
+	observer.ReportStreamValue(1, 1)
+	require.Equal(t, "[1,]", observer.PrintActiveStreams())
+	observer.ReportStreamValue(1, -1)
+	require.Equal(t, "[]", observer.PrintActiveStreams())
+}
+
+func TestAdminServiceObserver_Grows(t *testing.T) {
+	observer := NewReplicationStreamObserver(log.NewTestLogger())
+	observer.ReportStreamValue(16_000, 1)
+	require.Equal(t, "[16000,]", observer.PrintActiveStreams())
+	observer.ReportStreamValue(16_000, -1)
+	require.Equal(t, "[]", observer.PrintActiveStreams())
+}
+
+func TestAdminServiceObserver_Invalid(t *testing.T) {
+	observer := NewReplicationStreamObserver(log.NewTestLogger())
+	observer.ReportStreamValue(-1, 1)
+	require.Equal(t, "[]", observer.PrintActiveStreams())
+}
+
+type mockLogger struct {
+	logs []logLine
+	sync.Mutex
+}
+type logLine struct {
+	msg  string
+	tags []tag.Tag
+}
+
+func (l *mockLogger) Info(msg string, tags ...tag.Tag) {
+	l.Lock()
+	l.logs = append(l.logs, logLine{msg, tags})
+	l.Unlock()
+}
+func (l *mockLogger) Warn(msg string, tags ...tag.Tag) {
+	l.Lock()
+	l.logs = append(l.logs, logLine{msg, tags})
+	l.Unlock()
+}
+
+func TestAdminServiceObserver_GoRoutine(t *testing.T) {
+	logOutput := &mockLogger{}
+	observer := &ReplicationStreamObserver{
+		streamActive:   make([]atomic.Int32, 0),
+		streamGrowLock: sync.Mutex{},
+		interval:       100 * time.Millisecond,
+		logger:         logOutput,
+	}
+	observer.ReportStreamValue(1, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	observer.Start(ctx, "unittest", "testbound")
+	time.Sleep(20 * time.Millisecond)
+	observer.ReportStreamValue(16_000, 1)
+	time.Sleep(100 * time.Millisecond)
+	observer.ReportStreamValue(16_000, -1)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	logOutput.Lock()
+	require.Len(t, logOutput.logs, 3)
+	assert.Equal(t, logLine{"Logging active AdminService history streams",
+		[]tag.Tag{tag.NewStringTag("direction", "testbound"), tag.NewStringTag("name", "unittest"),
+			tag.NewStringTag("activeStreams", "[1,]")}}, logOutput.logs[0])
+	assert.Equal(t, logLine{"Logging active AdminService history streams",
+		[]tag.Tag{tag.NewStringTag("direction", "testbound"), tag.NewStringTag("name", "unittest"),
+			tag.NewStringTag("activeStreams", "[1,16000,]")}}, logOutput.logs[1])
+	assert.Equal(t, logLine{"Logging active AdminService history streams",
+		[]tag.Tag{tag.NewStringTag("direction", "testbound"), tag.NewStringTag("name", "unittest"),
+			tag.NewStringTag("activeStreams", "[1,]")}}, logOutput.logs[2])
+	logOutput.Unlock()
+}

--- a/transport/mux/multi_mux_manager.go
+++ b/transport/mux/multi_mux_manager.go
@@ -49,6 +49,7 @@ type (
 		Address() string
 		IsUsable() bool
 		Describe() string
+		Name() string
 	}
 	MuxProviderBuilder func(AddNewMux, context.Context) (MuxProvider, error)
 )
@@ -180,4 +181,7 @@ func (m *multiMuxManager) Describe() string {
 	sb.WriteString(strconv.FormatBool(m.hasShutDown.IsShutdown()))
 	sb.WriteString("]")
 	return sb.String()
+}
+func (m *multiMuxManager) Name() string {
+	return m.name
 }


### PR DESCRIPTION
## What was changed
Replaced "AdminStreamReplicationMessages" spam with a periodic observer

## Why?
The async poller provides more useful logs more infrequently, which also helps with observation of other logs in the proxy