### PR TITLE
Derive proxy version from git release / sha

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -44,12 +44,35 @@ jobs:
 
       - name: Set image names
         id: image-names
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "$EVENT_NAME" == "release" ]]; then
             echo "images=temporaliotest/s2s-proxy,temporalio/s2s-proxy" >> "$GITHUB_OUTPUT"
           else
             echo "images=temporaliotest/s2s-proxy" >> "$GITHUB_OUTPUT"
           fi
+      - name: Compute version
+        id: version
+        # Produces the VERSION passed to `make bins` and used as the image tag.
+        # Three cases:
+        #   local: "dev"             local build (Makefile default, no VERSION arg).
+        #   dispatch: "dev-<sha>"    CI build on main push; set by docker.yaml. Or manual dispatch with a commit SHA.
+        #   release: "v1.2.3"        GitHub release; set to the release tag by docker.yaml.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_COMMIT: ${{ inputs.commit }}
+        run: |
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            echo "value=$REF_NAME" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            SHA=$(echo "$INPUT_COMMIT" | cut -c1-7)
+            echo "value=dev-${SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=dev-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -57,7 +80,7 @@ jobs:
           images: ${{ steps.image-names.outputs.images }}
           # Don't set latest label if it is a prerelease.
           tags: |
-            type=raw,value=${{ github.ref_name }}
+            type=raw,value=${{ steps.version.outputs.value }}
             ${{ github.event_name == 'release' && github.event.release.prerelease != true && 'type=raw,value=latest' || '' }}
 
       - name: Build and push Docker image
@@ -68,5 +91,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: VERSION=${{ steps.version.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build stage
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
+ARG VERSION=dev
 ARG TARGETARCH
 
 # System dependencies
@@ -25,7 +26,7 @@ COPY . .
 
 # Build
 # need to make clean first in case binaries to be built are stale
-RUN make clean && CGO_ENABLED=0 make bins
+RUN make clean && CGO_ENABLED=0 make bins VERSION=${VERSION}
 
 # Runtime stage
 FROM alpine:3.22 AS base

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 ##### Arguments ######
+VERSION       ?= dev
 GOOS          ?= $(shell go env GOOS)
 GOARCH        ?= $(if $(TARGETARCH),$(TARGETARCH),$(shell go env GOARCH))
 GOPATH        ?= $(shell go env GOPATH)
@@ -28,7 +29,7 @@ clean-bins:
 # Binary target
 s2s-proxy: $(ALL_SRC)
 	@printf $(COLOR) "Build s2s-proxy with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)...\n"
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) go build -o ./bins/s2s-proxy ./cmd/proxy
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=$(CGO_ENABLED) go build -ldflags "-X main.Version=$(VERSION)" -o ./bins/s2s-proxy ./cmd/proxy
 
 update-tools:
 # When changing the golangci-lint version, update the version in .github/workflows/pull-request.yml

--- a/app/app.go
+++ b/app/app.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	DefaultName    = "s2s-proxy"
-	DefaultVersion = "0.0.1" // TODO: configure build-time injection of version.
+	DefaultName = "s2s-proxy"
 )
 
 type proxyRunner interface {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -42,6 +42,8 @@ func runWithCancelledCtx(t *testing.T, a *App) error {
 	return a.Run(ctx, []string{"app", "start", "--" + config.ConfigPathFlag, "stubbed.yaml"})
 }
 
+const testVersion = "dev"
+
 func TestBuildApp_ReflectsNameAndVersion(t *testing.T) {
 	app := New("just-another-proxy-💁", "9.9.9").buildApp(context.Background())
 	assert.Equal(t, "just-another-proxy-💁", app.Name)
@@ -49,7 +51,7 @@ func TestBuildApp_ReflectsNameAndVersion(t *testing.T) {
 }
 
 func TestRun_MissingConfigFlag_ReturnsError(t *testing.T) {
-	err := New(DefaultName, DefaultVersion).Run(
+	err := New(DefaultName, testVersion).Run(
 		context.Background(),
 		[]string{"app", "start"}, // no --config flag
 	)
@@ -59,7 +61,7 @@ func TestRun_MissingConfigFlag_ReturnsError(t *testing.T) {
 
 func TestRun_BadConfigPath_ReturnsError(t *testing.T) {
 	// tries to read the file w/o stubbed config, so it fails.
-	err := New(DefaultName, DefaultVersion).Run(
+	err := New(DefaultName, testVersion).Run(
 		context.Background(),
 		[]string{"app", "start", "--" + config.ConfigPathFlag, "/not/stubbed.yaml"},
 	)
@@ -68,7 +70,7 @@ func TestRun_BadConfigPath_ReturnsError(t *testing.T) {
 
 func TestRun_CancelledContext_StartsAndStopsProxy(t *testing.T) {
 	stub := &stubbedProxy{}
-	err := runWithCancelledCtx(t, New(DefaultName, DefaultVersion, withStubbedConfig(), withStubbedProxy(stub)))
+	err := runWithCancelledCtx(t, New(DefaultName, testVersion, withStubbedConfig(), withStubbedProxy(stub)))
 	require.NoError(t, err)
 	assert.True(t, stub.startCalled)
 	assert.True(t, stub.stopped)
@@ -76,7 +78,7 @@ func TestRun_CancelledContext_StartsAndStopsProxy(t *testing.T) {
 
 func TestRun_ProxyStartError_PropagatesAndSkipsStop(t *testing.T) {
 	stub := &stubbedProxy{startErr: errors.New("start failed")}
-	err := New(DefaultName, DefaultVersion, withStubbedConfig(), withStubbedProxy(stub)).Run(
+	err := New(DefaultName, testVersion, withStubbedConfig(), withStubbedProxy(stub)).Run(
 		context.Background(),
 		[]string{"app", "start", "--" + config.ConfigPathFlag, "stubbed.yaml"},
 	)
@@ -86,7 +88,7 @@ func TestRun_ProxyStartError_PropagatesAndSkipsStop(t *testing.T) {
 
 func TestRun_ExtraOptsSeam_InjectedRunnerIsUsed(t *testing.T) {
 	stub := &stubbedProxy{}
-	err := runWithCancelledCtx(t, New(DefaultName, DefaultVersion, withStubbedConfig(), withStubbedProxy(stub)))
+	err := runWithCancelledCtx(t, New(DefaultName, testVersion, withStubbedConfig(), withStubbedProxy(stub)))
 	require.NoError(t, err)
 	assert.True(t, stub.startCalled)
 }
@@ -97,7 +99,7 @@ func TestRun_ContextCancelledMidRun_StopsProxy(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- New(DefaultName, DefaultVersion, withStubbedConfig(), withStubbedProxy(stub)).Run(
+		done <- New(DefaultName, testVersion, withStubbedConfig(), withStubbedProxy(stub)).Run(
 			ctx,
 			[]string{"app", "start", "--" + config.ConfigPathFlag, "stubbed.yaml"},
 		)
@@ -110,6 +112,6 @@ func TestRun_ContextCancelledMidRun_StopsProxy(t *testing.T) {
 
 func TestRun_LogLevelFlag_ParsedWithoutError(t *testing.T) {
 	stub := &stubbedProxy{}
-	err := runWithCancelledCtx(t, New(DefaultName, DefaultVersion, withStubbedConfig(), withStubbedProxy(stub)))
+	err := runWithCancelledCtx(t, New(DefaultName, testVersion, withStubbedConfig(), withStubbedProxy(stub)))
 	require.NoError(t, err)
 }

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -9,12 +9,18 @@ import (
 	"github.com/temporalio/s2s-proxy/app"
 )
 
+// Version is injected at link time via -ldflags "-X main.Version=x.y.z".
+// Three cases:
+//   - local: "dev"             local build (Makefile default, no VERSION arg).
+//   - dispatch: "dev-<sha>"    CI build on main push; set by docker.yaml. Or manual dispatch with a commit SHA.
+//   - release: "v1.2.3"        GitHub release; set to the release tag by docker.yaml.
+var Version = "dev"
+
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// TODO: configure build-time injection of version.
-	if err := app.New(app.DefaultName, app.DefaultVersion).Run(ctx, os.Args); err != nil {
+	if err := app.New(app.DefaultName, Version).Run(ctx, os.Args); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## What was changed

The version of CLI was set to `DefaultVersion=0.0.1`.

This sets the `version` to:
- local ->  "dev"                      Local build (Makefile default, no VERSION arg)
- dispatch -> "dev-<sha>"    CI build on main push; set by docker.yaml. Or manual dispatch with a commit SHA.
- release -> "v1.2.3"               GitHub release; set to the release tag by docker.yaml.

## Why?

So that CLI `--version` aligns with docker image tag.


## Testing

### Local
`make bins && ./bins/s2s-proxy --version`
- `dev`

### Dispatch (simulated local)
`make bins VERSION=dev-$(git rev-parse --short HEAD) && ./bins/s2s-proxy --version`
- `dev-6f1f455`

### Release (simulated local)
`make bins VERSION=v1.2.3 && ./bins/s2s-proxy --version`
- ` v1.2.3`
