### PR TITLE
Registers prometheus metrics: MuxServerDisconnected and NumMuxesActive

### DIFF
--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -131,6 +131,8 @@ func init() {
 	prometheus.MustRegister(MuxConnectionEstablish)
 	prometheus.MustRegister(MuxDialFailed)
 	prometheus.MustRegister(MuxDialSuccess)
+	prometheus.MustRegister(MuxServerDisconnected)
+	prometheus.MustRegister(NumMuxesActive)
 
 	prometheus.MustRegister(TranslationCount)
 	prometheus.MustRegister(TranslationErrors)


### PR DESCRIPTION

## What was changed

Registers 2 unregistered prometheus metrics. 

## Why?

The metrics `MuxServerDisconnected` and `NumMuxesActive` are not being published. 

The metrics are missing prometheus `MustRegister` calls. This was missed in #161.
