### PR TITLE
update test timeout & dynamic port to reduce flakiness

### DIFF
--- a/endtoendtest/echo_server.go
+++ b/endtoendtest/echo_server.go
@@ -230,13 +230,13 @@ func (s *EchoServer) DescribeCluster(req *adminservice.DescribeClusterRequest) (
 	if s.RemoteClient == nil {
 		panic("nil RemoteClient")
 	}
-	timeout, cancel := context.WithTimeout(context.Background(), time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return adminservice.NewAdminServiceClient(s.RemoteClient).DescribeCluster(timeout, req)
 }
 
 func (s *EchoServer) DescribeMutableState(req *adminservice.DescribeMutableStateRequest) (*adminservice.DescribeMutableStateResponse, error) {
-	timeout, cancel := context.WithTimeout(context.Background(), time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return adminservice.NewAdminServiceClient(s.RemoteClient).DescribeMutableState(timeout, req)
 }

--- a/proxy/test/wiring_test.go
+++ b/proxy/test/wiring_test.go
@@ -119,12 +119,15 @@ func TestEOFFromServer(t *testing.T) {
 	adminHandler := &hangupAdminServer{}
 	grpcHost := grpc.NewServer()
 	adminservice.RegisterAdminServiceServer(grpcHost, adminHandler)
-	listener, _ := net.Listen("tcp", "localhost:8566")
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
 	go func() {
 		_ = grpcHost.Serve(listener)
 	}()
 	time.Sleep(10 * time.Millisecond)
-	client, err := grpc.NewClient("localhost:8566", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	client, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.NoError(t, err)
 	adminServiceClient := adminservice.NewAdminServiceClient(client)
 	clientCtx, cancelCtx := context.WithCancel(t.Context())


### PR DESCRIPTION

## What was changed

- Tests timeouts updated
- Port updated to be dynamic

## Why?

- Test flakiness.
