### PR TITLE
Fix lifetime.Err format verb in simpleGRPCServer.Describe

### DIFF
--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -465,7 +465,7 @@ func (s *simpleGRPCServer) CanMakeCalls() bool {
 	return true
 }
 func (s *simpleGRPCServer) Describe() string {
-	return fmt.Sprintf("[simpleGRPCServer %s listening on %s. lifetime.Err: %e]", s.name, s.listener.Addr(), s.lifetime.Err())
+	return fmt.Sprintf("[simpleGRPCServer %s listening on %s. lifetime.Err: %v]", s.name, s.listener.Addr(), s.lifetime.Err())
 }
 func (s *simpleGRPCServer) Name() string {
 	return s.name


### PR DESCRIPTION
Use %v instead of %e for the error value. %e is Go's
floating-point scientific-notation verb, which produced the
placeholder "%!e(<nil>)" in log output whenever the lifetime
context had not been cancelled. %v is the default verb for any
value and is nil-safe for errors: it prints the result of
err.Error() when non-nil and "<nil>" otherwise.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
