### PR TITLE
Add local-test cert generation script and simplify test configs

### DIFF
--- a/develop/README.md
+++ b/develop/README.md
@@ -56,17 +56,18 @@ temporal operator namespace describe default --address localhost:17233
 ### Steps
 1. Start two local Temporal clusters, one on port 7233 and one on port 8233
    1. Make sure `enableGlobalNamespace: true` is in your config, and name them `left` and `right`
-2. Start a proxy with `./bins/s2s-proxy start --config ./develop/config/local-test-config-server.yaml`
-3. Start a proxy with `./bins/s2s-proxy start --config ./develop/config/local-test-config-client.yaml`
-4. Add the proxy for Temporal-left
+2. Generate the TLS certs referenced by the proxy configs: `./scripts/generate-local-test-certs.sh`
+3. Start a proxy with `./bins/s2s-proxy start --config ./develop/config/local-test-config-server.yaml`
+4. Start a proxy with `./bins/s2s-proxy start --config ./develop/config/local-test-config-client.yaml`
+5. Add the proxy for Temporal-left
    1. `temporal --address localhost:7233 operator cluster upsert --frontend-address localhost:38233 --enable-connection`
-5. Add the proxy for Temporal-right
+6. Add the proxy for Temporal-right
    1. `temporal --address localhost:8233 operator cluster upsert --frontend-address localhost:37233 --enable-connection`
-6. Create a namespace on Temporal-left and add Temporal-right as passive
+7. Create a namespace on Temporal-left and add Temporal-right as passive
    1. `temporal operator namespace create --active-cluster left --global -n left-ns`
    2. `temporal operator search-attribute create -n left-ns --name CustomStringField --type Text`
    3. `temporal operator namespace update -n left-ns --cluster left --cluster right`
-7. Done! Create some workflows and run whatever tests you need. 
+8. Done! Create some workflows and run whatever tests you need. 
 
 ## Generate Lazy Client (hacky solution)
 

--- a/develop/config/local-test-config-client.yaml
+++ b/develop/config/local-test-config-client.yaml
@@ -9,30 +9,18 @@ clusterConnections:
       connectionType: "tcp" # TCP type must define both inbound and outbound
       tcpClient:
         address: "127.0.0.1:7233"
-        tls:
-          # certificatePath: "./proxycerts/client-internal.pem"
-          # keyPath: "./proxycerts/client-internal.key"
-          # remoteCAPath: ""
-          # caServerName: ""
-          # skipCAVerification: true
       tcpServer:
         # Connects to "remote" temporal via proxy
         address: "127.0.0.1:38233"
-        tls:
-          certificatePath: "./proxycerts/client-internal.pem"
-          keyPath: "./proxycerts/client-internal.key"
-          remoteCAPath: "./proxycerts/client-internal.pem"
-          caServerName: "localhost"
-          skipCAVerification: false
     remote:
       connectionType: "mux-client" # One mux represents both inbound and outbound
       muxCount: 10
       muxAddressInfo:
         address: "127.0.0.1:11000"
         tls:
-          certificatePath: "./proxycerts/clientowned.pem"
-          keyPath: "./proxycerts/clientowned.key"
-          remoteCAPath: "./proxycerts/client-account-cert.pem"
+          certificatePath: "./proxycerts/client.pem"
+          keyPath: "./proxycerts/client.key"
+          remoteCAPath: "./proxycerts/server.pem"
           caServerName: ""
           skipCAVerification: true
     failoverVersionIncrementTranslation:

--- a/develop/config/local-test-config-server.yaml
+++ b/develop/config/local-test-config-server.yaml
@@ -9,30 +9,18 @@ clusterConnections:
       connectionType: "tcp" # TCP type must define both inbound and outbound
       tcpClient:
         address: "127.0.0.1:8233"
-        tls:
-          # certificatePath: "./proxycerts/temporal-internal.pem"
-          # keyPath: "./proxycerts/temporal-internal.key"
-          # remoteCAPath: "./proxycerts/temporal-internal.pem"
-          # caServerName: "testhost"
-          # skipCAVerification: true
       tcpServer:
         # Connects to "remote" temporal via proxy
         address: "127.0.0.1:37233"
-        tls:
-          certificatePath: "./proxycerts/temporal-internal.pem"
-          keyPath: "./proxycerts/temporal-internal.key"
-          remoteCAPath: "./proxycerts/temporal-internal.pem"
-          caServerName: "localhost"
-          skipCAVerification: false
     remote:
       connectionType: "mux-server" # One mux represents both inbound and outbound
       muxCount: 10
       muxAddressInfo:
         address: "127.0.0.1:11000"
         tls:
-          certificatePath: "./proxycerts/client-account-cert.pem"
-          keyPath: "./proxycerts/client-account-cert.key"
-          remoteCAPath: "./proxycerts/clientowned.pem"
+          certificatePath: "./proxycerts/server.pem"
+          keyPath: "./proxycerts/server.key"
+          remoteCAPath: "./proxycerts/server.pem"
           caServerName: ""
           skipCAVerification: true
     failoverVersionIncrementTranslation:

--- a/scripts/generate-local-test-certs.sh
+++ b/scripts/generate-local-test-certs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Generates the cert/key pairs referenced by:
+#   develop/config/local-test-config-server.yaml
+#   develop/config/local-test-config-client.yaml
+#
+# Both configs load TLS material from ./proxycerts/ relative to the proxy's
+# working directory. Each side uses the peer's .pem as its remoteCAPath, so the
+# certs are self-signed (CA:TRUE), matching the pattern in generate-certs.sh.
+
+mkdir -p ./proxycerts
+
+echo "Generating Cluster Certificate for onebox-proxy-server.cluster.tmprl.cloud"
+openssl req -x509 -newkey rsa:4096 -keyout proxycerts/server.key -out proxycerts/server.pem -days 365 -nodes -addext "subjectAltName = DNS:onebox-proxy-server.cluster.tmprl.cloud" -subj "/C=US/ST=WA/O=Temporal/CN=onebox-proxy-server.cluster.tmprl.cloud"
+
+echo "Generating Cluster Certificate for onebox-proxy-client.cluster.tmprl.cloud"
+openssl req -x509 -newkey rsa:4096 -keyout proxycerts/client.key -out proxycerts/client.pem -days 365 -nodes -addext "subjectAltName = DNS:onebox-proxy-client.cluster.tmprl.cloud" -subj "/C=US/ST=WA/O=Temporal/CN=onebox-proxy-client.cluster.tmprl.cloud"


### PR DESCRIPTION
Adds scripts/generate-local-test-certs.sh to generate the server/client
cert pairs referenced by the local-test proxy configs, and trims the
configs to point at those filenames. README updated with the new step.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
