### PR TITLE
Allow client TLS to verify server with system root CAs

### DIFF
--- a/encryption/tls.go
+++ b/encryption/tls.go
@@ -37,7 +37,7 @@ type (
 )
 
 func (t TLSConfig) IsEnabled() bool {
-	return (t.CertificatePath != "" && t.KeyPath != "") || (t.RemoteCAPath != "" && t.CAServerName != "")
+	return (t.CertificatePath != "" && t.KeyPath != "") || t.CAServerName != ""
 }
 
 var netClient HttpGetter = &http.Client{
@@ -119,8 +119,8 @@ func GetClientTLSConfig(clientConfig TLSConfig) (tlsConfig *tls.Config, err erro
 	tlsConfig = auth.NewEmptyTLSConfig()
 	tlsConfig.InsecureSkipVerify = clientConfig.SkipCAVerification
 	if !clientConfig.SkipCAVerification {
-		if clientConfig.CAServerName == "" || clientConfig.RemoteCAPath == "" {
-			return nil, errors.New("CAServerName and RemoteCAPath must be set when SkipCAVerification is false")
+		if clientConfig.CAServerName == "" {
+			return nil, errors.New("CAServerName must be set when SkipCAVerification is false")
 		}
 		tlsConfig.ServerName = clientConfig.CAServerName
 	}
@@ -132,6 +132,8 @@ func GetClientTLSConfig(clientConfig TLSConfig) (tlsConfig *tls.Config, err erro
 		}
 		tlsConfig.RootCAs = caCertPool
 	}
+	// If RemoteCAPath is empty, RootCAs stays nil and Go's TLS stack falls
+	// back to the host's system root CAs (x509.SystemCertPool).
 
 	if clientConfig.CertificatePath != "" {
 		myCert, err := tls.LoadX509KeyPair(clientConfig.CertificatePath, clientConfig.KeyPath)

--- a/encryption/tls_test.go
+++ b/encryption/tls_test.go
@@ -55,15 +55,29 @@ func (s *tlsTestSuite) Test_ClientTLSConfig() {
 			isEnabled: true,
 		},
 		{
+			name: "server-auth-enabled-system-roots",
+			tlsConfig: TLSConfig{
+				CAServerName: "server",
+			},
+			isEnabled: true,
+		},
+		{
 			name:      "auth-disabled",
 			tlsConfig: TLSConfig{},
 			isEnabled: false,
 		},
 		{
-			name: "partialauth-disabled",
+			name: "partialauth-server-auth-only",
 			tlsConfig: TLSConfig{
 				CertificatePath: "path",
 				CAServerName:    "server",
+			},
+			isEnabled: true,
+		},
+		{
+			name: "partialauth-cert-only-disabled",
+			tlsConfig: TLSConfig{
+				CertificatePath: "path",
 			},
 			isEnabled: false,
 		},


### PR DESCRIPTION
GetClientTLSConfig previously required RemoteCAPath whenever
SkipCAVerification was false, forcing every client to ship a CA bundle
even when the server cert chains to a public CA (e.g. Let's Encrypt).
Now only CAServerName is required; if RemoteCAPath is empty, RootCAs
stays nil and Go's TLS stack falls back to x509.SystemCertPool. Also
update IsEnabled to recognize CAServerName-only configs as enabled.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Test agains  eu-central-1-internal.a2dd6.tmprl.cloud:8233 

client tls config with skipCAVerification = false (enable server verfication)

TLS connection pass when caServerName is set to 
```
<any>.a2dd6.tmprl.cloud
*.a2dd6.tmprl.cloud
a2dd6.tmprl.cloud
```

TLS connection failed when caServerName is set to 
```
other.tmprl.cloud
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
