### PR TITLE
chart: allow SyncWorkflowState in adminService ACL

### DIFF
--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -17,6 +17,7 @@ data:
           - StreamWorkflowReplicationMessages
           - ReapplyEvents
           - GetNamespace
+          - SyncWorkflowState
         allowedNamespaces:
         - temporal-system
         - myNamespace

--- a/charts/s2s-proxy/files/default.yaml
+++ b/charts/s2s-proxy/files/default.yaml
@@ -49,6 +49,7 @@ clusterConnections:
           - StreamWorkflowReplicationMessages
           - ReapplyEvents
           - GetNamespace
+          - SyncWorkflowState
       allowedNamespaces:
         # Optional. If configured, the temporal-system namespace must be included to allow migration workflows to run.
         - "temporal-system"


### PR DESCRIPTION
## What
Add `SyncWorkflowState` to the default `adminService` ACL allowlist in the s2s-proxy chart (`charts/s2s-proxy/files/default.yaml` and `example.yaml`).

## Why
`SyncWorkflowState` is the transition-history *repair* RPC relayed by the 1.32 proxy build. It was absent from the default `adminService` allowlist, so the cloud→self-hosted (c2s) replication repair path returns `PermissionDenied`. Adding it lets state-based replication repair complete. Companion to the 1.32 proxy build; keeps this chart's default in sync with the saas-components deploy.

Harmless for older proxy images — they bounce the method as `Unimplemented`; the ACL merely permits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)