### PR TITLE
Bump Docker builder image to golang:1.26-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 ARG VERSION=dev
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,11 @@ docker-login:
 docker-build-push:
 	@docker buildx build --platform=linux/amd64,linux/arm64 -t "${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_TAG}" --push .
 
+.PHONY: docker-local-build
+docker-local-build:
+	@docker build --build-arg VERSION=${DOCKER_TAG} -t "${DOCKER_IMAGE}:${DOCKER_TAG}" .
+	@echo "Built local image ${DOCKER_IMAGE}:${DOCKER_TAG}"
+
 
 .PHONY: helm-install
 helm-install:


### PR DESCRIPTION
Match the builder base image to go.mod (go 1.26.4); the 1.25 image can no
longer build the module after the toolchain bump.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
 make docker-local-build                
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
