### PR TITLE
chart: document remote TLS caServerName/remoteCAPath in default config

### DIFF
--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -37,6 +37,7 @@ data:
         muxAddressInfo:
           address: s2s-proxy-sample.example.tmprl.cloud:8233
           tls:
+            caServerName: ""
             certificatePath: /s2c-server-tls/tls.crt
             keyPath: /s2c-server-tls/tls.key
             remoteCAPath: ""

--- a/charts/s2s-proxy/files/default.yaml
+++ b/charts/s2s-proxy/files/default.yaml
@@ -31,7 +31,8 @@ clusterConnections:
         tls:
           certificatePath: ""
           keyPath: ""
-          remoteCAPath: ""
+          remoteCAPath: "" # path to the CA cert that signed the remote server's cert; empty = use system root CAs
+          caServerName: "" # required unless skipCAVerification: true; must match the remote cert's SAN/CN
     # This should be the routable address
     replicationEndpoint: "my-s2s-proxy.svc.cluster.local:9233"
     # This is what the remote cluster is allowed to access on your local cluster


### PR DESCRIPTION
Add caServerName to the remote muxAddressInfo TLS block in the chart's default
config and clarify both TLS field comments:
- remoteCAPath: path to the CA cert that signs the remote server's cert; empty
  falls back to system root CAs.
- caServerName: required unless skipCAVerification is true; must match the
  remote cert's SAN/CN.

Regenerate example.yaml accordingly (inline comments are stripped by helm's
toYaml rendering, so only the caServerName field appears there).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
