### PR TITLE
Add ProxyAdminService with member-aware responses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,86 @@ Start proxies
 ./bins/s2s-proxy start --config develop/config/cluster-b-mux-server-proxy.yaml
 ```
 
+## Query a running proxy
+
+`ProxyAdminService` reports the proxy's version and its cluster connections to other proxies. It is served on the proxy-to-proxy mux. A plain gRPC client cannot speak a mux. Reaching the service therefore needs a local listener.
+
+Add a listen address to the proxy's config:
+
+```yaml
+proxyAdmin:
+  listenAddress: "localhost:6061"
+```
+
+Absent or empty means no server runs. The listener has no TLS and no authorization, so bind it to loopback.
+
+Server reflection is registered. `grpcurl` therefore needs no descriptor:
+
+```bash
+A=temporal.s2sproxy.proxyadmin.v1.ProxyAdminService/DescribeClusterConnections
+grpcurl -plaintext localhost:6061 list
+grpcurl -plaintext localhost:6061 $A
+```
+
+### Scope and target
+
+The request message is empty. Two pieces of gRPC metadata control how far a call travels, so that every
+admin RPC inherits the same rules and each listener can enforce them in one interceptor rather than in
+every handler.
+
+`s2s-proxy-scope` is `member` or `group`. Absent means `group`.
+
+```bash
+# This process only.
+grpcurl -plaintext -H 's2s-proxy-scope: member' localhost:6061 $A
+
+# Every pod of this proxy deployment, aggregated. This is the default.
+grpcurl -plaintext localhost:6061 $A
+```
+
+`s2s-proxy-target` names a cluster connection. The call is forwarded once to that connection's peer proxy,
+which answers for its own deployment:
+
+```bash
+grpcurl -plaintext -H 's2s-proxy-target: cluster-b' localhost:6061 $A
+```
+
+`topology`, a scope that would also cover the far side of every cluster connection, is reserved but not
+implemented; asking for it returns `Unimplemented` rather than a narrower answer.
+
+### Peer discovery
+
+Group scope needs a way to reach the other pods. Configure a peer listener and a discovery provider:
+
+```yaml
+proxyAdmin:
+  listenAddress: "127.0.0.1:6061"
+  peer:
+    listenAddress: "0.0.0.0:9234"
+    tls:
+      certificatePath: /certs/peer.pem
+      keyPath: /certs/peer.key
+      # Every pod's certificate must carry this as a SAN.
+      # Peers are dialed by IP.
+      # A per-pod SAN scheme fails every handshake.
+      caServerName: s2s-proxy-peers
+      remoteCAPath: /certs/ca.pem
+    discovery:
+      provider: dns          # dns | static | none
+      dns:
+        name: s2s-proxy.default.svc.cluster.local
+```
+
+Each provider reads only its own block, so a block belonging to an unselected provider is ignored. That
+matters because layered configuration deep-merges and cannot delete keys: switching `provider` from `dns` to
+`static` through a Helm override leaves the `dns` block behind, and it has to stay inert.
+
+Without `peer`, a proxy only ever describes itself: every response carries a single member, and that
+member is always this one.
+
+A non-loopback peer listener with no TLS is refused at startup unless `allowInsecure: true` is set, because
+it publishes the deployment's topology to anything that can reach the pod network.
+
 ## Code Generation
 
 ### gRPC client generation
@@ -106,6 +186,14 @@ Start proxies
 Run `make generate-rpcwrappers` to re-generate the clients
 
 This uses the `cmd/tools/genrpcwrappers` tool to generates frontend and admin clients.
+
+### Proxy proto generation
+
+Run `make generate-proxy-proto` to re-generate the Go stubs for the proxy's own protos.
+
+The protos live under `proto/temporal/`. The generated Go is written to `api/`.
+
+This needs [buf](https://buf.build/docs/installation) on `PATH`. The plugins are remote. No local `protoc` or plugin binaries are required. CI fails if the checked-in stubs do not match the protos.
 
 ### Invalid UTF-8 Repair Functions
 

--- a/adminplane/discovery.go
+++ b/adminplane/discovery.go
@@ -1,0 +1,152 @@
+package adminplane
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
+
+	"github.com/temporalio/s2s-proxy/config"
+)
+
+// maxDiscoveredMembers bounds a single discovery result.
+// A name pointing at the wrong service then fans out to a bounded number of addresses rather than the whole cluster.
+const maxDiscoveredMembers = 256
+
+// Discovery enumerates the peer admin addresses of the other pods in this proxy deployment.
+//
+// It reports addresses, not identities.
+// A DNS A record carries no name.
+// A member is only identified once it answers.
+// Callers recognize themselves by comparing the id in a response, never by address.
+type Discovery interface {
+	// Provider names the mechanism, for inclusion in responses.
+	// Without it a roster of one is ambiguous between a single-replica deployment and a deployment with discovery switched off.
+	Provider() string
+	Discover(ctx context.Context) ([]string, error)
+}
+
+// NewDiscovery builds the provider named in cfg.
+// defaultPort is the port the peer listener binds, for providers that resolve names without ports.
+//
+// The configuration is assumed to have been validated already.
+// config.DiscoveryConfig.Validate owns the rules for what a usable provider block looks like.
+// Duplicating them here produced two ceilings that had already drifted apart.
+// The unknown-provider case remains because this is also reachable from a caller that built the config in Go.
+//
+// Adding a provider means a case here and a constructor below.
+func NewDiscovery(cfg config.DiscoveryConfig, defaultPort int) (Discovery, error) {
+	switch cfg.Provider {
+	case "", config.DiscoveryNone:
+		return NoDiscovery(), nil
+	case config.DiscoveryDNS:
+		port := cfg.DNS.Port
+		if port == 0 {
+			port = defaultPort
+		}
+		return NewDNSDiscovery(cfg.DNS.Name, port), nil
+	case config.DiscoveryStatic:
+		return NewStaticDiscovery(cfg.Static.Addresses), nil
+	default:
+		return nil, fmt.Errorf("unknown discovery provider %q, want one of %v",
+			cfg.Provider, config.DiscoveryProviders)
+	}
+}
+
+type noDiscovery struct{}
+
+// NoDiscovery reports no peers.
+// A proxy configured with it only ever describes itself.
+func NoDiscovery() Discovery { return noDiscovery{} }
+
+func (noDiscovery) Provider() string                           { return config.DiscoveryNone }
+func (noDiscovery) Discover(context.Context) ([]string, error) { return nil, nil }
+
+type staticDiscovery struct{ addresses []string }
+
+// NewStaticDiscovery reports a fixed address list.
+//
+// A list too long to fan out to is rejected when it is used rather than here.
+// Construction therefore stays infallible.
+// The error reaches the caller as an unreachable roster entry.
+func NewStaticDiscovery(addresses []string) Discovery {
+	return staticDiscovery{addresses: addresses}
+}
+
+func (staticDiscovery) Provider() string { return config.DiscoveryStatic }
+
+func (s staticDiscovery) Discover(context.Context) ([]string, error) {
+	return normalizeAddresses(s.addresses)
+}
+
+// LookupHostFunc resolves a host to addresses.
+type LookupHostFunc func(ctx context.Context, host string) ([]string, error)
+
+// DNSOption customises a DNS discovery provider.
+type DNSOption func(*dnsDiscovery)
+
+// WithLookupHost replaces the resolver.
+func WithLookupHost(f LookupHostFunc) DNSOption {
+	return func(d *dnsDiscovery) { d.lookupHost = f }
+}
+
+type dnsDiscovery struct {
+	name       string
+	port       int
+	lookupHost LookupHostFunc
+}
+
+// NewDNSDiscovery resolves name to one address per sibling pod, as a Kubernetes headless Service does.
+// Each address is paired with port.
+//
+// Such a Service publishes ready endpoints only.
+// A pod that is failing its readiness probe is absent from the result rather than reported as unreachable.
+// Responses say which provider produced the roster.
+// A reader can account for that.
+func NewDNSDiscovery(name string, port int, opts ...DNSOption) Discovery {
+	d := &dnsDiscovery{
+		name:       name,
+		port:       port,
+		lookupHost: net.DefaultResolver.LookupHost,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+func (d *dnsDiscovery) Provider() string { return config.DiscoveryDNS }
+
+func (d *dnsDiscovery) Discover(ctx context.Context) ([]string, error) {
+	hosts, err := d.lookupHost(ctx, d.name)
+	if err != nil {
+		return nil, fmt.Errorf("resolving %q: %w", d.name, err)
+	}
+	addresses := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		// JoinHostPort brackets IPv6 literals.
+		// A bare concatenation would not.
+		addresses = append(addresses, net.JoinHostPort(h, strconv.Itoa(d.port)))
+	}
+	return normalizeAddresses(addresses)
+}
+
+// normalizeAddresses sorts and de-duplicates an address list so a roster is stable across calls.
+//
+// Exceeding the cap is an error rather than a truncation.
+// Truncating would be by sorted address and would drop the same members on every call.
+// A stable blind spot would be reported as a complete survey.
+// A proxy deployment does not have this many pods.
+// The realistic cause is a name that also matches something else.
+// That is worth saying out loud.
+func normalizeAddresses(in []string) ([]string, error) {
+	out := slices.Clone(in)
+	slices.Sort(out)
+	out = slices.Compact(out)
+	if len(out) > maxDiscoveredMembers {
+		return nil, fmt.Errorf("discovered %d peers, more than the %d this proxy will fan out to: "+
+			"check that the name resolves only to this deployment", len(out), maxDiscoveredMembers)
+	}
+	return out, nil
+}

--- a/adminplane/discovery_test.go
+++ b/adminplane/discovery_test.go
@@ -1,0 +1,115 @@
+package adminplane
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/s2s-proxy/config"
+)
+
+func TestNewDiscoverySelectsProvider(t *testing.T) {
+	t.Run("empty provider means none", func(t *testing.T) {
+		d, err := NewDiscovery(config.DiscoveryConfig{}, 9234)
+		require.NoError(t, err)
+		require.Equal(t, config.DiscoveryNone, d.Provider())
+
+		addresses, err := d.Discover(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, addresses)
+	})
+
+	// Layered configuration deep-merges and cannot delete keys.
+	// Switching provider leaves the previous provider's block behind.
+	// The selected provider must ignore it entirely.
+	t.Run("an unselected provider's block is ignored", func(t *testing.T) {
+		d, err := NewDiscovery(config.DiscoveryConfig{
+			Provider: config.DiscoveryStatic,
+			DNS:      config.DNSDiscoveryConfig{Name: "leftover.svc.cluster.local"},
+			Static:   config.StaticDiscoveryConfig{Addresses: []string{"b:9234", "a:9234"}},
+		}, 9234)
+		require.NoError(t, err)
+		require.Equal(t, config.DiscoveryStatic, d.Provider())
+
+		addresses, err := d.Discover(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []string{"a:9234", "b:9234"}, addresses)
+	})
+
+	t.Run("unknown provider is rejected", func(t *testing.T) {
+		_, err := NewDiscovery(config.DiscoveryConfig{Provider: "carrier-pigeon"}, 9234)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unknown discovery provider")
+	})
+
+	// The rules for a usable provider block live in config.DiscoveryConfig.Validate.
+	// That runs first.
+	// This package only reports what config cannot know.
+
+	t.Run("dns port falls back to the peer listen port", func(t *testing.T) {
+		d, err := NewDiscovery(config.DiscoveryConfig{
+			Provider: config.DiscoveryDNS,
+			DNS:      config.DNSDiscoveryConfig{Name: "peers"},
+		}, 9234)
+		require.NoError(t, err)
+
+		dns, ok := d.(*dnsDiscovery)
+		require.True(t, ok)
+		require.Equal(t, 9234, dns.port)
+	})
+}
+
+func TestDNSDiscovery(t *testing.T) {
+	lookup := func(hosts []string, err error) LookupHostFunc {
+		return func(context.Context, string) ([]string, error) { return hosts, err }
+	}
+
+	t.Run("no endpoints is not an error", func(t *testing.T) {
+		d := NewDNSDiscovery("peers", 9234, WithLookupHost(lookup(nil, nil)))
+		addresses, err := d.Discover(context.Background())
+		require.NoError(t, err)
+		require.Empty(t, addresses)
+	})
+
+	t.Run("resolution failure is reported", func(t *testing.T) {
+		d := NewDNSDiscovery("peers", 9234, WithLookupHost(lookup(nil, errors.New("nxdomain"))))
+		_, err := d.Discover(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "peers")
+	})
+
+	t.Run("results are sorted and de-duplicated", func(t *testing.T) {
+		d := NewDNSDiscovery("peers", 9234,
+			WithLookupHost(lookup([]string{"10.0.0.2", "10.0.0.1", "10.0.0.2"}, nil)))
+		addresses, err := d.Discover(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []string{"10.0.0.1:9234", "10.0.0.2:9234"}, addresses)
+	})
+
+	// A bare concatenation would produce "::1:9234".
+	// That does not parse.
+	t.Run("IPv6 literals are bracketed", func(t *testing.T) {
+		d := NewDNSDiscovery("peers", 9234, WithLookupHost(lookup([]string{"::1"}, nil)))
+		addresses, err := d.Discover(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, []string{"[::1]:9234"}, addresses)
+	})
+
+	// A name pointing at the wrong service should not fan out across the whole cluster.
+	// It is reported rather than truncated.
+	// Truncating by sorted address drops the same members every time.
+	// A stable blind spot reads as a complete survey.
+	t.Run("too many peers is an error, not a truncation", func(t *testing.T) {
+		var hosts []string
+		for i := 0; i < maxDiscoveredMembers*2; i++ {
+			hosts = append(hosts, "10.1."+strconv.Itoa(i/256)+"."+strconv.Itoa(i%256))
+		}
+		d := NewDNSDiscovery("peers", 9234, WithLookupHost(lookup(hosts, nil)))
+		_, err := d.Discover(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "more than the")
+	})
+}

--- a/adminplane/listener.go
+++ b/adminplane/listener.go
@@ -1,0 +1,86 @@
+package adminplane
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
+)
+
+// maxAdminRecvBytes caps a response from another proxy.
+// Fan-out multiplies whatever one member sends.
+// The replication dial options raise this limit far higher than an admin response should ever need.
+const maxAdminRecvBytes = 4 << 20
+
+// DialOnce opens a connection for a single admin call.
+// The returned function closes it.
+//
+// It is deliberately not pooled and deliberately not tied to a process lifetime.
+// Pod addresses change on every rollout.
+// A pool would need eviction.
+// A lifetime-scoped cleanup hook would accumulate one registration per member per call for as long as the process runs.
+func DialOnce(address string, tlsConfig *tls.Config) (grpc.ClientConnInterface, func(), error) {
+	creds := insecure.NewCredentials()
+	if tlsConfig != nil {
+		creds = credentials.NewTLS(tlsConfig)
+	}
+	cc, err := grpc.NewClient(address,
+		grpc.WithTransportCredentials(creds),
+		// Deliberately fail fast, the default.
+		// A connecting channel already waits.
+		// A healthy but cold peer still succeeds.
+		// What fails immediately is a channel that reached TRANSIENT_FAILURE.
+		// Its cause is the answer the caller wanted.
+		// WaitForReady would block through that until the budget expired and report every dead peer as a timeout.
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxAdminRecvBytes)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{PermitWithoutStream: false}),
+	)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return cc, func() { _ = cc.Close() }, nil
+}
+
+// Server is a gRPC server on its own listener, stopped when its lifetime ends.
+//
+// Serve is called once.
+// Unlike the replication servers there is no retry loop.
+// A listener that stops accepting will not start again by being asked more often.
+// Retrying every second would turn one failure into an unbounded stream of log lines.
+type Server struct {
+	name     string
+	lifetime context.Context
+	listener net.Listener
+	server   *grpc.Server
+	logger   log.Logger
+}
+
+// NewServer prepares a server.
+func NewServer(name string, lifetime context.Context, listener net.Listener, server *grpc.Server, logger log.Logger) *Server {
+	return &Server{name: name, lifetime: lifetime, listener: listener, server: server, logger: logger}
+}
+
+func (s *Server) Start() {
+	context.AfterFunc(s.lifetime, func() {
+		s.server.GracefulStop()
+		_ = s.listener.Close()
+	})
+	go func() {
+		s.logger.Info("Starting admin gRPC server",
+			tag.Name(s.name), tag.Address(s.listener.Addr().String()))
+		err := s.server.Serve(s.listener)
+		if s.lifetime.Err() != nil || err == nil || errors.Is(err, grpc.ErrServerStopped) {
+			s.logger.Info("Admin gRPC server stopped", tag.Name(s.name))
+			return
+		}
+		s.logger.Error("Admin gRPC server failed",
+			tag.Name(s.name), tag.Address(s.listener.Addr().String()), tag.Error(err))
+	}()
+}

--- a/adminplane/role.go
+++ b/adminplane/role.go
@@ -1,0 +1,354 @@
+package adminplane
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+)
+
+// Metadata keys carrying the routing decisions for an admin call.
+//
+// They are metadata rather than request fields because an interceptor cannot read a request field without reflection.
+// With request fields, every listener's limits have to be re-checked inside every handler.
+// An RPC added later is then exposed until someone remembers to check it.
+// With metadata, one interceptor covers every RPC.
+const (
+	// MDScope is "member" or "group". Absent means group.
+	MDScope = "s2s-proxy-scope"
+	// MDTarget names a cluster connection whose peer proxy should answer instead.
+	MDTarget = "s2s-proxy-target"
+)
+
+// Scope is how far a call travels. Values are ordered by increasing breadth.
+type Scope int
+
+const (
+	// ScopeMember answers for the receiving process only.
+	ScopeMember Scope = iota
+	// ScopeGroup aggregates across the pods of the receiving proxy deployment.
+	ScopeGroup
+)
+
+const (
+	scopeMemberValue = "member"
+	scopeGroupValue  = "group"
+	// scopeTopologyValue is reserved for a scope that also covers the far side of every cluster connection.
+	// Recognizing it makes asking for it fail loudly instead of returning a narrower result that looks the same.
+	scopeTopologyValue = "topology"
+)
+
+// Role is a listener's position in the topology.
+// It determines how far calls arriving there may travel and how much of the answer they see.
+type Role int
+
+const (
+	// RoleUnset is the zero value and is rejected.
+	// A registration that forgets to state its role fails at startup rather than defaulting to the most permissive option.
+	RoleUnset Role = iota
+	// RoleOperator is a trusted local listener.
+	// Any scope, forwarding allowed, nothing withheld.
+	RoleOperator
+	// RolePeer is reached by the other pods of this same deployment.
+	// They only ever need this process's own answer.
+	// Member scope is forced and forwarding is refused.
+	// A group call therefore makes a single round of fan-out.
+	RolePeer
+	// RoleCounterparty is reached over a mux by a proxy belonging to a different organization.
+	// Answers are narrowed to the cluster connection the call arrived on.
+	// Only explicitly listed methods are served.
+	RoleCounterparty
+)
+
+func (r Role) String() string {
+	switch r {
+	case RoleOperator:
+		return "operator"
+	case RolePeer:
+		return "peer"
+	case RoleCounterparty:
+		return "counterparty"
+	}
+	return "unset"
+}
+
+// ServerOptions is the policy for one listener.
+type ServerOptions struct {
+	Role Role
+	// ConnectionName is the cluster connection a RoleCounterparty listener belongs to.
+	// Answers are narrowed to it.
+	ConnectionName string
+	// Methods narrows what this listener serves, below the compile-time ceiling in adminMethods.
+	// Full method names, resolved by ResolveCounterpartyMethods.
+	//
+	// Nil means no narrowing.
+	// A present-but-empty slice means serve nothing.
+	// An operator switches the admin plane off for one counterparty by writing the empty slice.
+	//
+	// auth.AccessControl cannot express that: its IsAllowed returns true for an empty list.
+	Methods []string
+}
+
+// serves reports whether the operator's configuration permits this method here.
+// Configuration can only narrow.
+// The compile-time ceiling is checked separately.
+func (o ServerOptions) serves(fullMethod string) bool {
+	if o.Methods == nil {
+		return true
+	}
+	return slices.Contains(o.Methods, fullMethod)
+}
+
+// Validate rejects a policy that cannot be enforced.
+func (o ServerOptions) Validate() error {
+	switch o.Role {
+	case RoleUnset:
+		return fmt.Errorf("adminplane: ServerOptions.Role must be set")
+	case RoleCounterparty:
+		if o.ConnectionName == "" {
+			// Without a name there is nothing to narrow to.
+			// The listener would answer for every cluster connection on this proxy.
+			// That includes connections belonging to other organizations.
+			return fmt.Errorf("adminplane: RoleCounterparty requires ConnectionName")
+		}
+	}
+	return nil
+}
+
+type optionsKey struct{}
+
+// OptionsFrom returns the policy of the listener that accepted this call.
+func OptionsFrom(ctx context.Context) ServerOptions {
+	o, _ := ctx.Value(optionsKey{}).(ServerOptions)
+	return o
+}
+
+type scopeKey struct{}
+
+// ScopeFrom returns the resolved scope for this call.
+// The interceptor sets it from the listener's limits.
+func ScopeFrom(ctx context.Context) Scope {
+	s, _ := ctx.Value(scopeKey{}).(Scope)
+	return s
+}
+
+// TargetFrom returns the cluster connection this call should be forwarded to, or "".
+func TargetFrom(ctx context.Context) string {
+	return firstMD(ctx, MDTarget)
+}
+
+func firstMD(ctx context.Context, key string) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	vals := md.Get(key)
+	if len(vals) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(vals[0])
+}
+
+// OutgoingMemberContext marks an outgoing call as member-scoped, for fanning out to siblings.
+func OutgoingMemberContext(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, MDScope, scopeMemberValue)
+}
+
+// OutgoingGroupContext marks an outgoing call as group-scoped.
+// The far proxy aggregates its own deployment.
+func OutgoingGroupContext(ctx context.Context) context.Context {
+	return metadata.AppendToOutgoingContext(ctx, MDScope, scopeGroupValue)
+}
+
+// adminServicePrefix is the gRPC method prefix this package governs.
+// Deriving it from the generated descriptor rather than injecting it means it cannot be empty.
+//
+// Methods outside it pass through untouched.
+// One yamux session serves one grpc.Server.
+// On a mux this interceptor is therefore installed server-wide and also sees every replication call.
+// A mistake in the admin policy must not be able to stop the data path.
+var adminServicePrefix = "/" + proxyadminv1.ProxyAdminService_ServiceDesc.ServiceName + "/"
+
+// methodPolicy is what a single admin RPC is allowed to do.
+// Both fields default to false.
+// An RPC that nobody has thought about is neither served to another organization nor sent to one.
+type methodPolicy struct {
+	// Counterparty allows another organization to call this method on us over a mux.
+	Counterparty bool
+	// Forwardable allows this proxy to send this method to another organization, via s2s-proxy-target.
+	Forwardable bool
+}
+
+// adminMethods is the capability ceiling.
+// It is keyed by the generated method constants.
+// A rename is therefore a compile error.
+//
+// The two columns are separate trust decisions.
+// What another organization may ask this proxy is not the same question as what this proxy may ask them.
+// Adding an RPC forces an explicit answer to both.
+//
+// There is no entry for the operator or peer listeners.
+// Both sit inside this deployment's trust boundary and serve whatever the process registered.
+// A hand-maintained list for them would misfire the first time someone added an RPC and forgot it.
+// The symptom would be Unimplemented on the operator listener.
+// That is the listener an operator debugs from.
+// The peer listener also has to serve whatever the operator fans out, or group scope breaks.
+var adminMethods = map[string]methodPolicy{
+	proxyadminv1.ProxyAdminService_DescribeClusterConnections_FullMethodName: {
+		Counterparty: true,
+		Forwardable:  true,
+	},
+}
+
+// authorize resolves the scope for a call and rejects anything the listener does not permit.
+func authorize(ctx context.Context, o ServerOptions, fullMethod string) (context.Context, error) {
+	// Namespace check first, before anything that can fail. See adminServicePrefix.
+	if !strings.HasPrefix(fullMethod, adminServicePrefix) {
+		return ctx, nil
+	}
+
+	if err := o.Validate(); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	policy := adminMethods[fullMethod]
+
+	if o.Role == RoleCounterparty {
+		// The ceiling first, then whatever narrowing the operator configured on top of it.
+		if !policy.Counterparty || !o.serves(fullMethod) {
+			return nil, status.Errorf(codes.Unimplemented,
+				"method %s is not served to a peer cluster", fullMethod)
+		}
+	}
+
+	if target := TargetFrom(ctx); target != "" {
+		if o.Role != RoleOperator {
+			return nil, status.Errorf(codes.PermissionDenied,
+				"%s may not be set on a %s listener", MDTarget, o.Role)
+		}
+		// Fail closed on egress.
+		// Whether this proxy may put a question to another organization is a separate decision from whether that organization would answer it.
+		// It is also the only half of the exchange this proxy controls.
+		if !policy.Forwardable {
+			return nil, status.Errorf(codes.PermissionDenied,
+				"method %s is not forwarded to a peer cluster", fullMethod)
+		}
+	}
+
+	scope, err := resolveScope(ctx, o)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx = context.WithValue(ctx, optionsKey{}, o)
+	ctx = context.WithValue(ctx, scopeKey{}, scope)
+	return ctx, nil
+}
+
+func resolveScope(ctx context.Context, o ServerOptions) (Scope, error) {
+	requested := firstMD(ctx, MDScope)
+	switch requested {
+	case "":
+		// Absent means group, clamped by the listener.
+		// A header-less call to a peer listener gets a member answer rather than an error.
+		// Plain grpcurl therefore still works there.
+		if o.Role == RolePeer {
+			return ScopeMember, nil
+		}
+		return ScopeGroup, nil
+	case scopeMemberValue:
+		return ScopeMember, nil
+	case scopeGroupValue:
+		if o.Role == RolePeer {
+			// Refuse rather than silently narrowing.
+			// A member answer and a group answer have the same shape.
+			// A caller could not tell it had been downgraded.
+			return 0, status.Errorf(codes.PermissionDenied,
+				"scope %q is not served on a %s listener", requested, o.Role)
+		}
+		return ScopeGroup, nil
+	case scopeTopologyValue:
+		return 0, status.Errorf(codes.Unimplemented, "scope %q is not implemented", requested)
+	default:
+		return 0, status.Errorf(codes.InvalidArgument,
+			"unknown %s %q, want %q or %q", MDScope, requested, scopeMemberValue, scopeGroupValue)
+	}
+}
+
+// UnaryInterceptor enforces o on unary calls.
+func UnaryInterceptor(o ServerOptions) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ctx, err := authorize(ctx, o, info.FullMethod)
+		if err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// StreamInterceptor enforces o on streaming calls.
+// Without it, the first streaming admin RPC would bypass every check above.
+func StreamInterceptor(o ServerOptions) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx, err := authorize(ss.Context(), o, info.FullMethod)
+		if err != nil {
+			return err
+		}
+		return handler(srv, &wrappedStream{ServerStream: ss, ctx: ctx})
+	}
+}
+
+type wrappedStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (w *wrappedStream) Context() context.Context { return w.ctx }
+
+// ResolveCounterpartyMethods maps the short method names an operator writes in configuration onto the full names the interceptor matches.
+// A name a counterparty could never be served is rejected.
+//
+// Configuration can only narrow the compile-time ceiling.
+// A name outside it is a mistake rather than a wider grant.
+// It fails at startup instead of silently denying at request time.
+// Short names are what the sibling aclPolicy.allowedMethods.adminService list already uses.
+//
+// A nil input returns nil: no narrowing.
+// An empty non-nil input returns an empty non-nil slice: serve nothing.
+func ResolveCounterpartyMethods(shortNames []string) ([]string, error) {
+	if shortNames == nil {
+		return nil, nil
+	}
+	resolved := make([]string, 0, len(shortNames))
+	for _, short := range shortNames {
+		full, err := counterpartyMethodByShortName(short)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, full)
+	}
+	return resolved, nil
+}
+
+func counterpartyMethodByShortName(short string) (string, error) {
+	var known []string
+	for full, policy := range adminMethods {
+		if !policy.Counterparty {
+			continue
+		}
+		name := full[strings.LastIndex(full, "/")+1:]
+		if name == short {
+			return full, nil
+		}
+		known = append(known, name)
+	}
+	slices.Sort(known)
+	return "", fmt.Errorf("method %q cannot be served to a peer cluster, want one of %v", short, known)
+}

--- a/adminplane/role_test.go
+++ b/adminplane/role_test.go
@@ -1,0 +1,277 @@
+package adminplane
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+)
+
+const (
+	describeRPC = proxyadminv1.ProxyAdminService_DescribeClusterConnections_FullMethodName
+	// futureRPC stands for the next RPC someone generates.
+	// It is spelled as a literal because it does not exist yet.
+	// The ceiling must refuse it until somebody lists it.
+	futureRPC       = "/temporal.s2sproxy.proxyadmin.v1.ProxyAdminService/MutateSomething"
+	replicationRPC  = "/temporal.server.api.adminservice.v1.AdminService/StreamWorkflowReplicationMessages"
+	otherServiceRPC = "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution"
+)
+
+// invoke runs the unary interceptor and reports what the handler saw.
+func invoke(t *testing.T, o ServerOptions, method string, md ...string) (context.Context, error) {
+	t.Helper()
+	ctx := context.Background()
+	if len(md) > 0 {
+		ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(md...))
+	}
+	var seen context.Context
+	_, err := UnaryInterceptor(o)(ctx, nil, &grpc.UnaryServerInfo{FullMethod: method},
+		func(ctx context.Context, _ any) (any, error) {
+			seen = ctx
+			return nil, nil
+		})
+	return seen, err
+}
+
+func TestRoleUnsetIsRejected(t *testing.T) {
+	// A registration that forgets to state its role must fail rather than default to the most permissive option.
+	_, err := invoke(t, ServerOptions{}, describeRPC)
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestCounterpartyRequiresAConnectionName(t *testing.T) {
+	// Without a name there is nothing to narrow the answer to.
+	_, err := invoke(t, ServerOptions{Role: RoleCounterparty}, describeRPC)
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestScopeResolution(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		opts      ServerOptions
+		scopeMD   string
+		wantScope Scope
+		wantCode  codes.Code
+	}{
+		{name: "operator defaults to group", opts: ServerOptions{Role: RoleOperator}, wantScope: ScopeGroup},
+		{name: "operator may ask for member", opts: ServerOptions{Role: RoleOperator}, scopeMD: "member", wantScope: ScopeMember},
+		{name: "operator may ask for group", opts: ServerOptions{Role: RoleOperator}, scopeMD: "group", wantScope: ScopeGroup},
+		// A header-less call to the peer listener still works.
+		// It gets a member answer.
+		{name: "peer defaults to member", opts: ServerOptions{Role: RolePeer}, wantScope: ScopeMember},
+		// Refused rather than narrowed.
+		// A member answer and a group answer have the same shape.
+		// A caller could not tell it had been downgraded.
+		{name: "peer refuses group", opts: ServerOptions{Role: RolePeer}, scopeMD: "group", wantCode: codes.PermissionDenied},
+		{name: "counterparty defaults to group", opts: ServerOptions{Role: RoleCounterparty, ConnectionName: "c"}, wantScope: ScopeGroup},
+		// Named so a newer caller fails loudly instead of silently receiving less than it asked for.
+		{name: "topology is not implemented", opts: ServerOptions{Role: RoleOperator}, scopeMD: "topology", wantCode: codes.Unimplemented},
+		{name: "unknown scope is rejected", opts: ServerOptions{Role: RoleOperator}, scopeMD: "galaxy", wantCode: codes.InvalidArgument},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var md []string
+			if tc.scopeMD != "" {
+				md = []string{MDScope, tc.scopeMD}
+			}
+			ctx, err := invoke(t, tc.opts, describeRPC, md...)
+			if tc.wantCode != codes.OK {
+				require.Error(t, err)
+				require.Equal(t, tc.wantCode, status.Code(err))
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantScope, ScopeFrom(ctx))
+			require.Equal(t, tc.opts, OptionsFrom(ctx))
+		})
+	}
+}
+
+func TestForwardingIsOperatorOnly(t *testing.T) {
+	for _, role := range []ServerOptions{
+		{Role: RolePeer},
+		{Role: RoleCounterparty, ConnectionName: "c"},
+	} {
+		t.Run(role.Role.String(), func(t *testing.T) {
+			// Otherwise a peer could pivot through this proxy into a third cluster.
+			_, err := invoke(t, role, describeRPC, MDTarget, "somewhere")
+			require.Error(t, err)
+			require.Equal(t, codes.PermissionDenied, status.Code(err))
+		})
+	}
+
+	ctx, err := invoke(t, ServerOptions{Role: RoleOperator}, describeRPC, MDTarget, "somewhere")
+	require.NoError(t, err)
+	require.Equal(t, "somewhere", TargetFrom(ctx))
+}
+
+// The allowlist stops an RPC added later from being served across an organizational boundary without anyone deciding that it should be.
+func TestCounterpartyMethodAllowlist(t *testing.T) {
+	counterparty := ServerOptions{Role: RoleCounterparty, ConnectionName: "c"}
+
+	_, err := invoke(t, counterparty, describeRPC)
+	require.NoError(t, err)
+
+	_, err = invoke(t, counterparty, futureRPC)
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	// The operator and peer listeners serve the whole admin service.
+	_, err = invoke(t, ServerOptions{Role: RoleOperator}, futureRPC)
+	require.NoError(t, err)
+}
+
+// The mux server carries replication traffic through the same interceptor chain.
+// One yamux session serves one gRPC server.
+// grpc-go has no per-service interceptor.
+// Gating anything outside the admin service would stop replication.
+func TestNonAdminMethodsPassThroughUntouched(t *testing.T) {
+	counterparty := ServerOptions{Role: RoleCounterparty, ConnectionName: "c"}
+
+	for _, method := range []string{replicationRPC, otherServiceRPC} {
+		t.Run(method, func(t *testing.T) {
+			ctx, err := invoke(t, counterparty, method)
+			require.NoError(t, err)
+			require.Equal(t, ServerOptions{}, OptionsFrom(ctx),
+				"a method outside the admin service must not be stamped with listener policy")
+		})
+	}
+
+	// An unset role is otherwise rejected.
+	// Even so, it must not block replication.
+	_, err := invoke(t, ServerOptions{}, replicationRPC)
+	require.NoError(t, err)
+}
+
+type fakeStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (f *fakeStream) Context() context.Context { return f.ctx }
+
+// Unary-only enforcement would fail open for the first streaming admin RPC anyone adds.
+func TestStreamInterceptorEnforcesTheSamePolicy(t *testing.T) {
+	counterparty := ServerOptions{Role: RoleCounterparty, ConnectionName: "c"}
+
+	err := StreamInterceptor(counterparty)(nil, &fakeStream{ctx: context.Background()},
+		&grpc.StreamServerInfo{FullMethod: futureRPC},
+		func(any, grpc.ServerStream) error { return nil })
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+
+	var seen context.Context
+	err = StreamInterceptor(counterparty)(nil, &fakeStream{ctx: context.Background()},
+		&grpc.StreamServerInfo{FullMethod: describeRPC},
+		func(_ any, ss grpc.ServerStream) error {
+			seen = ss.Context()
+			return nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, ScopeGroup, ScopeFrom(seen))
+}
+
+// The obvious formulation, min(want, time.Until(deadline)-slack), goes hugely negative for a context with no deadline.
+// That is the context grpcurl produces.
+func TestClampWithoutADeadlineKeepsTheFullBudget(t *testing.T) {
+	require.Equal(t, 2*time.Second, Clamp(context.Background(), 2*time.Second))
+}
+
+func TestClampShortensToFitADeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	got := Clamp(ctx, 2*time.Second)
+	require.Less(t, got, 500*time.Millisecond)
+	require.Positive(t, got)
+}
+
+// Egress is a separate decision from ingress.
+// The far side may well implement a method.
+// This is the local choice not to send it.
+func TestForwardingIsRefusedForAMethodOutsideTheCeiling(t *testing.T) {
+	_, err := invoke(t, ServerOptions{Role: RoleOperator}, futureRPC, MDTarget, "cluster-b")
+	require.Error(t, err)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+	require.Contains(t, status.Convert(err).Message(), "not forwarded")
+
+	// Without a target the same method is served locally.
+	// The refusal is about crossing the boundary rather than about the method existing.
+	_, err = invoke(t, ServerOptions{Role: RoleOperator}, futureRPC)
+	require.NoError(t, err)
+}
+
+// Configuration narrows the ceiling.
+// It can never widen it.
+func TestOperatorNarrowingOfTheCounterparty(t *testing.T) {
+	counterparty := func(methods []string) ServerOptions {
+		return ServerOptions{Role: RoleCounterparty, ConnectionName: "cluster-b", Methods: methods}
+	}
+	cases := []struct {
+		name    string
+		methods []string
+		method  string
+		wantErr codes.Code
+	}{
+		{name: "absent means the ceiling applies", methods: nil, method: describeRPC},
+		{name: "absent still refuses a method outside the ceiling", methods: nil, method: futureRPC, wantErr: codes.Unimplemented},
+		{name: "listing the method serves it", methods: []string{describeRPC}, method: describeRPC},
+		// This is how an operator declines to answer one counterparty at all.
+		// Methods is a slice rather than a set type so that absent and empty stay distinct.
+		// auth.AccessControl cannot express the distinction: its empty list means allow everything.
+		{name: "an empty list serves nothing", methods: []string{}, method: describeRPC, wantErr: codes.Unimplemented},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := invoke(t, counterparty(c.methods), c.method)
+			if c.wantErr == codes.OK {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, c.wantErr, status.Code(err))
+		})
+	}
+
+	// Narrowing applies only where it is configured.
+	// The operator listener is inside the trust boundary and is unaffected.
+	_, err := invoke(t, ServerOptions{Role: RoleOperator}, describeRPC)
+	require.NoError(t, err)
+}
+
+func TestResolveCounterpartyMethods(t *testing.T) {
+	// Absent and empty mean opposite things once they reach ServerOptions.
+	// They must stay distinguishable all the way through.
+	resolved, err := ResolveCounterpartyMethods(nil)
+	require.NoError(t, err)
+	require.Nil(t, resolved)
+
+	resolved, err = ResolveCounterpartyMethods([]string{})
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.Empty(t, resolved)
+
+	resolved, err = ResolveCounterpartyMethods([]string{"DescribeClusterConnections"})
+	require.NoError(t, err)
+	require.Equal(t, []string{describeRPC}, resolved)
+
+	// A typo is a startup error rather than a method that silently stops being served.
+	_, err = ResolveCounterpartyMethods([]string{"DescribeClusterConnection"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "DescribeClusterConnections")
+}
+
+// Clamp returning non-positive makes forward and fanOut report a deadline rather than dialing with no time left.
+// Without a case here neither path is ever exercised.
+func TestClampGoesNonPositiveOnceTheDeadlineHasPassed(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), -time.Second)
+	defer cancel()
+	require.Negative(t, Clamp(ctx, 2*time.Second))
+}

--- a/adminplane/serve.go
+++ b/adminplane/serve.go
@@ -1,0 +1,358 @@
+package adminplane
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Default budgets. Every one is clamped to the caller's deadline when there is one.
+const (
+	DefaultDiscoverBudget = 1 * time.Second
+	DefaultMemberBudget   = 2 * time.Second
+	DefaultForwardBudget  = 5 * time.Second
+
+	// deadlineSlack leaves room to build a response after the last member call returns.
+	deadlineSlack = 250 * time.Millisecond
+
+	// maxConcurrentMembers bounds simultaneous dials during fan-out.
+	maxConcurrentMembers = 16
+)
+
+// Budgets are the per-stage time limits for a call.
+type Budgets struct {
+	Discover time.Duration
+	Member   time.Duration
+	Forward  time.Duration
+}
+
+func (b Budgets) withDefaults() Budgets {
+	if b.Discover <= 0 {
+		b.Discover = DefaultDiscoverBudget
+	}
+	if b.Member <= 0 {
+		b.Member = DefaultMemberBudget
+	}
+	if b.Forward <= 0 {
+		b.Forward = DefaultForwardBudget
+	}
+	return b
+}
+
+// Clamp shortens want to fit the context's deadline.
+// It never extends it.
+//
+// The obvious formulation, min(want, time.Until(deadline)-slack), is wrong for a context with no deadline.
+// Deadline reports the zero time there.
+// time.Until of the zero time is hugely negative.
+// Every call would be given a budget in the past.
+func Clamp(ctx context.Context, want time.Duration) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return want
+	}
+	if remaining := time.Until(deadline) - deadlineSlack; remaining < want {
+		return remaining
+	}
+	return want
+}
+
+// PeerRouter resolves a cluster connection name to a connection to that connection's peer proxy.
+type PeerRouter interface {
+	// PeerConn returns a client for the named cluster connection, or a gRPC status error.
+	// InvalidArgument means no such connection is configured.
+	// FailedPrecondition means it exists but cannot currently carry a call.
+	PeerConn(name string) (grpc.ClientConnInterface, error)
+}
+
+// DialFunc opens a connection to a peer admin listener.
+// The returned function releases it.
+type DialFunc func(ctx context.Context, address string) (grpc.ClientConnInterface, func(), error)
+
+// Plane holds everything an admin endpoint needs to answer beyond its own process.
+type Plane struct {
+	Discovery Discovery
+	Dial      DialFunc
+	Peers     PeerRouter
+	// MemberID identifies this process in its own answers.
+	// It is also how this process recognizes its own reply when fan-out reaches it.
+	MemberID string
+	Budgets  Budgets
+}
+
+// Unreachable is a discovered member that did not answer.
+type Unreachable struct {
+	Address string
+	Message string
+	// Code is a google.rpc.Code value.
+	Code int32
+}
+
+// Result is one member's answer, or the failure to get one.
+type Result[T any] struct {
+	// ID is the member's self-reported identity.
+	// It is empty when the member did not answer.
+	ID string
+	// Address is what was dialed.
+	// It is empty for the local answer.
+	Address string
+	Value   T
+	Err     error
+}
+
+// Roster records who was asked and who replied.
+type Roster struct {
+	Provider    string
+	Discovered  int
+	Responding  int
+	Unreachable []Unreachable
+}
+
+// Handlers adapt one RPC to the plane.
+// Self, Call and Merge are required.
+type Handlers[Req, Resp any] struct {
+	// Self answers for this process alone.
+	Self func(ctx context.Context, req Req) Resp
+	// Call invokes this same RPC on another proxy.
+	Call func(ctx context.Context, cc grpc.ClientConnInterface, req Req) (Resp, error)
+	// Merge folds the local answer and the members' answers into one.
+	//
+	// It takes the members as a slice rather than a pre-folded value.
+	// An endpoint whose aggregate is not a sum can then still be expressed.
+	// Shard ownership is disjoint across pods.
+	// A configuration check wants to know whether the members agree, not what they add up to.
+	//
+	// It cannot fail.
+	// Partial data is the answer to report, not an error.
+	// A transport error would carry no roster and no partial results.
+	// That is the opposite of what someone debugging a broken deployment needs.
+	Merge func(self Result[Resp], members []Result[Resp], roster Roster) Resp
+	// View narrows a response for the listener that will send it.
+	// Serve always applies it last.
+	// A handler cannot forget to.
+	// Required for RoleCounterparty.
+	View func(resp Resp, opts ServerOptions) Resp
+	// ID reports which member produced a response.
+	// Fan-out uses it to recognize this process's own reply and drop it.
+	// Without it, a deployment that discovers itself counts itself twice.
+	ID func(resp Resp) string
+}
+
+// Serve answers one RPC at whatever scope the caller asked for and the listener allows.
+//
+//	target set     forward once to that connection's peer proxy, for its deployment
+//	member scope   this process only
+//	group scope    this process plus every discovered sibling, each asked at member scope
+//
+// Siblings are asked at member scope and peer listeners refuse anything wider.
+// A group call therefore produces exactly one round of fan-out.
+func Serve[Req, Resp any](ctx context.Context, p *Plane, req Req, h Handlers[Req, Resp]) (Resp, error) {
+	var zero Resp
+	opts := OptionsFrom(ctx)
+
+	if err := h.validate(opts); err != nil {
+		return zero, err
+	}
+
+	if target := TargetFrom(ctx); target != "" {
+		resp, err := forward(ctx, p, target, req, h)
+		if err != nil {
+			return zero, err
+		}
+		return h.view(resp, opts), nil
+	}
+
+	self := Result[Resp]{ID: p.MemberID, Value: h.Self(ctx, req)}
+
+	if ScopeFrom(ctx) == ScopeMember {
+		return h.view(self.Value, opts), nil
+	}
+
+	members, roster := fanOut(ctx, p, req, h)
+	return h.view(h.Merge(self, members, roster), opts), nil
+}
+
+// validate refuses to answer rather than trusting that the handler was assembled correctly.
+//
+// The unset role matters as much as the missing View.
+// Role is stamped by the interceptor.
+// A listener that registers the service without installing it arrives here with the zero value.
+// The zero value must not be the one that skips the narrowing.
+func (h Handlers[Req, Resp]) validate(opts ServerOptions) error {
+	switch {
+	case h.Self == nil || h.Call == nil || h.Merge == nil:
+		return status.Error(codes.Internal, "adminplane: endpoint is missing Self, Call or Merge")
+	case opts.Role == RoleUnset:
+		return status.Error(codes.Internal,
+			"adminplane: listener did not install the adminplane interceptor, so no policy applies")
+	case opts.Role == RoleCounterparty && h.View == nil:
+		// A response reaching another organization must have been narrowed deliberately.
+		// Narrowing by whichever fields the endpoint happened to populate is not deliberate.
+		return status.Error(codes.Internal,
+			"adminplane: endpoint has no View and may not be served to a peer cluster")
+	}
+	return nil
+}
+
+func (h Handlers[Req, Resp]) view(resp Resp, opts ServerOptions) Resp {
+	if h.View == nil {
+		return resp
+	}
+	return h.View(resp, opts)
+}
+
+// forward sends the call to the peer proxy of a named cluster connection.
+// That proxy answers for its own deployment.
+//
+// Metadata is not inherited by outgoing calls.
+// The forwarded request therefore carries only what is set here and cannot be forwarded again.
+func forward[Req, Resp any](ctx context.Context, p *Plane, target string, req Req, h Handlers[Req, Resp]) (Resp, error) {
+	var zero Resp
+	if p.Peers == nil {
+		return zero, status.Error(codes.Unimplemented, "this proxy cannot forward admin calls")
+	}
+	cc, err := p.Peers.PeerConn(target)
+	if err != nil {
+		return zero, err
+	}
+	budget := Clamp(ctx, p.Budgets.withDefaults().Forward)
+	if budget <= 0 {
+		return zero, status.Error(codes.DeadlineExceeded, "no time left to forward")
+	}
+	callCtx, cancel := context.WithTimeout(OutgoingGroupContext(ctx), budget)
+	defer cancel()
+	return h.Call(callCtx, cc, req)
+}
+
+// fanOut asks every discovered member for its own answer.
+//
+// Every discovered address is dialed, this process's own included.
+// A DNS record carries no identity.
+// Self cannot be recognized before the call.
+// It is recognized afterwards by id and discarded then.
+//
+// Dialing this process's own address also means a peer listener that failed to bind shows up as unreachable.
+// That is true and worth reporting.
+func fanOut[Req, Resp any](ctx context.Context, p *Plane, req Req, h Handlers[Req, Resp]) ([]Result[Resp], Roster) {
+	budgets := p.Budgets.withDefaults()
+	// Serve has already taken this process's own answer by the time fanOut runs.
+	// Every path out of here therefore has at least one responder.
+	// The early returns below are failures to reach anyone else, not failures to answer.
+	// Counting the local answer here rather than at the end makes all four of those paths right at once.
+	roster := Roster{Provider: providerName(p.Discovery), Responding: 1}
+
+	if p.Discovery == nil || p.Dial == nil {
+		return nil, roster
+	}
+
+	discoverBudget := Clamp(ctx, budgets.Discover)
+	if discoverBudget <= 0 {
+		return nil, roster
+	}
+	discoverCtx, cancelDiscover := context.WithTimeout(ctx, discoverBudget)
+	addresses, err := p.Discovery.Discover(discoverCtx)
+	cancelDiscover()
+	if err != nil {
+		roster.Unreachable = append(roster.Unreachable, Unreachable{
+			Message: "discovery failed: " + err.Error(),
+			Code:    int32(codes.Unavailable),
+		})
+		return nil, roster
+	}
+	roster.Discovered = len(addresses)
+
+	memberBudget := Clamp(ctx, budgets.Member)
+	if memberBudget <= 0 {
+		for _, address := range addresses {
+			roster.Unreachable = append(roster.Unreachable, Unreachable{
+				Address: address,
+				Message: "no time left to query member",
+				Code:    int32(codes.DeadlineExceeded),
+			})
+		}
+		return nil, roster
+	}
+
+	results := make([]Result[Resp], len(addresses))
+	sem := make(chan struct{}, maxConcurrentMembers)
+	var wg sync.WaitGroup
+	for i, address := range addresses {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i] = callMember(ctx, p, address, memberBudget, req, h)
+		}()
+	}
+	wg.Wait()
+
+	var members []Result[Resp]
+	for _, r := range results {
+		if r.Err != nil {
+			// This may be this process's own address.
+			// Self is recognized by the id in a reply.
+			// A failed dial has no reply.
+			// A peer listener that did not bind therefore looks like any other unreachable member here.
+			// Every sibling still reports it.
+			// The bind failure itself is logged where it happens.
+			roster.Unreachable = append(roster.Unreachable, Unreachable{
+				Address: r.Address,
+				Message: status.Convert(r.Err).Message(),
+				Code:    int32(status.Code(r.Err)),
+			})
+			continue
+		}
+		if r.ID != "" && r.ID == p.MemberID {
+			// This process's own reply, returned over its own peer listener.
+			// The local answer already covers it.
+			// Keeping both would double every count.
+			continue
+		}
+		members = append(members, r)
+	}
+	roster.Responding += len(members)
+	sort.Slice(roster.Unreachable, func(i, j int) bool {
+		return roster.Unreachable[i].Address < roster.Unreachable[j].Address
+	})
+	sort.SliceStable(members, func(i, j int) bool { return members[i].ID < members[j].ID })
+	return members, roster
+}
+
+func callMember[Req, Resp any](
+	ctx context.Context, p *Plane, address string, budget time.Duration, req Req, h Handlers[Req, Resp],
+) Result[Resp] {
+	result := Result[Resp]{Address: address}
+	callCtx, cancel := context.WithTimeout(OutgoingMemberContext(ctx), budget)
+	defer cancel()
+
+	cc, release, err := p.Dial(callCtx, address)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	defer release()
+
+	value, err := h.Call(callCtx, cc, req)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	result.Value = value
+	if h.ID != nil {
+		result.ID = h.ID(value)
+	}
+	return result
+}
+
+func providerName(d Discovery) string {
+	if d == nil {
+		return ""
+	}
+	return d.Provider()
+}

--- a/adminplane/serve_test.go
+++ b/adminplane/serve_test.go
@@ -1,0 +1,294 @@
+package adminplane
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/s2s-proxy/config"
+)
+
+// answer stands in for a response message.
+// Serve is generic.
+// None of this needs a proto.
+type answer struct {
+	ID  string
+	Sum int
+}
+
+// fakeConn is the connection the fake dialer hands back.
+// It carries the address it was opened for.
+// A member's answer is distinguishable that way without a transport.
+type fakeConn struct{ address string }
+
+func (fakeConn) Invoke(context.Context, string, any, any, ...grpc.CallOption) error { return nil }
+func (fakeConn) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, nil
+}
+
+type failingDiscovery struct{}
+
+func (failingDiscovery) Provider() string { return config.DiscoveryDNS }
+func (failingDiscovery) Discover(context.Context) ([]string, error) {
+	return nil, errors.New("no such host")
+}
+
+// dialRecorder is a fake dialer that records what was dialed and how much of it happened at once.
+type dialRecorder struct {
+	mu       sync.Mutex
+	dialed   []string
+	inFlight int
+	peak     int
+	fail     map[string]error
+	hold     time.Duration
+}
+
+func (d *dialRecorder) dial(_ context.Context, address string) (grpc.ClientConnInterface, func(), error) {
+	d.mu.Lock()
+	d.dialed = append(d.dialed, address)
+	d.inFlight++
+	if d.inFlight > d.peak {
+		d.peak = d.inFlight
+	}
+	err := d.fail[address]
+	d.mu.Unlock()
+
+	release := func() {
+		d.mu.Lock()
+		d.inFlight--
+		d.mu.Unlock()
+	}
+	if err != nil {
+		release()
+		return nil, func() {}, err
+	}
+	if d.hold > 0 {
+		time.Sleep(d.hold)
+	}
+	return fakeConn{address: address}, release, nil
+}
+
+func (d *dialRecorder) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.dialed)
+}
+
+func (d *dialRecorder) peakConcurrency() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.peak
+}
+
+// handlers answer as whichever address was dialed.
+// Each member is identifiable in the result.
+func handlers(selfID string) Handlers[struct{}, answer] {
+	return Handlers[struct{}, answer]{
+		Self: func(context.Context, struct{}) answer { return answer{ID: selfID, Sum: 1} },
+		Call: func(_ context.Context, cc grpc.ClientConnInterface, _ struct{}) (answer, error) {
+			return answer{ID: cc.(fakeConn).address, Sum: 1}, nil
+		},
+		Merge: func(self Result[answer], members []Result[answer], _ Roster) answer {
+			out := answer{ID: self.Value.ID, Sum: self.Value.Sum}
+			for _, m := range members {
+				out.Sum += m.Value.Sum
+			}
+			return out
+		},
+		ID:   func(a answer) string { return a.ID },
+		View: func(a answer, _ ServerOptions) answer { return a },
+	}
+}
+
+func planeFor(memberID string, addresses []string) (*Plane, *dialRecorder) {
+	rec := &dialRecorder{}
+	return &Plane{
+		Discovery: NewStaticDiscovery(addresses),
+		Dial:      rec.dial,
+		MemberID:  memberID,
+	}, rec
+}
+
+// groupCtx is the context the interceptor produces for a group-scoped operator call.
+func groupCtx() context.Context {
+	ctx := context.WithValue(context.Background(), optionsKey{}, ServerOptions{Role: RoleOperator})
+	return context.WithValue(ctx, scopeKey{}, ScopeGroup)
+}
+
+// Serve takes this process's own answer before fanning out.
+// Every way out of fanOut already has one responder.
+//
+// The first case is the shipped default.
+// The chart turns the operator listener on and leaves the peer block off.
+// That leaves Dial nil.
+func TestFanOutAlwaysCountsThisProcess(t *testing.T) {
+	cases := []struct {
+		name  string
+		plane *Plane
+	}{
+		{name: "no peer configuration", plane: &Plane{Discovery: NoDiscovery(), MemberID: "pod-a"}},
+		{name: "discovery failed", plane: &Plane{Discovery: failingDiscovery{}, Dial: (&dialRecorder{}).dial, MemberID: "pod-a"}},
+		{name: "nothing discovered", plane: &Plane{Discovery: NewStaticDiscovery(nil), Dial: (&dialRecorder{}).dial, MemberID: "pod-a"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, roster := fanOut(groupCtx(), c.plane, struct{}{}, handlers("pod-a"))
+			require.Equal(t, 1, roster.Responding,
+				"this process answered, so a roster saying nobody did is self-contradictory")
+		})
+	}
+}
+
+// A budget that has already run out must not read as a clean, empty roster.
+func TestFanOutReportsWhenThereWasNoTimeToAsk(t *testing.T) {
+	plane, rec := planeFor("pod-a", []string{"10.0.0.1:9234", "10.0.0.2:9234"})
+
+	// Already past its deadline.
+	// Clamp returns non-positive at the first stage.
+	ctx, cancel := context.WithTimeout(groupCtx(), -time.Second)
+	defer cancel()
+
+	members, roster := fanOut(ctx, plane, struct{}{}, handlers("pod-a"))
+
+	require.Empty(t, members)
+	require.Equal(t, 1, roster.Responding)
+	require.Equal(t, 0, rec.count(), "no member should be dialed once the budget is gone")
+}
+
+func TestFanOutReportsDiscoveryFailure(t *testing.T) {
+	plane := &Plane{Discovery: failingDiscovery{}, Dial: (&dialRecorder{}).dial, MemberID: "pod-a"}
+
+	_, roster := fanOut(groupCtx(), plane, struct{}{}, handlers("pod-a"))
+
+	require.Len(t, roster.Unreachable, 1)
+	require.Contains(t, roster.Unreachable[0].Message, "discovery failed")
+	// No address: the failure was enumerating members, not reaching one.
+	require.Empty(t, roster.Unreachable[0].Address)
+	require.Equal(t, int32(codes.Unavailable), roster.Unreachable[0].Code)
+}
+
+// Every discovered address is dialed, this pod's own included.
+// A DNS record carries no identity.
+// Self is recognized afterwards, by the id in its reply.
+func TestFanOutDropsOurOwnReply(t *testing.T) {
+	plane, rec := planeFor("10.0.0.1:9234", []string{"10.0.0.1:9234", "10.0.0.2:9234"})
+
+	members, roster := fanOut(groupCtx(), plane, struct{}{}, handlers("10.0.0.1:9234"))
+
+	require.Equal(t, 2, rec.count(), "self is not recognizable before the dial, so it is dialed too")
+	require.Len(t, members, 1, "our own reply is dropped, or every count doubles")
+	require.Equal(t, "10.0.0.2:9234", members[0].ID)
+	require.Equal(t, 2, roster.Responding)
+	require.Equal(t, 2, roster.Discovered)
+}
+
+// Without an ID function there is nothing to compare.
+// Self cannot be recognized and is counted twice.
+// Serve does not reject that today.
+// This pins the cost so it is visible.
+func TestFanOutCannotDropOurOwnReplyWithoutAnIDFunc(t *testing.T) {
+	plane, _ := planeFor("10.0.0.1:9234", []string{"10.0.0.1:9234", "10.0.0.2:9234"})
+
+	h := handlers("10.0.0.1:9234")
+	h.ID = nil
+
+	members, roster := fanOut(groupCtx(), plane, struct{}{}, h)
+
+	require.Len(t, members, 2)
+	require.Equal(t, 3, roster.Responding, "self is counted once locally and once over its own listener")
+}
+
+func TestFanOutRecordsAMemberThatCannotBeDialed(t *testing.T) {
+	plane, rec := planeFor("10.0.0.1:9234", []string{"10.0.0.1:9234", "10.0.0.9:9234"})
+	rec.fail = map[string]error{"10.0.0.9:9234": status.Error(codes.Unavailable, "connection refused")}
+
+	members, roster := fanOut(groupCtx(), plane, struct{}{}, handlers("10.0.0.1:9234"))
+
+	require.Empty(t, members, "the only address that answered was our own, which is dropped")
+	require.Len(t, roster.Unreachable, 1)
+	require.Equal(t, "10.0.0.9:9234", roster.Unreachable[0].Address)
+	require.Equal(t, int32(codes.Unavailable), roster.Unreachable[0].Code)
+	require.Equal(t, 1, roster.Responding)
+}
+
+// A wrong DNS name should cost a bounded number of simultaneous connections, not one per pod.
+func TestFanOutCapsConcurrentDials(t *testing.T) {
+	addresses := make([]string, 0, 64)
+	for i := range 64 {
+		addresses = append(addresses, "10.0.0."+strconv.Itoa(i)+":9234")
+	}
+	plane, rec := planeFor("pod-a", addresses)
+	rec.hold = 20 * time.Millisecond
+
+	fanOut(groupCtx(), plane, struct{}{}, handlers("pod-a"))
+
+	require.Equal(t, 64, rec.count())
+	require.LessOrEqual(t, rec.peakConcurrency(), maxConcurrentMembers)
+}
+
+// Serve refuses to answer rather than trusting that the handler was assembled correctly.
+// It also refuses rather than trusting that a listener installed the interceptor that decides its policy.
+func TestServeRefusesToAnswerWhatItCannotPolice(t *testing.T) {
+	withOptions := func(o ServerOptions) context.Context {
+		ctx := context.WithValue(context.Background(), optionsKey{}, o)
+		return context.WithValue(ctx, scopeKey{}, ScopeMember)
+	}
+	counterparty := ServerOptions{Role: RoleCounterparty, ConnectionName: "cluster-b"}
+
+	cases := []struct {
+		name  string
+		ctx   context.Context
+		muted func(h *Handlers[struct{}, answer])
+	}{
+		{
+			// A response bound for another organization must have been narrowed on purpose.
+			// Narrowing by whichever fields the endpoint happened to populate is not on purpose.
+			name:  "counterparty with no View",
+			ctx:   withOptions(counterparty),
+			muted: func(h *Handlers[struct{}, answer]) { h.View = nil },
+		},
+		{
+			// Role is stamped by the interceptor.
+			// Reaching here without one means the listener registered the service but not the policy.
+			// The zero value must not be the one that skips narrowing.
+			name:  "no listener policy at all",
+			ctx:   withOptions(ServerOptions{}),
+			muted: func(*Handlers[struct{}, answer]) {},
+		},
+		{
+			name:  "a required handler is missing",
+			ctx:   withOptions(ServerOptions{Role: RoleOperator}),
+			muted: func(h *Handlers[struct{}, answer]) { h.Merge = nil },
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := handlers("pod-a")
+			c.muted(&h)
+			_, err := Serve(c.ctx, &Plane{Discovery: NoDiscovery(), MemberID: "pod-a"}, struct{}{}, h)
+			require.Error(t, err)
+			require.Equal(t, codes.Internal, status.Code(err))
+		})
+	}
+}
+
+// Forwarding needs a router.
+// Without one the call is refused rather than reported as a member that did not answer.
+func TestForwardWithoutARouter(t *testing.T) {
+	ctx := context.WithValue(context.Background(), optionsKey{}, ServerOptions{Role: RoleOperator})
+	ctx = context.WithValue(ctx, scopeKey{}, ScopeGroup)
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(MDTarget, "cluster-b"))
+
+	_, err := Serve(ctx, &Plane{Discovery: NoDiscovery(), MemberID: "pod-a"}, struct{}{}, handlers("pod-a"))
+	require.Error(t, err)
+	require.Equal(t, codes.Unimplemented, status.Code(err))
+}

--- a/app/app.go
+++ b/app/app.go
@@ -82,6 +82,7 @@ func (a *App) startProxy(runCtx context.Context, cliCtx *urcli.Context) error {
 
 	fxApp := fx.New(
 		fx.Provide(func() *urcli.Context { return cliCtx }),
+		fx.Supply(proxy.DefaultIdentity(a.version)),
 		fx.Provide(func() log.Logger {
 			return log.NewZapLogger(log.BuildZapLogger(logCfg))
 		}),

--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -51,6 +51,8 @@ data:
         listenAddress: 0.0.0.0:9090
     profiling:
       pprofAddress: localhost:6060
+    proxyAdmin:
+      listenAddress: localhost:6061
 kind: ConfigMap
 metadata:
   name: example-s2s-proxy
@@ -124,6 +126,14 @@ spec:
           env:
             - name: CONFIG_YML
               value: "/config/config.yaml"
+            # Identifies this pod in admin responses.
+            # Without it every replica reports its container hostname.
+            # That is the pod name anyway.
+            # Being explicit survives a change to how the container is named.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/s2s-proxy/files/default.yaml
+++ b/charts/s2s-proxy/files/default.yaml
@@ -51,6 +51,13 @@ clusterConnections:
           - ReapplyEvents
           - GetNamespace
           - SyncWorkflowState
+        # Optional. Narrows what the remote cluster may call on this proxy's own admin API.
+        # Absent means the built-in default: DescribeClusterConnections and nothing else.
+        # An empty list serves nothing.
+        # That is how an operator declines to answer this counterparty at all.
+        # This differs from adminService above, where an empty list allows everything.
+        # proxyAdmin:
+        #   - DescribeClusterConnections
       allowedNamespaces:
         # Optional. If configured, the temporal-system namespace must be included to allow migration workflows to run.
         - "temporal-system"
@@ -78,6 +85,32 @@ clusterConnections:
 #    localClusterHealthCheck:
 #      protocol: "http"
 #      listenAddress: "0.0.0.0:8235"
+
+proxyAdmin:
+  # Serves ProxyAdminService for operator queries.
+  # It has no TLS and no authorization.
+  # A non-loopback address is refused at startup.
+  # Reach it with `kubectl exec` or a port-forward.
+  listenAddress: "localhost:6061"
+  # Uncomment to let one pod answer for the whole deployment.
+  # Without this, a query describes only the pod that received it.
+  # The dns name defaults to this release's headless Service.
+  #
+  # A non-loopback listener with no tls is refused at startup unless allowInsecure is set.
+  # It publishes the deployment's topology to anything that can reach the pod network.
+  #
+  # peer:
+  #   listenAddress: "0.0.0.0:9234"
+  #   tls:
+  #     certificatePath: /certs/peer.pem
+  #     keyPath: /certs/peer.key
+  #     remoteCAPath: /certs/ca.pem
+  #     # Every pod's certificate must carry this as a SAN.
+  #     # Peers are dialed by IP.
+  #     # A per-pod SAN scheme fails every handshake.
+  #     caServerName: s2s-proxy-peers
+  #   discovery:
+  #     provider: dns
 
 metrics:
   prometheus:

--- a/charts/s2s-proxy/templates/_helpers.tpl
+++ b/charts/s2s-proxy/templates/_helpers.tpl
@@ -72,6 +72,32 @@ Merge default config with overrides
 {{- end }}
 {{- $_ := set $merged "clusterConnections" $mergedClusterConnections -}}
 
+{{/*
+Merge every other top-level key. Without this, only clusterConnections is written back and
+everything else in configOverride is silently discarded.
+deepCopy the source: sprig mergeOverwrite mutates its first argument, and the loop above already
+writes defaults into .Values.configOverride.clusterConnections in place.
+*/}}
+{{- $merged = mergeOverwrite $merged (omit $overrides "clusterConnections" | deepCopy) -}}
+
+{{/*
+Point dns peer discovery at this release's headless Service unless the operator named something
+else. Otherwise every install has to hand-write a cluster-internal DNS name, which is exactly the
+configuration back and forth this endpoint exists to remove.
+*/}}
+{{- $peer := (($merged.proxyAdmin).peer) }}
+{{- if $peer }}
+{{-   $discovery := $peer.discovery | default dict }}
+{{-   if eq ($discovery.provider | default "") "dns" }}
+{{-     $dns := $discovery.dns | default dict }}
+{{-     if not $dns.name }}
+{{-       $_ := set $dns "name" (printf "%s.%s.svc.cluster.local" (include "s2s-proxy.fullname" .) .Release.Namespace) }}
+{{-       $_ := set $discovery "dns" $dns }}
+{{-       $_ := set $peer "discovery" $discovery }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+
 {{- $merged | toYaml }}
 {{- end }}
 
@@ -90,5 +116,15 @@ Parse port numbers from merged config
 {{- $metrics := ($firstCluster.metrics).prometheus.listenAddress | default $config.metrics.prometheus.listenAddress }}
 {{- $metricsPort := (split ":" $metrics)._1 }}
 
-{{- dict "egress" $egressPort "health" $healthPort "metrics" $metricsPort | toYaml }}
+{{/*
+The peer listener is optional. The loopback operator listener is deliberately never turned into a
+containerPort or a Service port.
+*/}}
+{{- $peerPort := "" }}
+{{- $peerAddress := ((($config.proxyAdmin).peer).listenAddress) }}
+{{- if $peerAddress }}
+{{-   $peerPort = (split ":" $peerAddress)._1 }}
+{{- end }}
+
+{{- dict "egress" $egressPort "health" $healthPort "metrics" $metricsPort "peer" $peerPort | toYaml }}
 {{- end }}

--- a/charts/s2s-proxy/templates/deployment.yaml
+++ b/charts/s2s-proxy/templates/deployment.yaml
@@ -48,9 +48,22 @@ spec:
           - containerPort: {{ $ports.metrics }}
             name: rpc-metrics
             protocol: TCP
+          {{- if $ports.peer }}
+          - containerPort: {{ $ports.peer }}
+            name: rpc-peer
+            protocol: TCP
+          {{- end }}
           env:
             - name: CONFIG_YML
               value: "/config/config.yaml"
+            # Identifies this pod in admin responses.
+            # Without it every replica reports its container hostname.
+            # That is the pod name anyway.
+            # Being explicit survives a change to how the container is named.
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/s2s-proxy/tests/configmap_test.yaml
+++ b/charts/s2s-proxy/tests/configmap_test.yaml
@@ -36,3 +36,39 @@ tests:
           pattern: |-
             muxAddressInfo:
               \s*address: addr:3333
+
+  # Layered configuration deep-merges and cannot delete keys.
+  # Switching provider leaves the previous provider's block behind.
+  # The rendered config must still select the new provider.
+  # The binary ignores the leftover block.
+  - it: should switch discovery provider without removing the previous block
+    set:
+      configOverride:
+        proxyAdmin:
+          peer:
+            listenAddress: "0.0.0.0:9234"
+            allowInsecure: true
+            discovery:
+              provider: static
+              dns:
+                name: leftover.svc
+              static:
+                addresses: ["p0:9234"]
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "provider: static"
+
+  - it: should default dns discovery to this release's headless service
+    set:
+      configOverride:
+        proxyAdmin:
+          peer:
+            listenAddress: "0.0.0.0:9234"
+            allowInsecure: true
+            discovery:
+              provider: dns
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "name: RELEASE-NAME-s2s-proxy\\.NAMESPACE\\.svc\\.cluster\\.local"

--- a/charts/s2s-proxy/tests/deployment_test.yaml
+++ b/charts/s2s-proxy/tests/deployment_test.yaml
@@ -43,3 +43,38 @@ tests:
             - containerPort: 3333
               name: rpc-metrics
               protocol: TCP
+
+  # The peer listener is opt-in.
+  # The default install exposes no extra port.
+  - it: should not expose a peer port by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: rpc-peer
+          any: true
+
+  - it: should expose a peer port when peer discovery is enabled
+    set:
+      configOverride:
+        proxyAdmin:
+          peer:
+            listenAddress: "0.0.0.0:9234"
+            allowInsecure: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 9234
+            name: rpc-peer
+            protocol: TCP
+
+  - it: should identify each pod for admin responses
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/temporalio/s2s-proxy/collect"
+	"github.com/temporalio/s2s-proxy/encryption"
 )
 
 const (
@@ -47,9 +48,73 @@ type (
 	S2SProxyConfig struct {
 		Metrics            *MetricsConfig           `yaml:"metrics"`
 		ProfilingConfig    *ProfilingConfig         `yaml:"profiling"`
+		ProxyAdmin         ProxyAdminConfig         `yaml:"proxyAdmin"`
 		Logging            LoggingConfig            `yaml:"logging"`
 		LogConfigs         map[string]LoggingConfig `yaml:"logConfigs"`
 		ClusterConnections []ClusterConnConfig      `yaml:"clusterConnections"`
+	}
+
+	ProxyAdminConfig struct {
+		// ListenAddress serves ProxyAdminService for local operator queries.
+		// Empty or absent means no server runs.
+		// This listener has no TLS and no authorization.
+		// Validate rejects anything but a loopback address.
+		ListenAddress string `yaml:"listenAddress"`
+
+		// Peer serves ProxyAdminService to the other pods of this proxy deployment.
+		// One pod can then answer for all of them.
+		// Absent means this pod only ever describes itself.
+		Peer *ProxyAdminPeerConfig `yaml:"peer"`
+	}
+
+	ProxyAdminPeerConfig struct {
+		// ListenAddress must be reachable from sibling pods.
+		// Unlike the operator listener it is normally not loopback.
+		ListenAddress string `yaml:"listenAddress"`
+
+		// AllowInsecure permits a non-loopback ListenAddress with no TLS.
+		// Without it that combination is a startup error.
+		// It publishes an unauthenticated view of the deployment's topology to anything that can reach the pod network.
+		AllowInsecure bool `yaml:"allowInsecure"`
+
+		// TLS secures peer traffic.
+		// Unlike the mux listener this verifies the client chain.
+		// CAServerName must name a SAN that every pod's certificate carries.
+		// Peers are dialed by IP.
+		// A per-pod SAN scheme fails every handshake.
+		TLS *encryption.TLSConfig `yaml:"tls"`
+
+		Discovery DiscoveryConfig `yaml:"discovery"`
+	}
+
+	// DiscoveryConfig selects one provider by name.
+	// Each provider reads only its own block.
+	// A block left behind by an unselected provider is inert.
+	//
+	// Every layered configuration tool in this stack deep-merges and cannot delete keys.
+	// Switching Provider from "dns" to "static" through a Helm values override cannot remove the dns block.
+	// Strict decoding would reject the config if the two shared a namespace.
+	DiscoveryConfig struct {
+		// Provider is "dns", "static", or "none".
+		// Empty means "none".
+		Provider string `yaml:"provider"`
+
+		DNS    DNSDiscoveryConfig    `yaml:"dns"`
+		Static StaticDiscoveryConfig `yaml:"static"`
+	}
+
+	DNSDiscoveryConfig struct {
+		// Name resolves to one address per sibling pod, as a Kubernetes headless Service does.
+		// Such a Service publishes ready endpoints only.
+		// A crash-looping pod is invisible to discovery rather than reported as unreachable.
+		Name string `yaml:"name"`
+
+		// Port defaults to the port in the peer ListenAddress.
+		Port int `yaml:"port"`
+	}
+
+	StaticDiscoveryConfig struct {
+		Addresses []string `yaml:"addresses"`
 	}
 
 	SATranslationConfig struct {
@@ -93,6 +158,25 @@ type (
 
 	AllowedMethods struct {
 		AdminService []string `yaml:"adminService"`
+
+		// ProxyAdmin narrows what the remote cluster may call on this proxy's own admin API.
+		// Short method names, like AdminService above.
+		//
+		// Absent means the built-in ceiling applies.
+		// That ceiling is DescribeClusterConnections and nothing else.
+		// A present-but-empty list means serve nothing.
+		// An operator declines to answer this counterparty at all by writing the empty list.
+		// A name the counterparty could never be served is a startup error.
+		// Configuration can only narrow.
+		//
+		// AdminService differs: its empty list means allow everything.
+		// That asymmetry is deliberate.
+		// The replication ACL's fail-open default is a compatibility promise.
+		// Repeating it here would make the natural spelling of "off" the widest possible setting.
+		//
+		// Writing "proxyAdmin:" with no value is absent, not empty.
+		// Write "proxyAdmin: []" to serve nothing.
+		ProxyAdmin []string `yaml:"proxyAdmin"`
 	}
 
 	ACLPolicy struct {
@@ -366,5 +450,6 @@ func (c *S2SProxyConfig) Validate() error {
 	return validation.Validate(
 		"",
 		validation.Children("clusterConnections", c.ClusterConnections, (*ClusterConnConfig).Validate),
+		validation.Nested("proxyAdmin", &c.ProxyAdmin),
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,3 +322,190 @@ func TestExampleChart(t *testing.T) {
 	require.Equal(t, ConnectionType("mux-client"), cc.Remote.ConnectionType)
 	require.Equal(t, "s2s-proxy-sample.example.tmprl.cloud:8233", cc.Remote.MuxAddressInfo.ConnectionString)
 }
+
+func TestProxyAdminConfig(t *testing.T) {
+	load := func(t *testing.T, body string) S2SProxyConfig {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+		cfg, err := LoadConfig[S2SProxyConfig](path)
+		require.NoError(t, err)
+		return cfg
+	}
+	loadErr := func(t *testing.T, body string) error {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+		_, err := LoadConfig[S2SProxyConfig](path)
+		return err
+	}
+
+	const clusterConnections = `
+clusterConnections:
+  - name: only
+`
+
+	t.Run("absent means disabled", func(t *testing.T) {
+		cfg := load(t, clusterConnections)
+		assert.Empty(t, cfg.ProxyAdmin.ListenAddress)
+		assert.Nil(t, cfg.ProxyAdmin.Peer)
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("listen address round-trips", func(t *testing.T) {
+		cfg := load(t, clusterConnections+"proxyAdmin:\n  listenAddress: \"localhost:6061\"\n")
+		assert.Equal(t, "localhost:6061", cfg.ProxyAdmin.ListenAddress)
+		assert.NoError(t, cfg.Validate())
+	})
+
+	// KnownFields(true) makes an unrecognized key fatal.
+	// The Go field has to exist before any YAML can set it.
+	t.Run("unknown key under proxyAdmin is rejected", func(t *testing.T) {
+		require.Error(t, loadErr(t, clusterConnections+"proxyAdmin:\n  nope: 1\n"))
+	})
+
+	t.Run("unknown key under discovery is rejected", func(t *testing.T) {
+		require.Error(t, loadErr(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "127.0.0.1:9234"
+    discovery:
+      provider: dns
+      nmae: typo
+`))
+	})
+
+	// Every layered configuration tool deep-merges and cannot delete keys.
+	// Switching provider leaves the previous provider's block behind.
+	// It has to be inert rather than fatal, or there is no way to change provider through a Helm override at all.
+	t.Run("an unselected provider's block is inert", func(t *testing.T) {
+		cfg := load(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "127.0.0.1:9234"
+    discovery:
+      provider: static
+      dns:
+        name: leftover.svc.cluster.local
+      static:
+        addresses: ["a:9234", "b:9234"]
+`)
+		require.NoError(t, cfg.Validate())
+		assert.Equal(t, DiscoveryStatic, cfg.ProxyAdmin.Peer.Discovery.Provider)
+		assert.Equal(t, "leftover.svc.cluster.local", cfg.ProxyAdmin.Peer.Discovery.DNS.Name)
+	})
+
+	t.Run("peer port defaults the dns port", func(t *testing.T) {
+		cfg := load(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "127.0.0.1:9234"
+    discovery:
+      provider: dns
+      dns:
+        name: peers.svc.cluster.local
+`)
+		require.NoError(t, cfg.Validate())
+		assert.Equal(t, 9234, cfg.ProxyAdmin.Peer.PeerPort())
+	})
+
+	t.Run("validation rejects unusable configurations", func(t *testing.T) {
+		for name, tc := range map[string]struct{ body, wants string }{
+			// The operator listener has no TLS and no authorization.
+			// Its View is a no-op.
+			// Off-host is never a shape it can safely take.
+			"operator listener off loopback": {
+				body:  "proxyAdmin:\n  listenAddress: \"0.0.0.0:6061\"\n",
+				wants: "proxyAdmin: listenAddress: is \"0.0.0.0:6061\", which is not loopback",
+			},
+			"operator listener without a port": {
+				body:  "proxyAdmin:\n  listenAddress: \"localhost\"\n",
+				wants: "proxyAdmin: listenAddress: is not a valid host:port",
+			},
+			"peer without a listen address": {
+				body:  "proxyAdmin:\n  peer: {}\n",
+				wants: "proxyAdmin.peer: listenAddress: is required",
+			},
+			"unknown provider": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"127.0.0.1:9234\"\n    discovery:\n      provider: carrier-pigeon\n",
+				wants: "proxyAdmin.peer.discovery: provider: is \"carrier-pigeon\", want one of",
+			},
+			"dns without a name": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"127.0.0.1:9234\"\n    discovery:\n      provider: dns\n",
+				wants: "proxyAdmin.peer.discovery: dns.name: is required",
+			},
+			// Siblings are dialed at the peer listen address port.
+			// An address that binds an arbitrary port leaves discovery with nothing to dial.
+			"dns without a port to dial": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"127.0.0.1:0\"\n    allowInsecure: true\n    discovery:\n      provider: dns\n      dns:\n        name: peers.svc\n",
+				wants: "proxyAdmin.peer: discovery.dns.port: is required",
+			},
+			"static without addresses": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"127.0.0.1:9234\"\n    discovery:\n      provider: static\n",
+				wants: "proxyAdmin.peer.discovery: static.addresses: is required",
+			},
+			// A plaintext listener on the pod network publishes the deployment's topology to anything that can reach it.
+			// It has to be stated rather than fallen into.
+			"non-loopback without tls": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"0.0.0.0:9234\"\n",
+				wants: "set proxyAdmin.peer.allowInsecure to accept it",
+			},
+			// TLSConfig.IsEnabled is true with only caServerName set.
+			// That would hand the listener a TLS config with no certificate and fail every handshake at runtime.
+			"tls without a certificate": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"0.0.0.0:9234\"\n    tls:\n      caServerName: peers\n",
+				wants: "proxyAdmin.peer: tls.certificatePath: is required",
+			},
+			// peerServerTLSConfig verifies its callers.
+			// It needs the CA to verify them against.
+			// Without this the listener fails to build and is skipped.
+			// The only symptom is one log line plus every sibling reporting this pod unreachable.
+			"tls without a CA to verify peers": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"0.0.0.0:9234\"\n    tls:\n      certificatePath: /c\n      keyPath: /k\n      caServerName: peers\n",
+				wants: "proxyAdmin.peer: tls.remoteCAPath: is required",
+			},
+			// Siblings are dialed by IP.
+			// Without this the fan-out dial has no name to verify the sibling certificate against.
+			// It fails inside GetClientTLSConfig.
+			"tls without a caServerName": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"0.0.0.0:9234\"\n    tls:\n      certificatePath: /c\n      keyPath: /k\n      remoteCAPath: /ca\n",
+				wants: "proxyAdmin.peer: tls.caServerName: is required",
+			},
+			// GetClientTLSConfig assigns this to InsecureSkipVerify.
+			// Every sibling this pod dials goes unverified while the config still reads as TLS-secured.
+			"tls with verification skipped": {
+				body:  "proxyAdmin:\n  peer:\n    listenAddress: \"0.0.0.0:9234\"\n    tls:\n      certificatePath: /c\n      keyPath: /k\n      remoteCAPath: /ca\n      caServerName: peers\n      skipCAVerification: true\n",
+				wants: "proxyAdmin.peer: tls.skipCAVerification: disables verification",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				cfg := load(t, clusterConnections+tc.body)
+				err := cfg.Validate()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wants)
+			})
+		}
+	})
+
+	t.Run("non-loopback with allowInsecure is accepted", func(t *testing.T) {
+		cfg := load(t, clusterConnections+"proxyAdmin:\n  peer:\n    listenAddress: \"0.0.0.0:9234\"\n    allowInsecure: true\n")
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("a fully specified peer is accepted", func(t *testing.T) {
+		cfg := load(t, clusterConnections+`
+proxyAdmin:
+  listenAddress: "127.0.0.1:6061"
+  peer:
+    listenAddress: "0.0.0.0:9234"
+    tls:
+      certificatePath: /c
+      keyPath: /k
+      remoteCAPath: /ca
+      caServerName: peers
+    discovery:
+      provider: dns
+      dns:
+        name: peers.svc.cluster.local
+`)
+		require.NoError(t, cfg.Validate())
+	})
+}

--- a/config/proxyadmin.go
+++ b/config/proxyadmin.go
@@ -1,0 +1,181 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+// Discovery provider names. Empty is equivalent to DiscoveryNone.
+const (
+	DiscoveryNone   = "none"
+	DiscoveryDNS    = "dns"
+	DiscoveryStatic = "static"
+)
+
+// DiscoveryProviders lists every provider name Validate accepts, for error messages.
+var DiscoveryProviders = []string{DiscoveryNone, DiscoveryDNS, DiscoveryStatic}
+
+// Validate reports configuration that can never work.
+// A typo fails startup rather than leaving a listener that silently never starts.
+//
+// Failures that depend on the environment rather than the config are handled at runtime instead.
+// A port already in use and a name that does not resolve are both of that kind.
+func (c *ProxyAdminConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("listenAddress", c.ListenAddress,
+			validation.When(isSet, validation.IsHostPort(), isLoopback(
+				"Bind it to loopback, or serve siblings through proxyAdmin.peer, which authenticates its callers."))),
+		validation.WhenNested(func() bool { return c.Peer != nil }, "peer", c.Peer),
+	)
+}
+
+func (p *ProxyAdminPeerConfig) Validate() error {
+	// TLSConfig.IsEnabled is true when only caServerName is set.
+	// The fields below are therefore required individually rather than taken as a group.
+	tlsEnabled := p.TLS != nil && p.TLS.IsEnabled()
+
+	rules := []validation.Rule{
+		validation.Field("listenAddress", p.ListenAddress,
+			validation.Required[string](), validation.IsHostPort(),
+			validation.WhenFn(func() bool { return !tlsEnabled && !p.AllowInsecure }, isLoopback(
+				"Configure proxyAdmin.peer.tls, or set proxyAdmin.peer.allowInsecure to accept it."))),
+	}
+	if tlsEnabled {
+		rules = append(rules, p.tlsRules()...)
+	}
+	rules = append(rules,
+		validation.Field("discovery.dns.port", p.Discovery.DNS.Port,
+			validation.WhenFn(p.discoveryPortUnresolvable, validation.Required[int]())),
+		validation.Nested("discovery", &p.Discovery),
+	)
+
+	return validation.Validate("", rules...)
+}
+
+// tlsRules validates the peer TLS block.
+// That block serves the peer listener and dials every sibling.
+func (p *ProxyAdminPeerConfig) tlsRules() []validation.Rule {
+	return []validation.Rule{
+		validation.Field("tls.certificatePath", p.TLS.CertificatePath, validation.Required[string]()),
+		validation.Field("tls.keyPath", p.TLS.KeyPath, validation.Required[string]()),
+		// The peer listener verifies its callers, unlike the mux.
+		// It needs the CA to verify them against.
+		// Without this the listener fails to build and is skipped at startup.
+		// The only symptom is one log line plus every sibling reporting this pod unreachable.
+		validation.Field("tls.remoteCAPath", p.TLS.RemoteCAPath, validation.Required[string]()),
+		// Peers are dialed by IP.
+		// This must name a SAN that every pod's certificate carries.
+		validation.Field("tls.caServerName", p.TLS.CAServerName, validation.Required[string]()),
+		validation.Field("tls.skipCAVerification", p.TLS.SkipCAVerification, isFalse(
+			"disables verification of every sibling this pod dials, which defeats the peer TLS it is set alongside")),
+	}
+}
+
+// discoveryPortUnresolvable reports whether the dns provider has no port to dial siblings on.
+// Neither discovery.dns.port nor the peer listen address supplies one in that case.
+func (p *ProxyAdminPeerConfig) discoveryPortUnresolvable() bool {
+	return p.Discovery.Provider == DiscoveryDNS && p.PeerPort() == 0
+}
+
+func (d *DiscoveryConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("provider", d.Provider, knownDiscoveryProvider()),
+		// Blocks belonging to an unselected provider are deliberately not validated.
+		// Layered configuration deep-merges and cannot delete keys.
+		// Switching provider leaves the previous provider's block behind.
+		// It must stay inert.
+		validation.WhenRules(func() bool { return d.Provider == DiscoveryDNS },
+			validation.Field("dns.name", d.DNS.Name, validation.Required[string]()),
+		),
+		validation.WhenRules(func() bool { return d.Provider == DiscoveryStatic },
+			validation.Field("static.addresses", d.Static.Addresses, nonEmpty[string]()),
+		),
+	)
+}
+
+func isSet(s string) bool { return s != "" }
+
+func nonEmpty[V any]() validation.Check[[]V] {
+	return func(vs []V) error {
+		if len(vs) == 0 {
+			return errors.New("is required")
+		}
+		return nil
+	}
+}
+
+func knownDiscoveryProvider() validation.Check[string] {
+	return func(provider string) error {
+		if provider == "" || slices.Contains(DiscoveryProviders, provider) {
+			return nil
+		}
+		return fmt.Errorf("is %q, want one of %v", provider, DiscoveryProviders)
+	}
+}
+
+// isLoopback rejects an address reachable from outside this host.
+// An unparseable or name-based host is rejected too.
+// The check errs toward making the operator state their intent.
+func isLoopback(remedy string) validation.Check[string] {
+	return func(listenAddress string) error {
+		if loopbackListenAddress(listenAddress) {
+			return nil
+		}
+		return fmt.Errorf("is %q, which is not loopback: this publishes an unauthenticated view "+
+			"of the deployment topology to anything that can reach it. %s", listenAddress, remedy)
+	}
+}
+
+func isFalse(because string) validation.Check[bool] {
+	return func(v bool) error {
+		if !v {
+			return nil
+		}
+		return errors.New(because)
+	}
+}
+
+// peerPort returns the port of a host:port listen address, or 0 when the address binds an arbitrary port.
+func peerPort(listenAddress string) (int, error) {
+	_, portStr, err := net.SplitHostPort(listenAddress)
+	if err != nil {
+		return 0, err
+	}
+	if portStr == "" || portStr == "0" {
+		return 0, nil
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port %q: %w", portStr, err)
+	}
+	return port, nil
+}
+
+// loopbackListenAddress reports whether an address only accepts connections from this host.
+func loopbackListenAddress(listenAddress string) bool {
+	host, _, err := net.SplitHostPort(listenAddress)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// PeerPort returns the port the peer listener binds, for defaulting discovery ports.
+func (p ProxyAdminPeerConfig) PeerPort() int {
+	port, err := peerPort(p.ListenAddress)
+	if err != nil {
+		return 0
+	}
+	return port
+}

--- a/encryption/tls.go
+++ b/encryption/tls.go
@@ -146,6 +146,12 @@ func GetClientTLSConfig(clientConfig TLSConfig) (tlsConfig *tls.Config, err erro
 	return
 }
 
+// LoadCACert reads a CA bundle from a file path or an https URL, for callers that build their own
+// tls.Config rather than using the helpers above.
+func LoadCACert(pathOrUrl string) (*x509.CertPool, error) {
+	return fetchCACert(pathOrUrl)
+}
+
 func fetchCACert(pathOrUrl string) (*x509.CertPool, error) {
 	var caBytes []byte
 	var err error

--- a/endtoendtest/echo_server.go
+++ b/endtoendtest/echo_server.go
@@ -123,6 +123,7 @@ func NewEchoServer(
 		proxy, err = s2sproxy.NewProxy(
 			configProvider,
 			logging.NewLoggerProvider(logger, configProvider),
+			s2sproxy.Identity{Version: "test", MemberID: serviceName},
 		)
 		if err != nil {
 			panic(err)

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -78,6 +78,31 @@ var (
 	EncryptionDEKOpDur       = BucketedHistogramVec("enc_dek_op_duration_secs", "Duration of the AES-256-GCM step alone in seconds, excluding any KEK wrap or unwrap, labeled by operation", prometheus.ExponentialBuckets(0.00001, 4, 7), "operation")
 	EncryptionDEKRotations   = DefaultCounterVec("enc_dek_rotations_total", "Total DEK rotations, labeled by reason", "reason")
 
+	// Cluster connection health, sampled in /proxy/connection_metrics.go
+
+	// config_name carries the same value as the mux metrics' config_name, sanitizeConnectionName of
+	// the configured name.
+	// A dashboard variable built from num_muxes_active therefore also populates these.
+	//
+	// This is the state breakdown nothing else exports.
+	// mux_connection_active is set to 1 on every observer tick until the session's lifetime ends.
+	// num_muxes_active is the size of the session map.
+	// A session failing its ping but still in the map reads as healthy in both.
+	ClusterConnectionMuxSessions = DefaultGaugeVec("cluster_connection_mux_sessions",
+		"Mux sessions this pod holds for a cluster connection, by session state. State is refreshed by the session's own health check about once a minute, so an errored session can take that long to appear here. Not reported for a connection whose remote is plain tcp.",
+		"config_name", "state")
+	// The denominator that makes the state breakdown alertable.
+	// A session that never established was never added to the manager.
+	// The sessions held say nothing on their own about how many were meant to exist.
+	ClusterConnectionMuxSessionsTarget = DefaultGaugeVec("cluster_connection_mux_sessions_target",
+		"Mux sessions this pod is configured to hold for a cluster connection.",
+		"config_name")
+	// Version skew during a rollout.
+	// collectors.NewBuildInfoCollector reports the module version.
+	// This is the -X main.Version stamp the binary was actually built with.
+	ProxyBuildInfo = DefaultGaugeVec("build_info",
+		"Always 1, labelled with the build this process is running.", "version")
+
 	// Translation interceptor
 
 	translationLabels  = []string{"kind", "message_type"}
@@ -158,6 +183,10 @@ func init() {
 		EncryptionDEKOpDur,
 		EncryptionDEKRotations,
 	)
+
+	prometheus.MustRegister(ClusterConnectionMuxSessions)
+	prometheus.MustRegister(ClusterConnectionMuxSessionsTarget)
+	prometheus.MustRegister(ProxyBuildInfo)
 
 	prometheus.MustRegister(TranslationCount)
 	prometheus.MustRegister(TranslationErrors)

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -376,6 +376,7 @@ func (c *ClusterConnection) Start() {
 	c.inboundObserver.Start(c.lifetime, c.inboundServer.Name(), "inbound")
 	c.outboundServer.Start()
 	c.outboundObserver.Start(c.lifetime, c.outboundServer.Name(), "outbound")
+	c.sampleMetrics(c.lifetime)
 }
 
 func (c *ClusterConnection) Describe() string {

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -18,6 +18,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/temporalio/s2s-proxy/adminplane"
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
 	"github.com/temporalio/s2s-proxy/auth"
 	"github.com/temporalio/s2s-proxy/collect"
 	"github.com/temporalio/s2s-proxy/common"
@@ -37,6 +39,8 @@ const (
 	LogClusterConnection = "clusterConnection"
 	LogInterceptor       = "interceptor"
 	LogTLSHandshake      = "tlsHandshake"
+	LogProxyAdmin        = "proxyAdmin"
+	LogProxyAdminPeer    = "proxyAdminPeer"
 )
 
 type (
@@ -59,6 +63,12 @@ type (
 	ClusterConnection struct {
 		// When lifetime closes, all clients and servers in ClusterConnection will stop.
 		lifetime context.Context
+		// name is the configured name, unsanitized.
+		// It is what the admin API reports and what routes an admin call to a peer.
+		// It must not be the prometheus-safe variant.
+		name string
+		// remoteDefinition is kept for the session count this connection is configured to hold.
+		remoteDefinition config.ClusterDefinition
 		// outboundServer receives connections from the local Temporal and makes calls using outboundClient.
 		outboundServer contextAwareServer
 		// outboundClient is connected to a remote Temporal server somewhere.
@@ -106,6 +116,11 @@ type (
 		aclPolicy        *config.ACLPolicy
 		shardCountConfig config.ShardCountConfig
 		loggers          logging.LoggerProvider
+		// adminService is registered on this server when non-nil, under adminOptions.
+		// Only the inbound mux server sets it.
+		// That is the one a peer cluster can reach.
+		adminService proxyadminv1.ProxyAdminServiceServer
+		adminOptions adminplane.ServerOptions
 
 		shardManager      ShardManager
 		lcmParameters     LCMParameters
@@ -119,14 +134,38 @@ func sanitizeConnectionName(name string) string {
 }
 
 // NewClusterConnection unpacks the connConfig and creates the inbound and outbound clients and servers.
-func NewClusterConnection(lifetime context.Context, connConfig config.ClusterConnConfig, logProvider logging.LoggerProvider) (*ClusterConnection, error) {
+//
+// adminService is registered on the inbound mux server so that a peer cluster can describe this proxy.
+// Nil serves no admin API on this connection.
+func NewClusterConnection(
+	lifetime context.Context,
+	connConfig config.ClusterConnConfig,
+	adminService proxyadminv1.ProxyAdminServiceServer,
+	logProvider logging.LoggerProvider,
+) (*ClusterConnection, error) {
+	// Resolved before anything is built.
+	// An operator's typo fails startup rather than silently denying a method at request time.
+	//
+	// config cannot do this itself.
+	// adminplane owns the ceiling and already imports config.
+	// The check has to live on this side of that edge.
+	var err error
+	var counterpartyMethods []string
+	if connConfig.ACLPolicy != nil {
+		counterpartyMethods, err = adminplane.ResolveCounterpartyMethods(connConfig.ACLPolicy.AllowedMethods.ProxyAdmin)
+		if err != nil {
+			return nil, fmt.Errorf("aclPolicy.allowedMethods.proxyAdmin: %w", err)
+		}
+	}
+
 	// The name is used in metrics and in the protocol for identifying the multi-client-conn. Sanitize it or else grpc.Dial will be very unhappy.
 	sanitizedConnectionName := sanitizeConnectionName(connConfig.Name)
 	cc := &ClusterConnection{
-		lifetime: lifetime,
-		loggers:  logProvider.With(tag.NewStringTag("clusterConn", sanitizedConnectionName)),
+		lifetime:         lifetime,
+		name:             connConfig.Name,
+		remoteDefinition: connConfig.Remote,
+		loggers:          logProvider.With(tag.NewStringTag("clusterConn", sanitizedConnectionName)),
 	}
-	var err error
 	cc.inboundClient, err = createClient(lifetime, sanitizedConnectionName, connConfig.Local, "inbound")
 	if err != nil {
 		return nil, err
@@ -194,9 +233,18 @@ func NewClusterConnection(lifetime context.Context, connConfig config.ClusterCon
 			CustomSearchAttributeAliases: connConfig.CustomSearchAttributeAliases,
 		},
 		// TODO: There is no test checking that ACLPolicy isn't accidentally dropped
-		aclPolicy:         connConfig.ACLPolicy,
-		shardCountConfig:  connConfig.ShardCountConfig,
-		loggers:           cc.loggers,
+		aclPolicy:        connConfig.ACLPolicy,
+		shardCountConfig: connConfig.ShardCountConfig,
+		loggers:          cc.loggers,
+		adminService:     adminService,
+		adminOptions: adminplane.ServerOptions{
+			// The far end of a mux belongs to another organization.
+			// Answers are narrowed to this one connection.
+			// Only explicitly listed methods are served.
+			Role:           adminplane.RoleCounterparty,
+			ConnectionName: connConfig.Name,
+			Methods:        counterpartyMethods,
+		},
 		shardManager:      cc.shardManager,
 		lcmParameters:     getLCMParameters(connConfig.ShardCountConfig, true),
 		routingParameters: getRoutingParameters(connConfig.ShardCountConfig, true, "inbound"),
@@ -253,6 +301,10 @@ func createServer(lifetime context.Context, c serverConfiguration) (contextAware
 		if err != nil {
 			return nil, nil, err
 		}
+
+		if c.adminService != nil {
+			proxyadminv1.RegisterProxyAdminServiceServer(grpcServer, c.adminService)
+		}
 		// The Mux manager needs to update its associated client
 		muxMgr, err := mux.NewGRPCMuxManager(lifetime, c.name, c.clusterDefinition,
 			c.managedClient.(*grpcutil.MultiClientConn), grpcServer, c.loggers.Get(LogMuxManager))
@@ -271,7 +323,11 @@ func createTCPServer(lifetime context.Context, c serverConfiguration) (contextAw
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid configuration for inbound server: %w", err)
 	}
-	// Ending the lifetime releases the port.
+	// The socket is bound here, before Start.
+	// Registering the close now stops an abandoned proxy from holding the port.
+	// A proxy is abandoned when a later cluster connection fails to build.
+	// Start registers its own close.
+	// The second one is a no-op.
 	context.AfterFunc(lifetime, func() { _ = listener.Close() })
 	grpcServer, err := buildProxyServer(c, c.clusterDefinition.TcpServer.TLSConfig, observer.ReportStreamValue, lifetime)
 	if err != nil {
@@ -325,6 +381,73 @@ func (c *ClusterConnection) Start() {
 func (c *ClusterConnection) Describe() string {
 	return fmt.Sprintf("[ClusterConnection connects outbound server %s to outbound client %s, inbound server %s to inbound client %s]",
 		c.outboundServer.Describe(), c.outboundClient.Describe(), c.inboundServer.Describe(), c.inboundClient.Describe())
+}
+
+// inboundMux returns the mux manager on the inbound server, if the connection is multiplexed.
+// A TCP connection has no mux manager and reports false.
+func (c *ClusterConnection) inboundMux() (mux.MultiMuxManager, bool) {
+	muxMgr, ok := c.inboundServer.(mux.MultiMuxManager)
+	return muxMgr, ok
+}
+
+// describeAdmin reports this connection as one member's contribution to an admin response.
+//
+// memberID and version identify the reporting pod.
+// They are the same for every connection it reports.
+// They are passed in rather than looked up here.
+func (c *ClusterConnection) describeAdmin(memberID, version string) *proxyadminv1.ClusterConnection {
+	// self is true from this pod's point of view.
+	// A merge clears it on rows from other members.
+	// Only the aggregator knows which pod actually served the response.
+	member := &proxyadminv1.ClusterConnectionMember{
+		Identity: &proxyadminv1.Member{
+			Id:      memberID,
+			Self:    true,
+			Version: version,
+		},
+	}
+
+	muxMgr, multiplexed := c.inboundMux()
+	if !multiplexed {
+		// Not multiplexed.
+		// It is reported by name so that a plainly configured connection does not look absent.
+		// There is no session state to describe.
+		// The admin API does not support these connections.
+		member.State = proxyadminv1.ConnectionState_CONNECTION_STATE_UNSPECIFIED
+		return &proxyadminv1.ClusterConnection{
+			Name:    c.name,
+			State:   member.GetState(),
+			Members: []*proxyadminv1.ClusterConnectionMember{member},
+		}
+	}
+
+	counts := mux.CountSessions(muxMgr)
+	target := mux.DesiredMuxCount(c.remoteDefinition)
+	member.MuxSessionsConnected = int32(counts.Connected)
+	member.MuxSessionsTotal = int32(counts.Total)
+	member.MuxSessionsTarget = int32(target)
+	member.State = sessionState(counts, target)
+
+	return &proxyadminv1.ClusterConnection{
+		Name:                 c.name,
+		State:                member.GetState(),
+		MuxSessionsConnected: member.GetMuxSessionsConnected(),
+		MuxSessionsTotal:     member.GetMuxSessionsTotal(),
+		MuxSessionsTarget:    member.GetMuxSessionsTarget(),
+		Members:              []*proxyadminv1.ClusterConnectionMember{member},
+	}
+}
+
+// sessionState reduces one member's sessions to a state.
+//
+// Anything short of every configured session being connected is ERROR.
+// A session that never established was never added to the manager.
+// Counting only the sessions held would report a connection running at a third of its configured capacity as healthy.
+func sessionState(counts mux.SessionCounts, target int) proxyadminv1.ConnectionState {
+	if target > 0 && counts.Connected == target {
+		return proxyadminv1.ConnectionState_CONNECTION_STATE_CONNECTED
+	}
+	return proxyadminv1.ConnectionState_CONNECTION_STATE_ERROR
 }
 
 func (c *ClusterConnection) AcceptingInboundTraffic() bool {
@@ -410,6 +533,13 @@ func makeServerOptions(c serverConfiguration, tlsConfig encryption.TLSConfig) ([
 			c.aclPolicy.AllowedMethods.AdminService, c.aclPolicy.AllowedNamespaces)
 		unaryInterceptors = append(unaryInterceptors, aclInterceptor.Intercept)
 		streamInterceptors = append(streamInterceptors, aclInterceptor.StreamIntercept)
+	}
+
+	if c.adminService != nil {
+		// This server also carries replication traffic.
+		// The admin interceptors deliberately pass through any method outside the admin service.
+		unaryInterceptors = append(unaryInterceptors, adminplane.UnaryInterceptor(c.adminOptions))
+		streamInterceptors = append(streamInterceptors, adminplane.StreamInterceptor(c.adminOptions))
 	}
 
 	opts := []grpc.ServerOption{

--- a/proxy/cluster_connection_test.go
+++ b/proxy/cluster_connection_test.go
@@ -183,25 +183,25 @@ func newPairedLocalClusterConnection(t *testing.T, isMux bool, loggers logging.L
 		var localCtx context.Context
 		localCtx, cancelLocalCC = context.WithCancel(t.Context())
 		localCC, err = NewClusterConnection(localCtx, makeTCPClusterConfig("TCP-only Connection Local Proxy",
-			localFVI, remoteFVI, a.localProxyOutbound, a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound, a.remoteProxyInbound), loggers)
+			localFVI, remoteFVI, a.localProxyOutbound, a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound, a.remoteProxyInbound), nil, loggers)
 		require.NoError(t, err)
 
 		var remoteCtx context.Context
 		remoteCtx, cancelRemoteCC = context.WithCancel(t.Context())
 		remoteCC, err = NewClusterConnection(remoteCtx, makeTCPClusterConfig("TCP-only Connection Remote Proxy",
-			remoteFVI, localFVI, a.remoteProxyOutbound, a.remoteTemporalAddr, a.remoteProxyInbound, a.remoteProxyOutbound, a.localProxyInbound), loggers)
+			remoteFVI, localFVI, a.remoteProxyOutbound, a.remoteTemporalAddr, a.remoteProxyInbound, a.remoteProxyOutbound, a.localProxyInbound), nil, loggers)
 		require.NoError(t, err)
 	} else {
 		var localCtx context.Context
 		localCtx, cancelLocalCC = context.WithCancel(t.Context())
 		localCC, err = NewClusterConnection(localCtx, makeMuxClusterConfig("Mux Connection Local Establishing Proxy",
-			config.ConnTypeMuxClient, localFVI, remoteFVI, a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.remoteProxyInbound), loggers)
+			config.ConnTypeMuxClient, localFVI, remoteFVI, a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.remoteProxyInbound), nil, loggers)
 		require.NoError(t, err)
 
 		var remoteCtx context.Context
 		remoteCtx, cancelRemoteCC = context.WithCancel(t.Context())
 		remoteCC, err = NewClusterConnection(remoteCtx, makeMuxClusterConfig("Mux Connection Remote Receiving Proxy",
-			config.ConnTypeMuxServer, remoteFVI, localFVI, a.remoteProxyOutbound, a.remoteTemporalAddr, a.remoteProxyOutbound, a.remoteProxyInbound), loggers)
+			config.ConnTypeMuxServer, remoteFVI, localFVI, a.remoteProxyOutbound, a.remoteTemporalAddr, a.remoteProxyOutbound, a.remoteProxyInbound), nil, loggers)
 		require.NoError(t, err)
 	}
 	clientFromLocal, err := grpc.NewClient(a.localProxyOutbound, grpcutil.MakeDialOptions(nil, metrics.GetStandardGRPCClientInterceptor("outbound-local"))...)
@@ -275,7 +275,7 @@ func TestMuxCCFailover(t *testing.T) {
 	newConnection, err := NewClusterConnection(t.Context(),
 		makeMuxClusterConfig("newRemoteMux", config.ConnTypeMuxServer, remoteFVI, localFVI, plcc.addresses.remoteProxyOutbound,
 			plcc.addresses.remoteTemporalAddr, plcc.addresses.remoteProxyOutbound, plcc.addresses.remoteProxyInbound,
-			func(cc *config.ClusterConnConfig) { cc.Remote.MuxCount = 5 }), loggerProvider)
+			func(cc *config.ClusterConnConfig) { cc.Remote.MuxCount = 5 }), nil, loggerProvider)
 	require.NoError(t, err)
 	newConnection.Start()
 	// Wait for localCC's client retry...
@@ -304,7 +304,7 @@ func TestNewProxyReportsConfigurationErrors(t *testing.T) {
 	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
 
 	t.Run("no cluster connections", func(t *testing.T) {
-		_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{}), loggers)
+		_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{}), loggers, Identity{Version: "test", MemberID: "pod-test"})
 		require.EqualError(t, err, "cannot create proxy: clusterConnections is empty")
 	})
 
@@ -316,7 +316,7 @@ func TestNewProxyReportsConfigurationErrors(t *testing.T) {
 
 		_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
 			ClusterConnections: []config.ClusterConnConfig{broken},
-		}), loggers)
+		}), loggers, Identity{Version: "test", MemberID: "pod-test"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `cannot create cluster connection "broken"`)
 	})
@@ -334,7 +334,7 @@ func TestNewProxyReportsConfigurationErrors(t *testing.T) {
 		// listeners and the error names the field that caused it.
 		_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
 			ClusterConnections: []config.ClusterConnConfig{cc},
-		}), loggers)
+		}), loggers, Identity{Version: "test", MemberID: "pod-test"})
 		require.ErrorContains(t, err, "cannot create proxy: invalid config: ")
 		require.ErrorContains(t, err, "clusterConnections[0].encryption.default: uri: invalid key URI: vault://typo")
 	})
@@ -350,7 +350,7 @@ func TestNewProxyRejectsDuplicateClusterConnectionNames(t *testing.T) {
 
 	_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
 		ClusterConnections: []config.ClusterConnConfig{first, second},
-	}), loggers)
+	}), loggers, Identity{Version: "test", MemberID: "pod-test"})
 	require.EqualError(t, err, `cannot create proxy: duplicate cluster connection name "same"`)
 }
 
@@ -359,9 +359,11 @@ func TestTCPListenerIsReleasedWhenNeverStarted(t *testing.T) {
 	a := getDynamicPlccAddresses(t)
 
 	ctx, cancel := context.WithCancel(t.Context())
+	// nil admin service: this test is about the listener.
+	// The service is registered only on a mux server.
 	cc, err := NewClusterConnection(ctx, makeTCPClusterConfig("abandoned", localFVI, remoteFVI,
 		a.localProxyOutbound, a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound,
-		a.remoteProxyInbound), loggers)
+		a.remoteProxyInbound), nil, loggers)
 	require.NoError(t, err)
 
 	cancel() // never Started
@@ -378,4 +380,31 @@ func TestTCPListenerIsReleasedWhenNeverStarted(t *testing.T) {
 		}, 5*time.Second, 50*time.Millisecond, "listener on %s was never released", address)
 	}
 	runtime.KeepAlive(cc)
+}
+
+// By the time the duplicate is found, earlier connections have already bound listeners.
+// Their cleanup hangs off the lifetime context.
+// The failed Proxy is discarded.
+// NewProxy has to cancel that lifetime on the way out or the ports stay bound.
+func TestNewProxyErrorReleasesEarlierListeners(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+	first := makeTCPClusterConfig("first", localFVI, remoteFVI, a.localProxyOutbound,
+		a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound, a.remoteProxyInbound)
+	dup := makeTCPClusterConfig("dup", localFVI, remoteFVI, a.remoteProxyOutbound,
+		a.remoteTemporalAddr, a.remoteProxyInbound, a.remoteProxyOutbound, a.localProxyInbound)
+
+	_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
+		ClusterConnections: []config.ClusterConnConfig{first, dup, dup},
+	}), loggers, Identity{Version: "test", MemberID: "pod-test"})
+	require.Error(t, err)
+
+	require.Eventually(t, func() bool {
+		l, err := net.Listen("tcp", a.localProxyInbound)
+		if err != nil {
+			return false
+		}
+		_ = l.Close()
+		return true
+	}, 5*time.Second, 50*time.Millisecond, "the first connection's listener was never released")
 }

--- a/proxy/connection_metrics.go
+++ b/proxy/connection_metrics.go
@@ -1,0 +1,75 @@
+package proxy
+
+import (
+	"context"
+	"time"
+
+	"github.com/temporalio/s2s-proxy/metrics"
+	"github.com/temporalio/s2s-proxy/transport/mux"
+)
+
+// connectionSampleInterval is how often a connection's session states are copied into gauges.
+//
+// Sampling faster does not detect a failure faster.
+// A session is marked errored by its own health check.
+// That check pings about once a minute.
+// One minute is the floor regardless of what this is set to.
+const connectionSampleInterval = 15 * time.Second
+
+// sessionStates are pre-touched so a connection reports zero series for the states it is not in,
+// rather than the state simply being absent.
+// Same idiom as transport/mux/observer.go.
+var sessionStates = []string{
+	mux.SessionStateConnected,
+	mux.SessionStateErrored,
+	mux.SessionStateClosed,
+}
+
+// sampleMetrics keeps this connection's gauges current until lifetime ends.
+//
+// It reads mux.CountSessions, the same function describeAdmin reads.
+// The metric and the admin API cannot disagree about how many sessions are up.
+func (c *ClusterConnection) sampleMetrics(lifetime context.Context) {
+	muxMgr, multiplexed := c.inboundMux()
+	if !multiplexed {
+		// A tcp connection holds no sessions.
+		// Reporting zeros would be indistinguishable from a mux that has lost all of them.
+		return
+	}
+
+	label := sanitizeConnectionName(c.name)
+	for _, state := range sessionStates {
+		metrics.ClusterConnectionMuxSessions.WithLabelValues(label, state)
+	}
+	metrics.ClusterConnectionMuxSessionsTarget.WithLabelValues(label).
+		Set(float64(mux.DesiredMuxCount(c.remoteDefinition)))
+
+	go func() {
+		ticker := time.NewTicker(connectionSampleInterval)
+		defer ticker.Stop()
+		for {
+			// Sampled before waiting, unlike observer.go.
+			// A connection that lives less than one interval is therefore not invisible.
+			c.sampleSessions(label, muxMgr)
+			select {
+			case <-lifetime.Done():
+				metrics.ClusterConnectionMuxSessionsTarget.DeleteLabelValues(label)
+				for _, state := range sessionStates {
+					metrics.ClusterConnectionMuxSessions.DeleteLabelValues(label, state)
+				}
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+func (c *ClusterConnection) sampleSessions(label string, muxMgr mux.MultiMuxManager) {
+	counts := mux.CountSessions(muxMgr)
+	set := func(state string, value int) {
+		metrics.ClusterConnectionMuxSessions.WithLabelValues(label, state).Set(float64(value))
+	}
+	set(mux.SessionStateConnected, counts.Connected)
+	set(mux.SessionStateErrored, counts.Errored)
+	set(mux.SessionStateClosed, counts.Closed)
+}

--- a/proxy/connection_metrics_test.go
+++ b/proxy/connection_metrics_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/metrics"
+	"github.com/temporalio/s2s-proxy/transport/mux"
+	"github.com/temporalio/s2s-proxy/transport/mux/session"
+)
+
+// fakeMuxManager reports a fixed set of sessions.
+// Only GetMuxConnections is reached by mux.CountSessions.
+// The rest of MultiMuxManager is here to satisfy the interface.
+type fakeMuxManager struct {
+	mux.MultiMuxManager
+	sessions map[string]session.ManagedMuxSession
+}
+
+func (f fakeMuxManager) GetMuxConnections() map[string]session.ManagedMuxSession { return f.sessions }
+
+// fakeSession reports one state and nothing else.
+type fakeSession struct {
+	session.ManagedMuxSession
+	info *session.MuxSessionInfo
+}
+
+func (f fakeSession) State() *session.MuxSessionInfo { return f.info }
+
+func sessionsInStates(states ...session.MuxSessionState) map[string]session.ManagedMuxSession {
+	out := map[string]session.ManagedMuxSession{}
+	for i, st := range states {
+		out[string(rune('a'+i))] = fakeSession{info: &session.MuxSessionInfo{State: st}}
+	}
+	return out
+}
+
+// The sampler reads mux.CountSessions, the same function the admin API reads.
+// A divergence between the metric and the endpoint would have to be a bug in one of the two callers.
+func TestSampleSessionsReportsEveryState(t *testing.T) {
+	cases := []struct {
+		name     string
+		sessions map[string]session.ManagedMuxSession
+		want     map[string]float64
+	}{
+		{
+			name:     "all connected",
+			sessions: sessionsInStates(session.Connected, session.Connected),
+			want:     map[string]float64{"connected": 2, "error": 0, "closed": 0},
+		},
+		{
+			// The case no existing metric can express.
+			// mux_connection_active reads 1 and num_muxes_active counts the session.
+			// Both report this as healthy.
+			name:     "one of three failing its ping",
+			sessions: sessionsInStates(session.Connected, session.Connected, session.Error),
+			want:     map[string]float64{"connected": 2, "error": 1, "closed": 0},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			label := "test_" + t.Name()
+			t.Cleanup(func() {
+				for _, state := range sessionStates {
+					metrics.ClusterConnectionMuxSessions.DeleteLabelValues(label, state)
+				}
+			})
+
+			cc := &ClusterConnection{}
+			cc.sampleSessions(label, fakeMuxManager{sessions: c.sessions})
+
+			// Every pre-touched label has to be one the sampler writes.
+			// A label created at zero and never written is indistinguishable from a state that is genuinely empty.
+			require.ElementsMatch(t, sessionStates, slices.Collect(maps.Keys(c.want)))
+
+			for state, want := range c.want {
+				require.Equal(t, want, gaugeValue(t, metrics.ClusterConnectionMuxSessions.WithLabelValues(label, state)),
+					"state %q", state)
+			}
+		})
+	}
+}
+
+// The target is the denominator that makes the state breakdown alertable.
+// Sessions held says nothing on its own about how many were meant to exist.
+func TestMuxSessionTargetUsesTheConfiguredCount(t *testing.T) {
+	a := getDynamicPlccAddresses(t)
+	withCount := makeMuxClusterConfig("counted", config.ConnTypeMuxServer, localFVI, remoteFVI,
+		a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.localProxyInbound,
+		func(cc *config.ClusterConnConfig) { cc.Remote.MuxCount = 7 })
+
+	require.Equal(t, 7, mux.DesiredMuxCount(withCount.Remote))
+
+	// An unset count is the historical default rather than zero.
+	// Otherwise every existing config would report a target of none.
+	withCount.Remote.MuxCount = 0
+	require.Equal(t, 10, mux.DesiredMuxCount(withCount.Remote))
+}
+
+// gaugeValue reads a gauge without pulling in prometheus/testutil.
+// That would add a dependency for one assertion.
+func gaugeValue(t *testing.T, g prometheus.Gauge) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, g.Write(&m))
+	return m.GetGauge().GetValue()
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.temporal.io/server/common/log/tag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -146,6 +148,7 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 	}
 
 	metrics.NewProxyCount.Inc()
+	metrics.ProxyBuildInfo.WithLabelValues(identity.Version).Set(1)
 	return proxy, nil
 }
 
@@ -245,9 +248,32 @@ func (s *Proxy) startAdminServer(
 		logger.Error("Failed to listen for ProxyAdminService", tag.Address(address), tag.Error(err))
 		return
 	}
+	// Reuse the registered server metrics rather than declaring a second collector.
+	// A second grpcprom.ServerMetrics under the same namespace and subsystem panics at process start.
+	// The registry rejects a duplicate fully-qualified name, whether or not the label lists match.
+	// grpc_service already distinguishes ProxyAdminService from the replication services.
+	//
+	// The map key has to be "direction".
+	// GRPCServerMetrics was built with WithContextLabels("direction").
+	// grpcprom resolves this map by name.
+	// It substitutes an empty value for an unrecognized key rather than failing.
+	adminLabels := grpcprom.WithLabelsFromContext(func(context.Context) prometheus.Labels {
+		return prometheus.Labels{"direction": "admin_" + opts.Role.String()}
+	})
+	// Ordering matters, same convention as makeServerOptions.
+	// ChainUnaryInterceptor runs its arguments outermost first.
+	// Metrics therefore wrap adminplane.
+	// Its PermissionDenied and Unimplemented rejections land in grpc_code.
+	// Those rejections are the most useful thing this listener reports.
 	serverOpts := []grpc.ServerOption{
-		grpc.ChainUnaryInterceptor(adminplane.UnaryInterceptor(opts)),
-		grpc.ChainStreamInterceptor(adminplane.StreamInterceptor(opts)),
+		grpc.ChainUnaryInterceptor(
+			metrics.GRPCServerMetrics.UnaryServerInterceptor(adminLabels),
+			adminplane.UnaryInterceptor(opts),
+		),
+		grpc.ChainStreamInterceptor(
+			metrics.GRPCServerMetrics.StreamServerInterceptor(adminLabels),
+			adminplane.StreamInterceptor(opts),
+		),
 	}
 	if creds != nil {
 		serverOpts = append(serverOpts, grpc.Creds(creds))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2,15 +2,29 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
+	"slices"
 	"strings"
+	"time"
 
 	"go.temporal.io/server/common/log/tag"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/temporalio/s2s-proxy/adminplane"
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
 	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/encryption"
 	"github.com/temporalio/s2s-proxy/logging"
 	"github.com/temporalio/s2s-proxy/metrics"
 )
@@ -29,15 +43,49 @@ type (
 		remoteHealthCheckConfig *config.HealthCheckConfig
 		metricsConfig           *config.MetricsConfig
 		profilingConfig         *config.ProfilingConfig
+		proxyAdminConfig        config.ProxyAdminConfig
 		clusterConnections      map[migrationId]*ClusterConnection
 		localHealthCheckServer  *http.Server
 		remoteHealthCheckServer *http.Server
 		metricsServer           *http.Server
+		adminServers            []*adminplane.Server
+		adminService            proxyadminv1.ProxyAdminServiceServer
+		version                 string
+		memberID                string
+		startTime               time.Time
 		logProvider             logging.LoggerProvider
+	}
+
+	// Identity is who this process says it is in admin responses.
+	//
+	// MemberID must differ between processes.
+	// It is supplied rather than read from the shared config file.
+	// A value in that file would be identical on every replica.
+	// Deduplication by id would then collapse the whole deployment into a single member.
+	Identity struct {
+		Version  string
+		MemberID string
 	}
 )
 
-func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerProvider) (*Proxy, error) {
+// DefaultIdentity derives this process's identity from its environment.
+// $POD_NAME comes first.
+// A Kubernetes deployment can then be explicit.
+// The hostname is the fallback.
+// Inside a pod that is the pod name.
+func DefaultIdentity(version string) Identity {
+	id := Identity{Version: version}
+	if name := os.Getenv("POD_NAME"); name != "" {
+		id.MemberID = name
+		return id
+	}
+	if host, err := os.Hostname(); err == nil {
+		id.MemberID = host
+	}
+	return id
+}
+
+func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerProvider, identity Identity) (*Proxy, error) {
 	s2sConfig := configProvider.GetS2SProxyConfig()
 	if err := s2sConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("cannot create proxy: invalid config: %w", err)
@@ -49,6 +97,9 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 		cancel:             cancel,
 		clusterConnections: make(map[migrationId]*ClusterConnection, len(s2sConfig.ClusterConnections)),
 		logProvider:        logProvider,
+		version:            identity.Version,
+		memberID:           identity.MemberID,
+		startTime:          time.Now(),
 	}
 	if len(s2sConfig.ClusterConnections) == 0 {
 		cancel()
@@ -58,15 +109,28 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 		proxy.metricsConfig = s2sConfig.Metrics
 	}
 	proxy.profilingConfig = s2sConfig.ProfilingConfig
+	proxy.proxyAdminConfig = s2sConfig.ProxyAdmin
+
+	plane, err := proxy.newAdminPlane()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("cannot create proxy: %w", err)
+	}
+	proxy.adminService = NewProxyAdminServiceServer(proxy, plane)
 
 	for _, clusterCfg := range s2sConfig.ClusterConnections {
 		id := migrationId{clusterCfg.Name}
-		// Error on duplicate cluster connection names
+		// The name identifies the connection to the admin API and selects which peer a forwarded call reaches.
+		// A duplicate is not merely confusing.
+		// The second connection would take over the first one's traffic silently.
 		if _, duplicate := proxy.clusterConnections[id]; duplicate {
+			// Earlier connections have already bound listeners and dialed clients.
+			// Their cleanup hangs off the lifetime.
+			// Cancel it or the ports stay bound.
 			cancel()
 			return nil, fmt.Errorf("cannot create proxy: duplicate cluster connection name %q", clusterCfg.Name)
 		}
-		cc, err := NewClusterConnection(ctx, clusterCfg, logProvider)
+		cc, err := NewClusterConnection(ctx, clusterCfg, proxy.adminService, logProvider)
 		if err != nil {
 			cancel()
 			return nil, fmt.Errorf("cannot create cluster connection %q: %w", clusterCfg.Name, err)
@@ -84,6 +148,9 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 	metrics.NewProxyCount.Inc()
 	return proxy, nil
 }
+
+// MemberID reports how this process identifies itself in admin responses.
+func (s *Proxy) MemberID() string { return s.memberID }
 
 func (s *Proxy) startHealthCheckHandler(lifetime context.Context, healthChecker HealthChecker, cfg config.HealthCheckConfig) (*http.Server, error) {
 	if cfg.Protocol != config.HTTP {
@@ -128,6 +195,103 @@ func (s *Proxy) startPProfHTTPServer() {
 	}()
 }
 
+// startAdminServers serves ProxyAdminService on the local operator listener and, when configured,
+// on the peer listener that sibling pods use.
+//
+// The service is otherwise reachable only over a mux.
+// A plain gRPC client cannot speak that.
+//
+// Neither listener is required for the proxy to do its job.
+// A bind failure is logged and startup continues, as it does for metrics and health checks.
+func (s *Proxy) startAdminServers() {
+	if addr := s.proxyAdminConfig.ListenAddress; addr != "" {
+		// Trusted local endpoint.
+		// Reflection is registered so grpcurl works without a descriptor.
+		s.startAdminServer(LogProxyAdmin, addr, adminplane.ServerOptions{Role: adminplane.RoleOperator},
+			nil, true)
+	}
+
+	peerCfg := s.proxyAdminConfig.Peer
+	if peerCfg == nil || peerCfg.ListenAddress == "" {
+		return
+	}
+	var creds credentials.TransportCredentials
+	if peerCfg.TLS != nil && peerCfg.TLS.IsEnabled() {
+		tlsConfig, err := peerServerTLSConfig(*peerCfg.TLS)
+		if err != nil {
+			s.logProvider.Get(LogProxyAdminPeer).Error("Failed to build peer TLS config", tag.Error(err))
+			return
+		}
+		creds = credentials.NewTLS(tlsConfig)
+	}
+	// No reflection.
+	// This listener is reachable from the pod network and only ever talks to other pods of this deployment.
+	// Those pods know the schema.
+	s.startAdminServer(LogProxyAdminPeer, peerCfg.ListenAddress,
+		adminplane.ServerOptions{Role: adminplane.RolePeer}, creds, false)
+}
+
+func (s *Proxy) startAdminServer(
+	component logging.LogComponentName,
+	address string,
+	opts adminplane.ServerOptions,
+	creds credentials.TransportCredentials,
+	withReflection bool,
+) {
+	logger := s.logProvider.Get(component)
+	name := string(component)
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		logger.Error("Failed to listen for ProxyAdminService", tag.Address(address), tag.Error(err))
+		return
+	}
+	serverOpts := []grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(adminplane.UnaryInterceptor(opts)),
+		grpc.ChainStreamInterceptor(adminplane.StreamInterceptor(opts)),
+	}
+	if creds != nil {
+		serverOpts = append(serverOpts, grpc.Creds(creds))
+	}
+	grpcServer := grpc.NewServer(serverOpts...)
+	proxyadminv1.RegisterProxyAdminServiceServer(grpcServer, s.adminService)
+	if withReflection {
+		reflection.Register(grpcServer)
+	}
+	server := adminplane.NewServer(name, s.lifetime, listener, grpcServer, logger)
+	s.adminServers = append(s.adminServers, server)
+	server.Start()
+}
+
+// peerServerTLSConfig builds the peer listener's TLS config.
+//
+// encryption.GetServerTLSConfig is deliberately not reused.
+// It sets RequireAnyClientCert and replaces VerifyPeerCertificate with a function that logs the subject and returns nil.
+// The client chain is never checked.
+//
+// That is acceptable where TLS is only providing encryption.
+// This listener is bound to the pod network.
+// The certificate is the only thing distinguishing a sibling pod from anything else that can reach it.
+func peerServerTLSConfig(cfg encryption.TLSConfig) (*tls.Config, error) {
+	certificate, err := tls.LoadX509KeyPair(cfg.CertificatePath, cfg.KeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading peer key pair: %w", err)
+	}
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{certificate},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if cfg.RemoteCAPath == "" {
+		return nil, errors.New("peer tls requires remoteCAPath to verify sibling certificates")
+	}
+	pool, err := encryption.LoadCACert(cfg.RemoteCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading peer CA: %w", err)
+	}
+	tlsConfig.ClientCAs = pool
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	return tlsConfig, nil
+}
+
 func (s *Proxy) startMetricsHandler(lifetime context.Context, cfg config.MetricsConfig) error {
 	// Why not use the global ServeMux? So that it can be used in unit tests
 	mux := http.NewServeMux()
@@ -147,6 +311,86 @@ func (s *Proxy) startMetricsHandler(lifetime context.Context, cfg config.Metrics
 		_ = s.metricsServer.Close()
 	})
 	return nil
+}
+
+// SelfClusterConnections describes this process alone.
+// It reports every cluster connection this process is configured with, as one member's contribution to a deployment-wide answer.
+func (s *Proxy) SelfClusterConnections(context.Context) *proxyadminv1.DescribeClusterConnectionsResponse {
+	resp := &proxyadminv1.DescribeClusterConnectionsResponse{}
+	startTime := timestamppb.New(s.startTime)
+	for _, cc := range s.clusterConnections {
+		described := cc.describeAdmin(s.memberID, s.version)
+		for _, m := range described.GetMembers() {
+			m.GetIdentity().StartTime = startTime
+		}
+		resp.ClusterConnections = append(resp.ClusterConnections, described)
+	}
+	// Sorted so repeated calls return the same order.
+	slices.SortFunc(resp.ClusterConnections, func(a, b *proxyadminv1.ClusterConnection) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+	return resp
+}
+
+// PeerConn returns a client for the peer proxy of a named cluster connection.
+//
+// The two failure modes are distinguished because they mean different things to whoever is debugging.
+// An unknown name is a typo.
+// A known name that cannot carry a call is a link that is down.
+//
+// Reporting a down link immediately also avoids spending the whole forward budget on a resolver that will never produce an address.
+func (s *Proxy) PeerConn(name string) (grpc.ClientConnInterface, error) {
+	cc, ok := s.clusterConnections[migrationId{name}]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "unknown cluster connection %q", name)
+	}
+	if _, multiplexed := cc.inboundMux(); !multiplexed {
+		// The admin service is only registered on a mux server.
+		// Forwarding over a TCP connection would reach a server that never registered it and return a bare Unimplemented.
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"cluster connection %q is not multiplexed", name)
+	}
+	if !cc.outboundClient.CanMakeCalls() {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"cluster connection %q has no established mux session", name)
+	}
+	return cc.outboundClient, nil
+}
+
+// newAdminPlane assembles the discovery and dialing an admin endpoint needs to answer for the whole deployment.
+// Peer discovery is optional.
+// Without it a proxy only ever describes itself.
+func (s *Proxy) newAdminPlane() (*adminplane.Plane, error) {
+	plane := &adminplane.Plane{
+		Peers:     s,
+		MemberID:  s.memberID,
+		Discovery: adminplane.NoDiscovery(),
+	}
+
+	peerCfg := s.proxyAdminConfig.Peer
+	if peerCfg == nil {
+		return plane, nil
+	}
+
+	discovery, err := adminplane.NewDiscovery(peerCfg.Discovery, peerCfg.PeerPort())
+	if err != nil {
+		return nil, err
+	}
+	plane.Discovery = discovery
+
+	// Built once.
+	// GetClientTLSConfig re-reads the key pair from disk on every call.
+	var peerTLS *tls.Config
+	if peerCfg.TLS != nil && peerCfg.TLS.IsEnabled() {
+		peerTLS, err = encryption.GetClientTLSConfig(*peerCfg.TLS)
+		if err != nil {
+			return nil, fmt.Errorf("peer client TLS: %w", err)
+		}
+	}
+	plane.Dial = func(ctx context.Context, address string) (grpc.ClientConnInterface, func(), error) {
+		return adminplane.DialOnce(address, peerTLS)
+	}
+	return plane, nil
 }
 
 func (s *Proxy) Start() error {
@@ -188,6 +432,8 @@ func (s *Proxy) Start() error {
 		s.logProvider.Get("init").Warn(`Started up without metrics! Double-check the YAML config,` +
 			` it needs at least the following path: metrics.prometheus.listenAddress`)
 	}
+
+	s.startAdminServers()
 
 	for _, v := range s.clusterConnections {
 		v.Start()

--- a/proxy/proxyadmin_peer_test.go
+++ b/proxy/proxyadmin_peer_test.go
@@ -1,0 +1,300 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/s2s-proxy/adminplane"
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/logging"
+)
+
+// dynamicAddress reserves a localhost address and releases it.
+// A listener can bind it next.
+func dynamicAddress(t *testing.T) string {
+	t.Helper()
+	return getDynamicPorts(t, 1)[0]
+}
+
+// buildPeerProxyAt starts a proxy whose peer listener binds peerAddr and whose static discovery list is peers.
+// A static list keeps the group deterministic, unlike DNS in a unit test.
+func buildPeerProxyAt(t *testing.T, memberID, connName, peerAddr string, peers []string) (*Proxy, string) {
+	t.Helper()
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+	operatorAddr := dynamicAddress(t)
+
+	cfg := config.S2SProxyConfig{
+		ProxyAdmin: config.ProxyAdminConfig{
+			ListenAddress: operatorAddr,
+			Peer: &config.ProxyAdminPeerConfig{
+				ListenAddress: peerAddr,
+				Discovery: config.DiscoveryConfig{
+					Provider: config.DiscoveryStatic,
+					Static:   config.StaticDiscoveryConfig{Addresses: peers},
+				},
+			},
+		},
+		ClusterConnections: []config.ClusterConnConfig{
+			makeMuxClusterConfig(connName, config.ConnTypeMuxServer, localFVI, remoteFVI,
+				a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.localProxyInbound),
+		},
+	}
+
+	proxy, err := NewProxy(config.NewMockConfigProvider(cfg), loggers,
+		Identity{Version: "v-test", MemberID: memberID})
+	require.NoError(t, err)
+	require.NoError(t, proxy.Start())
+	t.Cleanup(proxy.Stop)
+	return proxy, operatorAddr
+}
+
+func adminClient(t *testing.T, address string) proxyadminv1.ProxyAdminServiceClient {
+	t.Helper()
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return proxyadminv1.NewProxyAdminServiceClient(conn)
+}
+
+// Two proxies discover each other and each answers for the pair.
+// A single call describes the deployment, not the pod that happened to receive it.
+func TestGroupScopeAggregatesBothMembers(t *testing.T) {
+	// Allocate the peer addresses first so each proxy can list both.
+	peerA := dynamicAddress(t)
+	peerB := dynamicAddress(t)
+	peers := []string{peerA, peerB}
+
+	proxyA, operatorA := buildPeerProxyAt(t, "pod-a", "conn-a", peerA, peers)
+	proxyB, _ := buildPeerProxyAt(t, "pod-b", "conn-b", peerB, peers)
+
+	client := adminClient(t, operatorA)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	var resp *proxyadminv1.DescribeClusterConnectionsResponse
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = client.DescribeClusterConnections(ctx, &proxyadminv1.DescribeClusterConnectionsRequest{})
+		return err == nil && respondingMembers(resp) == 2
+	}, 20*time.Second, 200*time.Millisecond, "the two members never both answered")
+
+	// The answering member names itself.
+	// The other member is not lost.
+	// Both proxies dial every address, their own included.
+	// This also proves self is deduplicated by id rather than counted twice.
+	require.Equal(t, proxyA.MemberID(), selfMemberID(resp))
+	require.NotEqual(t, proxyA.MemberID(), proxyB.MemberID())
+	require.Equal(t, 1, selfRows(resp), "exactly one row per connection is self")
+
+	// The union of both members' connections, each reported by both members.
+	names := map[string]int{}
+	for _, cc := range resp.GetClusterConnections() {
+		names[cc.GetName()] = len(cc.GetMembers())
+	}
+	require.Equal(t, map[string]int{"conn-a": 2, "conn-b": 2}, names,
+		"each connection should list every responding member, including the one that lacks it")
+}
+
+// A member scoped call answers for one process.
+// It never fans out and carries no roster.
+func TestMemberScopeDoesNotFanOut(t *testing.T) {
+	peerA := dynamicAddress(t)
+	_, operatorA := buildPeerProxyAt(t, "pod-a", "conn-a", peerA, []string{peerA})
+
+	client := adminClient(t, operatorA)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	resp, err := client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDScope, "member"),
+		&proxyadminv1.DescribeClusterConnectionsRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetClusterConnections(), 1)
+	require.Len(t, resp.GetClusterConnections()[0].GetMembers(), 1)
+}
+
+// A discovered member that is not listening leaves no row of its own.
+// It reported nothing.
+// There is nothing to report it in.
+//
+// It is not necessarily visible at all.
+// The unreachable member only holds a connection that would otherwise read CONNECTED down to ERROR.
+// TestRollup covers that case.
+// This connection is a mux-server with nothing dialed in.
+// It reads ERROR either way.
+// The dead member leaves no trace.
+func TestUnreachableMemberLeavesNoRow(t *testing.T) {
+	peerA := dynamicAddress(t)
+	// Reserved and released.
+	// Nothing is listening there.
+	dead := dynamicAddress(t)
+
+	_, operatorA := buildPeerProxyAt(t, "pod-a", "conn-a", peerA, []string{peerA, dead})
+
+	client := adminClient(t, operatorA)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	var resp *proxyadminv1.DescribeClusterConnectionsResponse
+	require.Eventually(t, func() bool {
+		var err error
+		resp, err = client.DescribeClusterConnections(ctx, &proxyadminv1.DescribeClusterConnectionsRequest{})
+		return err == nil && len(resp.GetClusterConnections()) == 1
+	}, 20*time.Second, 200*time.Millisecond, "the live member never answered")
+
+	// One row, from the member that answered.
+	// Nothing anywhere names the dead one.
+	require.Len(t, resp.GetClusterConnections()[0].GetMembers(), 1)
+	require.Equal(t, "pod-a", resp.GetClusterConnections()[0].GetMembers()[0].GetIdentity().GetId())
+}
+
+// respondingMembers counts the rows in the first connection.
+// That is one row per member that answered.
+func respondingMembers(resp *proxyadminv1.DescribeClusterConnectionsResponse) int {
+	if len(resp.GetClusterConnections()) == 0 {
+		return 0
+	}
+	return len(resp.GetClusterConnections()[0].GetMembers())
+}
+
+// selfMemberID returns the id of the pod that served the response.
+func selfMemberID(resp *proxyadminv1.DescribeClusterConnectionsResponse) string {
+	for _, cc := range resp.GetClusterConnections() {
+		for _, m := range cc.GetMembers() {
+			if m.GetIdentity().GetSelf() {
+				return m.GetIdentity().GetId()
+			}
+		}
+	}
+	return ""
+}
+
+// selfRows counts the self-marked rows in one connection.
+// Exactly one member served the response.
+// A merge that forgot to clear self on the others would return more.
+func selfRows(resp *proxyadminv1.DescribeClusterConnectionsResponse) int {
+	n := 0
+	for _, m := range resp.GetClusterConnections()[0].GetMembers() {
+		if m.GetIdentity().GetSelf() {
+			n++
+		}
+	}
+	return n
+}
+
+// The peer listener exists for siblings.
+// They only ever need one process's answer.
+// Refusing to forward keeps a group call to a single round of fan-out.
+func TestPeerListenerRefusesForwarding(t *testing.T) {
+	peerA := dynamicAddress(t)
+	proxyA, _ := buildPeerProxyAt(t, "pod-a", "conn-a", peerA, []string{peerA})
+	require.NotNil(t, proxyA)
+
+	client := adminClient(t, peerA)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDTarget, "conn-a"),
+		&proxyadminv1.DescribeClusterConnectionsRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+
+	// A group scoped call is refused rather than quietly answered as a member.
+	_, err = client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDScope, "group"),
+		&proxyadminv1.DescribeClusterConnectionsRequest{})
+	require.Error(t, err)
+	require.Equal(t, codes.PermissionDenied, status.Code(err))
+}
+
+// The listeners are optional.
+// Absent configuration must produce none.
+// Asserting only that would also hold if the feature were deleted.
+// The enabled case is asserted alongside it.
+func TestAdminListenersFollowConfiguration(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	build := func(t *testing.T, admin config.ProxyAdminConfig) *Proxy {
+		t.Helper()
+		a := getDynamicPlccAddresses(t)
+		proxy, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
+			ProxyAdmin: admin,
+			ClusterConnections: []config.ClusterConnConfig{
+				makeMuxClusterConfig("conn", config.ConnTypeMuxServer, localFVI, remoteFVI,
+					a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.localProxyInbound),
+			},
+		}), loggers, Identity{Version: "v-test", MemberID: "pod-a"})
+		require.NoError(t, err)
+		require.NoError(t, proxy.Start())
+		t.Cleanup(proxy.Stop)
+		return proxy
+	}
+
+	t.Run("none when unconfigured", func(t *testing.T) {
+		require.Empty(t, build(t, config.ProxyAdminConfig{}).adminServers)
+	})
+
+	t.Run("operator only", func(t *testing.T) {
+		proxy := build(t, config.ProxyAdminConfig{ListenAddress: dynamicAddress(t)})
+		require.Len(t, proxy.adminServers, 1)
+	})
+
+	t.Run("operator and peer", func(t *testing.T) {
+		peer := dynamicAddress(t)
+		proxy := build(t, config.ProxyAdminConfig{
+			ListenAddress: dynamicAddress(t),
+			Peer:          &config.ProxyAdminPeerConfig{ListenAddress: peer},
+		})
+		require.Len(t, proxy.adminServers, 2)
+
+		// A registered listener is one that actually answers.
+		client := adminClient(t, peer)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, err := client.DescribeClusterConnections(ctx, &proxyadminv1.DescribeClusterConnectionsRequest{})
+		require.NoError(t, err)
+	})
+}
+
+// A diagnostic listener that cannot bind is unavailable, not a reason to refuse to proxy replication traffic.
+// The peer listener on a free port proves the failure was contained to one.
+func TestAdminBindFailureDoesNotStopStartup(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+
+	taken := dynamicAddress(t)
+	blocker, err := net.Listen("tcp", taken)
+	require.NoError(t, err)
+	defer func() { _ = blocker.Close() }()
+
+	peer := dynamicAddress(t)
+	proxy, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
+		ProxyAdmin: config.ProxyAdminConfig{
+			ListenAddress: taken,
+			Peer:          &config.ProxyAdminPeerConfig{ListenAddress: peer},
+		},
+		ClusterConnections: []config.ClusterConnConfig{
+			makeMuxClusterConfig("conn", config.ConnTypeMuxServer, localFVI, remoteFVI,
+				a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.localProxyInbound),
+		},
+	}), loggers, Identity{Version: "v-test", MemberID: "pod-a"})
+	require.NoError(t, err)
+	require.NoError(t, proxy.Start())
+	defer proxy.Stop()
+
+	require.Len(t, proxy.adminServers, 1, "the listener that could not bind is skipped, the other still starts")
+	require.True(t, proxy.clusterConnections[migrationId{"conn"}].AcceptingInboundTraffic(),
+		"replication is unaffected by a diagnostic listener failing to bind")
+}

--- a/proxy/proxyadmin_tls_test.go
+++ b/proxy/proxyadmin_tls_test.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/encryption"
+	"github.com/temporalio/s2s-proxy/logging"
+)
+
+const peerSAN = "s2s-proxy-peers"
+
+// peerServerTLSConfig exists because encryption.GetServerTLSConfig never checks the client chain.
+// That function sets RequireAnyClientCert and replaces VerifyPeerCertificate with one that logs the subject and returns nil.
+// This asserts the difference: a certificate from another CA is refused.
+func TestPeerListenerRejectsACertificateFromAnotherCA(t *testing.T) {
+	ours := newTestCA(t, "ours")
+	theirs := newTestCA(t, "theirs")
+
+	serverCert, serverKey := ours.issue(t, "server", peerSAN)
+	peerTLS := encryption.TLSConfig{
+		CertificatePath: serverCert,
+		KeyPath:         serverKey,
+		RemoteCAPath:    ours.certPath,
+		CAServerName:    peerSAN,
+	}
+
+	built, err := peerServerTLSConfig(peerTLS)
+	require.NoError(t, err)
+	require.Equal(t, tls.RequireAndVerifyClientCert, built.ClientAuth,
+		"anything weaker accepts a certificate without checking who signed it")
+	require.Nil(t, built.VerifyPeerCertificate,
+		"an override here would replace Go's chain verification with whatever it returns")
+
+	address := startPeerTLSServer(t, peerTLS)
+
+	t.Run("a peer signed by our CA is accepted", func(t *testing.T) {
+		cert, key := ours.issue(t, "sibling", peerSAN)
+		require.NoError(t, callPeer(t, address, ours.certPath, cert, key))
+	})
+
+	t.Run("a peer signed by another CA is refused", func(t *testing.T) {
+		cert, key := theirs.issue(t, "stranger", peerSAN)
+		// The stranger still trusts this server.
+		// The failure is the server rejecting the client rather than the client rejecting the server.
+		err := callPeer(t, address, ours.certPath, cert, key)
+		require.Error(t, err)
+	})
+
+	t.Run("a peer presenting no certificate is refused", func(t *testing.T) {
+		require.Error(t, callPeer(t, address, ours.certPath, "", ""))
+	})
+}
+
+// startPeerTLSServer brings up a proxy whose peer listener uses tlsCfg, through the real config path.
+// peerServerTLSConfig is therefore the code under test rather than a hand-built tls.Config.
+func startPeerTLSServer(t *testing.T, tlsCfg encryption.TLSConfig) string {
+	t.Helper()
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+	address := dynamicAddress(t)
+
+	proxy, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
+		ProxyAdmin: config.ProxyAdminConfig{
+			Peer: &config.ProxyAdminPeerConfig{ListenAddress: address, TLS: &tlsCfg},
+		},
+		ClusterConnections: []config.ClusterConnConfig{
+			makeMuxClusterConfig("conn", config.ConnTypeMuxServer, localFVI, remoteFVI,
+				a.localProxyOutbound, a.localTemporalAddr, a.localProxyOutbound, a.localProxyInbound),
+		},
+	}), loggers, Identity{Version: "v-test", MemberID: "pod-a"})
+	require.NoError(t, err)
+	require.NoError(t, proxy.Start())
+	t.Cleanup(proxy.Stop)
+	require.Len(t, proxy.adminServers, 1, "the peer listener must be up for this to test anything")
+	return address
+}
+
+// callPeer dials the peer listener and makes one call.
+// An empty certPath sends no client certificate at all.
+func callPeer(t *testing.T, address, caPath, certPath, keyPath string) error {
+	t.Helper()
+	pool, err := encryption.LoadCACert(caPath)
+	require.NoError(t, err)
+
+	clientTLS := &tls.Config{RootCAs: pool, ServerName: peerSAN, MinVersion: tls.VersionTLS12}
+	if certPath != "" {
+		pair, err := tls.LoadX509KeyPair(certPath, keyPath)
+		require.NoError(t, err)
+		clientTLS.Certificates = []tls.Certificate{pair}
+	}
+
+	conn, err := grpc.NewClient(address, grpc.WithTransportCredentials(credentials.NewTLS(clientTLS)))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_, err = proxyadminv1.NewProxyAdminServiceClient(conn).
+		DescribeClusterConnections(ctx, &proxyadminv1.DescribeClusterConnectionsRequest{})
+	return err
+}

--- a/proxy/proxyadminservice.go
+++ b/proxy/proxyadminservice.go
@@ -1,0 +1,265 @@
+package proxy
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"google.golang.org/grpc"
+
+	"github.com/temporalio/s2s-proxy/adminplane"
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+)
+
+// adminSelfDescriber produces this process's own view of its cluster connections.
+type adminSelfDescriber interface {
+	SelfClusterConnections(ctx context.Context) *proxyadminv1.DescribeClusterConnectionsResponse
+}
+
+type proxyAdminServiceServer struct {
+	proxyadminv1.UnimplementedProxyAdminServiceServer
+	self  adminSelfDescriber
+	plane *adminplane.Plane
+}
+
+// NewProxyAdminServiceServer builds the admin service.
+// One instance serves every listener.
+// What differs between them is the ServerOptions their interceptor applies.
+func NewProxyAdminServiceServer(self adminSelfDescriber, plane *adminplane.Plane) proxyadminv1.ProxyAdminServiceServer {
+	return &proxyAdminServiceServer{self: self, plane: plane}
+}
+
+type (
+	describeRequest  = *proxyadminv1.DescribeClusterConnectionsRequest
+	describeResponse = *proxyadminv1.DescribeClusterConnectionsResponse
+)
+
+func (s *proxyAdminServiceServer) DescribeClusterConnections(
+	ctx context.Context, req describeRequest,
+) (describeResponse, error) {
+	return adminplane.Serve(ctx, s.plane, req, adminplane.Handlers[describeRequest, describeResponse]{
+		Self: func(ctx context.Context, _ describeRequest) describeResponse {
+			return s.self.SelfClusterConnections(ctx)
+		},
+		Call: func(ctx context.Context, cc grpc.ClientConnInterface, req describeRequest) (describeResponse, error) {
+			return proxyadminv1.NewProxyAdminServiceClient(cc).DescribeClusterConnections(ctx, req)
+		},
+		Merge: mergeDescribeClusterConnections,
+		View:  viewDescribeClusterConnections,
+		ID:    func(resp describeResponse) string { return selfIdentity(resp).GetId() },
+	})
+}
+
+// viewDescribeClusterConnections narrows a response to what the receiving listener may see.
+//
+// A counterparty is another organization reached over a mux.
+// It gets the state of the link it holds the other end of.
+// Nothing else.
+//
+// The response is built field by field rather than by deleting fields.
+// A field added to the proto later is not served across an organizational boundary until someone adds it here.
+//
+// Two things are withheld deliberately:
+//
+//   - This deployment's shape. The per-pod rows in Members carry pod ids, addresses and versions,
+//     and how many rows there are is this deployment's replica count.
+//   - Every other cluster connection. Each belongs to a different migration.
+func viewDescribeClusterConnections(resp describeResponse, opts adminplane.ServerOptions) describeResponse {
+	if opts.Role != adminplane.RoleCounterparty || resp == nil {
+		return resp
+	}
+	out := &proxyadminv1.DescribeClusterConnectionsResponse{}
+	for _, cc := range resp.GetClusterConnections() {
+		if cc.GetName() != opts.ConnectionName {
+			continue
+		}
+		out.ClusterConnections = append(out.ClusterConnections, &proxyadminv1.ClusterConnection{
+			Name:                 cc.GetName(),
+			State:                cc.GetState(),
+			MuxSessionsConnected: cc.GetMuxSessionsConnected(),
+			MuxSessionsTotal:     cc.GetMuxSessionsTotal(),
+			MuxSessionsTarget:    cc.GetMuxSessionsTarget(),
+		})
+	}
+	return out
+}
+
+// mergeDescribeClusterConnections folds the members' answers into one deployment-wide answer.
+func mergeDescribeClusterConnections(
+	self adminplane.Result[describeResponse],
+	members []adminplane.Result[describeResponse],
+	roster adminplane.Roster,
+) describeResponse {
+	all := make([]adminplane.Result[describeResponse], 0, len(members)+1)
+	all = append(all, self)
+	all = append(all, members...)
+
+	out := &proxyadminv1.DescribeClusterConnectionsResponse{}
+
+	// Iterate the union of names, not just this member's.
+	// A member missing a connection another member has is the half-applied configuration this endpoint exists to surface.
+	// Intersecting would hide it.
+	for _, name := range unionOfConnectionNames(all) {
+		out.ClusterConnections = append(out.ClusterConnections, mergeConnection(name, all, roster))
+	}
+	return out
+}
+
+func unionOfConnectionNames(all []adminplane.Result[describeResponse]) []string {
+	seen := map[string]struct{}{}
+	var names []string
+	for _, r := range all {
+		for _, cc := range r.Value.GetClusterConnections() {
+			if _, ok := seen[cc.GetName()]; ok {
+				continue
+			}
+			seen[cc.GetName()] = struct{}{}
+			names = append(names, cc.GetName())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func mergeConnection(
+	name string, all []adminplane.Result[describeResponse], roster adminplane.Roster,
+) *proxyadminv1.ClusterConnection {
+	merged := &proxyadminv1.ClusterConnection{Name: name}
+
+	var states []proxyadminv1.ConnectionState
+
+	// all[0] is this process's own answer.
+	// Every other element came from a member this process dialed.
+	for i, r := range all {
+		src := memberEntry(name, r)
+
+		// Built field by field rather than mutated.
+		// src points into the member's own answer.
+		// Later connections read that answer again.
+		//
+		// The reporting pod set self on its own row.
+		// Only the aggregator knows which pod served this response.
+		// Only the aggregator knows what address each member was reached at.
+		srcID := src.GetIdentity()
+		entry := &proxyadminv1.ClusterConnectionMember{
+			Identity: &proxyadminv1.Member{
+				Id:        srcID.GetId(),
+				Self:      i == 0,
+				Address:   r.Address,
+				Version:   srcID.GetVersion(),
+				StartTime: srcID.GetStartTime(),
+			},
+			State:                src.GetState(),
+			MuxSessionsConnected: src.GetMuxSessionsConnected(),
+			MuxSessionsTotal:     src.GetMuxSessionsTotal(),
+			MuxSessionsTarget:    src.GetMuxSessionsTarget(),
+		}
+
+		merged.Members = append(merged.Members, entry)
+		states = append(states, entry.GetState())
+
+		merged.MuxSessionsConnected += entry.GetMuxSessionsConnected()
+		merged.MuxSessionsTotal += entry.GetMuxSessionsTotal()
+		merged.MuxSessionsTarget += entry.GetMuxSessionsTarget()
+	}
+
+	sortMembers(merged.Members)
+	merged.State = rollup(states, len(roster.Unreachable) > 0)
+	return merged
+}
+
+// selfIdentity returns the identity a response's own pod reported for itself.
+func selfIdentity(resp describeResponse) *proxyadminv1.Member {
+	for _, cc := range resp.GetClusterConnections() {
+		for _, m := range cc.GetMembers() {
+			if m.GetIdentity().GetSelf() {
+				return m.GetIdentity()
+			}
+		}
+	}
+	return nil
+}
+
+// memberEntry finds one member's entry for a connection.
+// It synthesizes an errored entry when that member does not have the connection at all.
+func memberEntry(name string, r adminplane.Result[describeResponse]) *proxyadminv1.ClusterConnectionMember {
+	for _, cc := range r.Value.GetClusterConnections() {
+		if cc.GetName() != name {
+			continue
+		}
+		// A member-scoped response carries exactly one entry: the responder itself.
+		if entries := cc.GetMembers(); len(entries) > 0 {
+			return entries[0]
+		}
+	}
+	// The member answered, it just has no connection by this name.
+	// Its identity is carried across from whichever connection it did report.
+	// The row still names the pod that disagrees.
+	//
+	// MuxSessionsTarget stays zero.
+	// That is what separates this row from a member that has the connection and cannot hold it.
+	identity := selfIdentity(r.Value)
+	return &proxyadminv1.ClusterConnectionMember{
+		Identity: &proxyadminv1.Member{
+			Id:      identity.GetId(),
+			Version: identity.GetVersion(),
+		},
+		State: proxyadminv1.ConnectionState_CONNECTION_STATE_ERROR,
+	}
+}
+
+// rollup reduces member states to one.
+//
+// Anything other than every member reporting CONNECTED is ERROR.
+//
+// Three conditions are what aggregating exists to surface:
+//
+//   - a member that is degraded
+//   - a member that does not have this connection at all
+//   - a member that never answered
+//
+// None of them can be rolled up to anything healthier.
+//
+// anyUnreachable is read separately because a member that never replied contributes no state at all.
+// Without it a deployment with a dead pod would report exactly the same as a healthy one.
+func rollup(states []proxyadminv1.ConnectionState, anyUnreachable bool) proxyadminv1.ConnectionState {
+	const (
+		unspecified = proxyadminv1.ConnectionState_CONNECTION_STATE_UNSPECIFIED
+		connected   = proxyadminv1.ConnectionState_CONNECTION_STATE_CONNECTED
+		errored     = proxyadminv1.ConnectionState_CONNECTION_STATE_ERROR
+	)
+
+	var counted int
+	for _, s := range states {
+		if s == unspecified {
+			// A connection that is not multiplexed.
+			// It has no session state to contribute.
+			continue
+		}
+		counted++
+		if s != connected {
+			return errored
+		}
+	}
+
+	switch {
+	case counted == 0:
+		return unspecified
+	case anyUnreachable:
+		return errored
+	default:
+		return connected
+	}
+}
+
+// sortMembers orders members by id so repeated calls return the same list.
+// Members that did not report an id sort last.
+func sortMembers(members []*proxyadminv1.ClusterConnectionMember) {
+	sort.SliceStable(members, func(i, j int) bool {
+		a, b := members[i].GetIdentity().GetId(), members[j].GetIdentity().GetId()
+		if (a == "") != (b == "") {
+			return b == ""
+		}
+		return strings.Compare(a, b) < 0
+	})
+}

--- a/proxy/proxyadminservice_test.go
+++ b/proxy/proxyadminservice_test.go
@@ -1,0 +1,297 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/s2s-proxy/adminplane"
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+	"github.com/temporalio/s2s-proxy/transport/mux"
+)
+
+const (
+	stateConnected   = proxyadminv1.ConnectionState_CONNECTION_STATE_CONNECTED
+	stateError       = proxyadminv1.ConnectionState_CONNECTION_STATE_ERROR
+	stateUnspecified = proxyadminv1.ConnectionState_CONNECTION_STATE_UNSPECIFIED
+)
+
+type memberConn struct {
+	name                     string
+	state                    proxyadminv1.ConnectionState
+	connected, total, target int32
+}
+
+// memberResponse builds one member's member-scoped answer.
+func memberResponse(id, version string, conns ...memberConn) *proxyadminv1.DescribeClusterConnectionsResponse {
+	resp := &proxyadminv1.DescribeClusterConnectionsResponse{}
+	for _, c := range conns {
+		member := &proxyadminv1.ClusterConnectionMember{
+			// Every pod marks its own row. The merge decides which one survives as self.
+			Identity:             &proxyadminv1.Member{Id: id, Self: true, Version: version},
+			State:                c.state,
+			MuxSessionsConnected: c.connected,
+			MuxSessionsTotal:     c.total,
+			MuxSessionsTarget:    c.target,
+		}
+		resp.ClusterConnections = append(resp.ClusterConnections, &proxyadminv1.ClusterConnection{
+			Name:                 c.name,
+			State:                c.state,
+			MuxSessionsConnected: c.connected,
+			MuxSessionsTotal:     c.total,
+			MuxSessionsTarget:    c.target,
+			Members:              []*proxyadminv1.ClusterConnectionMember{member},
+		})
+	}
+	return resp
+}
+
+func result(resp *proxyadminv1.DescribeClusterConnectionsResponse) adminplane.Result[describeResponse] {
+	return adminplane.Result[describeResponse]{ID: selfIdentity(resp).GetId(), Value: resp}
+}
+
+func memberByID(t *testing.T, cc *proxyadminv1.ClusterConnection, id string) *proxyadminv1.ClusterConnectionMember {
+	t.Helper()
+	for _, m := range cc.GetMembers() {
+		if m.GetIdentity().GetId() == id {
+			return m
+		}
+	}
+	t.Fatalf("no member %q in %v", id, cc)
+	return nil
+}
+
+func connectionByName(t *testing.T, resp *proxyadminv1.DescribeClusterConnectionsResponse, name string) *proxyadminv1.ClusterConnection {
+	t.Helper()
+	for _, cc := range resp.GetClusterConnections() {
+		if cc.GetName() == name {
+			return cc
+		}
+	}
+	t.Fatalf("no cluster connection named %q in %v", name, resp)
+	return nil
+}
+
+func TestMergeSumsSessionsAcrossMembers(t *testing.T) {
+	self := result(memberResponse("pod-a", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 7, total: 7, target: 7}))
+	peer := result(memberResponse("pod-b", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 6, total: 6, target: 6}))
+
+	merged := mergeDescribeClusterConnections(self, []adminplane.Result[describeResponse]{peer},
+		adminplane.Roster{Provider: "static", Discovered: 2, Responding: 2})
+
+	cc := connectionByName(t, merged, "cluster-b")
+	require.Equal(t, stateConnected, cc.GetState())
+	require.Equal(t, int32(13), cc.GetMuxSessionsConnected())
+	require.Equal(t, int32(13), cc.GetMuxSessionsTotal())
+	require.Equal(t, int32(13), cc.GetMuxSessionsTarget())
+	require.Len(t, cc.GetMembers(), 2)
+	require.Equal(t, "v1", memberByID(t, cc, "pod-a").GetIdentity().GetVersion())
+}
+
+// A member that is missing a connection another member has is a half-applied configuration, which
+// is precisely what an aggregated view exists to reveal. Intersecting the names would hide it.
+func TestMergeReportsConnectionMissingFromOneMember(t *testing.T) {
+	self := result(memberResponse("pod-a", "v1",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 4, total: 4, target: 4},
+		memberConn{name: "cluster-c", state: stateConnected, connected: 4, total: 4, target: 4}))
+	peer := result(memberResponse("pod-b", "v1",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 4, total: 4, target: 4}))
+
+	merged := mergeDescribeClusterConnections(self, []adminplane.Result[describeResponse]{peer},
+		adminplane.Roster{Provider: "static", Discovered: 2, Responding: 2})
+
+	clusterC := connectionByName(t, merged, "cluster-c")
+	require.Equal(t, stateError, clusterC.GetState())
+	require.Len(t, clusterC.GetMembers(), 2)
+
+	absent := memberByID(t, clusterC, "pod-b")
+	require.Equal(t, stateError, absent.GetState())
+	// A target of zero separates a member that lacks the connection from one that has it and cannot hold a session.
+	require.Zero(t, absent.GetMuxSessionsTarget())
+	require.Equal(t, int32(4), clusterC.GetMuxSessionsConnected(), "the absent member contributes no sessions")
+	require.Equal(t, int32(4), clusterC.GetMuxSessionsTarget())
+}
+
+// A member that never answered is absent from members[].
+// Without an explicit rule the remaining members would make the deployment look entirely healthy.
+func TestMergeUnreachableMemberErrorsEveryConnection(t *testing.T) {
+	self := result(memberResponse("pod-a", "v1",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 7, total: 7, target: 7},
+		memberConn{name: "cluster-c", state: stateConnected, connected: 7, total: 7, target: 7}))
+
+	merged := mergeDescribeClusterConnections(self, nil, adminplane.Roster{
+		Provider: "dns", Discovered: 2, Responding: 1,
+		Unreachable: []adminplane.Unreachable{{Address: "10.0.0.9:9234", Message: "connection refused", Code: 14}},
+	})
+
+	// The member that failed to answer has no row: it reported nothing to put in one.
+	// Erroring every connection is the only trace it leaves.
+	require.Len(t, merged.GetClusterConnections(), 2)
+	for _, cc := range merged.GetClusterConnections() {
+		require.Equal(t, stateError, cc.GetState())
+		require.Len(t, cc.GetMembers(), 1)
+	}
+}
+
+func TestMergeReportsVersionSkewPerMember(t *testing.T) {
+	self := result(memberResponse("pod-a", "v1.4.2",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 7, total: 7, target: 7}))
+	peer := result(memberResponse("pod-b", "v1.4.1",
+		memberConn{name: "cluster-b", state: stateError, total: 7, target: 7}))
+
+	merged := mergeDescribeClusterConnections(self, []adminplane.Result[describeResponse]{peer},
+		adminplane.Roster{Provider: "dns", Discovered: 2, Responding: 2})
+
+	cc := connectionByName(t, merged, "cluster-b")
+	require.Equal(t, "v1.4.2", memberByID(t, cc, "pod-a").GetIdentity().GetVersion())
+	require.Equal(t, "v1.4.1", memberByID(t, cc, "pod-b").GetIdentity().GetVersion())
+	require.Equal(t, stateError, cc.GetState(), "one member connected and one errored is not connected")
+}
+
+// Only the aggregator knows which pod served the response.
+// Every reporting pod's own claim to self has to be cleared except the one that answered.
+func TestMergeMarksOnlyTheRespondingPodAsSelf(t *testing.T) {
+	self := result(memberResponse("pod-a", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1}))
+	peer := result(memberResponse("pod-b", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1}))
+
+	merged := mergeDescribeClusterConnections(self, []adminplane.Result[describeResponse]{peer},
+		adminplane.Roster{Provider: "static", Discovered: 2, Responding: 2})
+
+	cc := connectionByName(t, merged, "cluster-b")
+	require.True(t, memberByID(t, cc, "pod-a").GetIdentity().GetSelf())
+	require.False(t, memberByID(t, cc, "pod-b").GetIdentity().GetSelf())
+}
+
+// Not-multiplexed connections carry no session state.
+// They must not drag the rollup to ERROR.
+func TestMergeAllUnspecifiedStaysUnspecified(t *testing.T) {
+	self := result(memberResponse("pod-a", "v1", memberConn{name: "tcp-conn", state: stateUnspecified}))
+	peer := result(memberResponse("pod-b", "v1", memberConn{name: "tcp-conn", state: stateUnspecified}))
+
+	merged := mergeDescribeClusterConnections(self, []adminplane.Result[describeResponse]{peer},
+		adminplane.Roster{Provider: "static", Discovered: 2, Responding: 2})
+
+	require.Equal(t, stateUnspecified, connectionByName(t, merged, "tcp-conn").GetState())
+}
+
+func TestMergeSortsMembersById(t *testing.T) {
+	self := result(memberResponse("pod-z", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1}))
+	peers := []adminplane.Result[describeResponse]{
+		result(memberResponse("pod-m", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1})),
+		result(memberResponse("pod-a", "v1", memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1})),
+	}
+
+	merged := mergeDescribeClusterConnections(self, peers,
+		adminplane.Roster{Provider: "static", Discovered: 3, Responding: 3})
+
+	var ids []string
+	for _, m := range connectionByName(t, merged, "cluster-b").GetMembers() {
+		ids = append(ids, m.GetIdentity().GetId())
+	}
+	require.Equal(t, []string{"pod-a", "pod-m", "pod-z"}, ids)
+}
+
+func TestViewNarrowsToTheArrivingConnectionForACounterparty(t *testing.T) {
+	resp := memberResponse("pod-a", "v1",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1},
+		memberConn{name: "cluster-c", state: stateConnected, connected: 1, total: 1, target: 1})
+	narrowed := viewDescribeClusterConnections(resp,
+		adminplane.ServerOptions{Role: adminplane.RoleCounterparty, ConnectionName: "cluster-b"})
+
+	require.Len(t, narrowed.GetClusterConnections(), 1)
+	cc := narrowed.GetClusterConnections()[0]
+	require.Equal(t, "cluster-b", cc.GetName())
+	require.Equal(t, stateConnected, cc.GetState())
+	require.Equal(t, int32(1), cc.GetMuxSessionsConnected())
+	// Sessions connected reads as healthy on its own. The target is what makes it alertable.
+	require.Equal(t, int32(1), cc.GetMuxSessionsTarget())
+
+	// This deployment's shape does not cross the boundary.
+	// Pod ids, addresses and versions say where this deployment's pods are.
+	// How many rows there are says how many it runs.
+	require.Empty(t, cc.GetMembers(), "per-pod detail names our pods")
+}
+
+// The response is built field by field.
+// A name that matches nothing yields an empty answer rather than the whole thing.
+func TestViewYieldsNothingWhenTheConnectionNameMatchesNothing(t *testing.T) {
+	resp := memberResponse("pod-a", "v1",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1})
+
+	narrowed := viewDescribeClusterConnections(resp,
+		adminplane.ServerOptions{Role: adminplane.RoleCounterparty, ConnectionName: "cluster-z"})
+
+	require.Empty(t, narrowed.GetClusterConnections())
+}
+
+func TestViewLeavesOperatorResponsesIntact(t *testing.T) {
+	resp := memberResponse("pod-a", "v1",
+		memberConn{name: "cluster-b", state: stateConnected, connected: 1, total: 1, target: 1},
+		memberConn{name: "cluster-c", state: stateConnected, connected: 1, total: 1, target: 1})
+
+	kept := viewDescribeClusterConnections(resp, adminplane.ServerOptions{Role: adminplane.RoleOperator})
+
+	require.Len(t, kept.GetClusterConnections(), 2)
+	require.Len(t, kept.GetClusterConnections()[0].GetMembers(), 1)
+}
+
+func TestSessionState(t *testing.T) {
+	cases := []struct {
+		name   string
+		counts mux.SessionCounts
+		target int
+		want   proxyadminv1.ConnectionState
+	}{
+		{name: "every configured session connected", counts: mux.SessionCounts{Connected: 10, Total: 10}, target: 10, want: stateConnected},
+		// A session that never established was never added to the manager.
+		// The sessions held read as fully connected on their own.
+		{name: "fewer sessions held than configured", counts: mux.SessionCounts{Connected: 3, Total: 3}, target: 10, want: stateError},
+		{name: "partially connected", counts: mux.SessionCounts{Connected: 1, Total: 10}, target: 10, want: stateError},
+		{name: "no sessions", counts: mux.SessionCounts{}, target: 10, want: stateError},
+		{name: "errored only", counts: mux.SessionCounts{Errored: 3, Total: 3}, target: 3, want: stateError},
+		{name: "closed only", counts: mux.SessionCounts{Closed: 3, Total: 3}, target: 3, want: stateError},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, sessionState(c.counts, c.target))
+		})
+	}
+}
+
+// rollup is the group-scope answer.
+// Group is the default scope.
+// A state it cannot represent is the state most callers will read.
+func TestRollup(t *testing.T) {
+	cases := []struct {
+		name           string
+		states         []proxyadminv1.ConnectionState
+		anyUnreachable bool
+		want           proxyadminv1.ConnectionState
+	}{
+		{name: "all connected", states: []proxyadminv1.ConnectionState{stateConnected, stateConnected}, want: stateConnected},
+		{name: "one member errored", states: []proxyadminv1.ConnectionState{stateConnected, stateError}, want: stateError},
+		{name: "all errored", states: []proxyadminv1.ConnectionState{stateError, stateError}, want: stateError},
+		// Not multiplexed: no session state to contribute.
+		{name: "all unspecified", states: []proxyadminv1.ConnectionState{stateUnspecified}, want: stateUnspecified},
+		// One connection of the two is multiplexed.
+		// It is the only one with a state to report.
+		{name: "unspecified alongside connected", states: []proxyadminv1.ConnectionState{stateUnspecified, stateConnected}, want: stateConnected},
+		{name: "unspecified alongside errored", states: []proxyadminv1.ConnectionState{stateUnspecified, stateError}, want: stateError},
+		// A member that never answered is not evidence of health.
+		{
+			name:   "connected but a member did not answer",
+			states: []proxyadminv1.ConnectionState{stateConnected}, anyUnreachable: true, want: stateError,
+		},
+		// Nothing multiplexed reported anything.
+		// An unreachable member has no state to degrade.
+		{
+			name:   "unspecified and a member did not answer",
+			states: []proxyadminv1.ConnectionState{stateUnspecified}, anyUnreachable: true, want: stateUnspecified,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, rollup(c.states, c.anyUnreachable))
+		})
+	}
+}

--- a/proxy/test/echo_proxy_test.go
+++ b/proxy/test/echo_proxy_test.go
@@ -78,6 +78,12 @@ func withACLPolicy(aclPolicy *config.ACLPolicy) cfgOption {
 	return func(c *config.S2SProxyConfig) { conn(c).ACLPolicy = aclPolicy }
 }
 
+func withProxyAdmin(address string) cfgOption {
+	return func(c *config.S2SProxyConfig) {
+		c.ProxyAdmin = config.ProxyAdminConfig{ListenAddress: address}
+	}
+}
+
 func withRemoteMuxClient(address string) cfgOption {
 	return func(c *config.S2SProxyConfig) {
 		conn(c).Remote.ConnectionType = config.ConnTypeMuxClient

--- a/proxy/test/proxyadmin_test.go
+++ b/proxy/test/proxyadmin_test.go
@@ -1,0 +1,237 @@
+package proxy
+
+import (
+	"time"
+
+	"go.temporal.io/server/common/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/temporalio/s2s-proxy/adminplane"
+	proxyadminv1 "github.com/temporalio/s2s-proxy/api/proxyadmin/v1"
+	"github.com/temporalio/s2s-proxy/endtoendtest"
+)
+
+func connectionState(desc *proxyadminv1.DescribeClusterConnectionsResponse) proxyadminv1.ConnectionState {
+	conns := desc.GetClusterConnections()
+	// there must only be a single connection - otherwise could be misleading.
+	if len(conns) != 1 {
+		return proxyadminv1.ConnectionState_CONNECTION_STATE_UNSPECIFIED
+	}
+	return conns[0].GetState()
+}
+
+// soleConnName returns "" if there is not exactly one cluster connection.
+func soleConnName(desc *proxyadminv1.DescribeClusterConnectionsResponse) string {
+	conns := desc.GetClusterConnections()
+	if len(conns) != 1 {
+		return ""
+	}
+	return conns[0].GetName()
+}
+
+func (s *proxyTestSuite) Test_SelfClusterConnections_MuxStateFlips() {
+	// echoServer dials, as the mux client.
+	// echoClient listens, as the mux server.
+	echoServerConfig := s.createEchoServerConfig(
+		withRemoteMuxClient(s.clientProxyInboundAddress),
+	)
+	echoClientConfig := s.createEchoClientConfig(
+		withRemoteMuxServer(s.clientProxyInboundAddress),
+	)
+
+	echoServerInfo := endtoendtest.ClusterInfo{
+		ServerAddress:  s.echoServerAddress,
+		ClusterShardID: serverClusterShard,
+		S2sProxyConfig: echoServerConfig,
+	}
+	echoClientInfo := endtoendtest.ClusterInfo{
+		ServerAddress:  s.echoClientAddress,
+		ClusterShardID: clientClusterShard,
+		S2sProxyConfig: echoClientConfig,
+	}
+
+	logger := log.NewTestLogger()
+	echoServer := endtoendtest.NewEchoServer(echoServerInfo, echoClientInfo, "EchoServer", logger, nil)
+	echoClient := endtoendtest.NewEchoServer(echoClientInfo, echoServerInfo, "EchoClient", logger, nil)
+
+	proxy := echoClient.Proxy
+	ctx := s.T().Context()
+
+	isConnected := func() bool {
+		return connectionState(proxy.SelfClusterConnections(ctx)) ==
+			proxyadminv1.ConnectionState_CONNECTION_STATE_CONNECTED
+	}
+
+	// connectionState assumes one connection. Assert that shape once, here.
+	s.Require().Len(proxy.SelfClusterConnections(ctx).GetClusterConnections(), 1)
+
+	// 1. Constructed, nothing started.
+	s.Equal(proxyadminv1.ConnectionState_CONNECTION_STATE_ERROR,
+		connectionState(proxy.SelfClusterConnections(ctx)))
+
+	// 2. Mux listener up. Nobody has dialed it yet.
+	echoClient.Start()
+	defer echoClient.Stop()
+
+	s.Equal(proxyadminv1.ConnectionState_CONNECTION_STATE_ERROR,
+		connectionState(proxy.SelfClusterConnections(ctx)), "no peer has dialed yet")
+
+	// 3. Peer dials in: ERROR -> CONNECTED.
+	echoServer.Start()
+	defer echoServer.Stop()
+
+	s.Eventually(isConnected, 10*time.Second, 100*time.Millisecond,
+		"state never flipped to CONNECTED")
+
+	// 4. Peer goes away: CONNECTED -> not CONNECTED.
+	echoServer.Stop()
+
+	s.Eventually(func() bool { return !isConnected() }, 10*time.Second, 100*time.Millisecond,
+		"state never flipped away from CONNECTED")
+}
+
+// Test_DescribeClusterConnections_OverLocalListener covers the operator endpoint end to end,
+// through a real listener so that the interceptor which resolves scope and target actually runs.
+//
+// echoServer's connection is named proxy1 and reaches echoClient, named proxy2. Getting "proxy2"
+// back proves the call crossed the mux and was answered by the other proxy.
+func (s *proxyTestSuite) Test_DescribeClusterConnections_OverLocalListener() {
+	adminAddress := GetLocalhostAddress()
+
+	echoServerInfo := endtoendtest.ClusterInfo{
+		ServerAddress:  s.echoServerAddress,
+		ClusterShardID: serverClusterShard,
+		S2sProxyConfig: s.createEchoServerConfig(
+			withRemoteMuxClient(s.clientProxyInboundAddress),
+			withProxyAdmin(adminAddress),
+		),
+	}
+	echoClientInfo := endtoendtest.ClusterInfo{
+		ServerAddress:  s.echoClientAddress,
+		ClusterShardID: clientClusterShard,
+		S2sProxyConfig: s.createEchoClientConfig(withRemoteMuxServer(s.clientProxyInboundAddress)),
+	}
+
+	logger := log.NewTestLogger()
+	echoServer := endtoendtest.NewEchoServer(echoServerInfo, echoClientInfo, "EchoServer", logger, nil)
+	echoClient := endtoendtest.NewEchoServer(echoClientInfo, echoServerInfo, "EchoClient", logger, nil)
+
+	echoClient.Start()
+	defer echoClient.Stop()
+	echoServer.Start()
+	defer echoServer.Stop()
+
+	conn, err := grpc.NewClient(adminAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	s.Require().NoError(err)
+	defer func() { _ = conn.Close() }()
+	client := proxyadminv1.NewProxyAdminServiceClient(conn)
+	ctx := s.T().Context()
+	empty := &proxyadminv1.DescribeClusterConnectionsRequest{}
+
+	// No target: this proxy answers for its own deployment.
+	self, err := client.DescribeClusterConnections(ctx, empty)
+	s.Require().NoError(err)
+	s.Equal("proxy1", soleConnName(self))
+	// The literal, not MemberID().
+	// MemberID() would compare the field against itself and pass whichever proxy answered.
+	s.Equal("EchoServer", selfMemberID(self), "the proxy that received the call answers for itself")
+
+	// A session that never established is not in the manager.
+	// Sessions connected reads as healthy on its own.
+	// The target is what an operator compares it against.
+	selfConn := self.GetClusterConnections()[0]
+	s.Positive(selfConn.GetMuxSessionsTarget(), "the configured session count is reported")
+	s.Equal(selfConn.GetMuxSessionsTarget(), selfConn.GetMembers()[0].GetMuxSessionsTarget())
+
+	// Member scope: the same answer, from one process.
+	member, err := client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDScope, "member"), empty)
+	s.Require().NoError(err)
+	s.Equal("proxy1", soleConnName(member))
+	s.Len(member.GetClusterConnections()[0].GetMembers(), 1, "member scope describes one process")
+
+	// Target set: the peer proxy answers, for its own deployment.
+	targeted := metadata.AppendToOutgoingContext(ctx, adminplane.MDTarget, "proxy1")
+	s.Eventually(func() bool {
+		resp, err := client.DescribeClusterConnections(targeted, empty)
+		return err == nil && soleConnName(resp) == "proxy2"
+	}, 10*time.Second, 100*time.Millisecond, "the local listener never returned the peer proxy's answer")
+
+	// An unknown target names a connection that does not exist.
+	// That is a caller mistake.
+	_, err = client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDTarget, "nope"), empty)
+	s.Require().Error(err)
+	s.Equal(codes.InvalidArgument, status.Code(err))
+
+	// An unrecognized scope is refused rather than silently answered at a narrower one.
+	// The caller could not distinguish a narrowed answer from a real one.
+	_, err = client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDScope, "galaxy"), empty)
+	s.Require().Error(err)
+	s.Equal(codes.InvalidArgument, status.Code(err))
+}
+
+// A peer cluster reaches the admin service over the mux. It must see only the connection its call
+// arrived on, never the other migrations this proxy carries.
+func (s *proxyTestSuite) Test_DescribeClusterConnections_CounterpartyIsScopedToItsConnection() {
+	echoServerInfo := endtoendtest.ClusterInfo{
+		ServerAddress:  s.echoServerAddress,
+		ClusterShardID: serverClusterShard,
+		S2sProxyConfig: s.createEchoServerConfig(withRemoteMuxClient(s.clientProxyInboundAddress)),
+	}
+	echoClientInfo := endtoendtest.ClusterInfo{
+		ServerAddress:  s.echoClientAddress,
+		ClusterShardID: clientClusterShard,
+		S2sProxyConfig: s.createEchoClientConfig(withRemoteMuxServer(s.clientProxyInboundAddress)),
+	}
+
+	logger := log.NewTestLogger()
+	echoServer := endtoendtest.NewEchoServer(echoServerInfo, echoClientInfo, "EchoServer", logger, nil)
+	echoClient := endtoendtest.NewEchoServer(echoClientInfo, echoServerInfo, "EchoClient", logger, nil)
+
+	echoClient.Start()
+	defer echoClient.Stop()
+	echoServer.Start()
+	defer echoServer.Stop()
+
+	// PeerConn reaches the far proxy's mux-registered service.
+	// That is the counterparty listener.
+	var client proxyadminv1.ProxyAdminServiceClient
+	s.Eventually(func() bool {
+		cc, err := echoServer.Proxy.PeerConn("proxy1")
+		if err != nil {
+			return false
+		}
+		client = proxyadminv1.NewProxyAdminServiceClient(cc)
+		return true
+	}, 10*time.Second, 100*time.Millisecond, "no mux session to the peer was ever established")
+
+	ctx := s.T().Context()
+	resp, err := client.DescribeClusterConnections(ctx, &proxyadminv1.DescribeClusterConnectionsRequest{})
+	s.Require().NoError(err)
+	s.Equal("proxy2", soleConnName(resp), "a counterparty sees only the connection it arrived on")
+
+	// Forwarding is refused: otherwise a peer could pivot through us into a third cluster.
+	_, err = client.DescribeClusterConnections(
+		metadata.AppendToOutgoingContext(ctx, adminplane.MDTarget, "proxy2"),
+		&proxyadminv1.DescribeClusterConnectionsRequest{})
+	s.Require().Error(err)
+	s.Equal(codes.PermissionDenied, status.Code(err))
+}
+
+// selfMemberID returns the id of the pod that served a response.
+func selfMemberID(resp *proxyadminv1.DescribeClusterConnectionsResponse) string {
+	for _, cc := range resp.GetClusterConnections() {
+		for _, m := range cc.GetMembers() {
+			if m.GetIdentity().GetSelf() {
+				return m.GetIdentity().GetId()
+			}
+		}
+	}
+	return ""
+}

--- a/proxy/test/test_common.go
+++ b/proxy/test/test_common.go
@@ -353,7 +353,7 @@ func createProxy(
 	}
 
 	configProvider := &simpleConfigProvider{cfg: *cfg}
-	proxy, err := s2sproxy.NewProxy(configProvider, logging.NewLoggerProvider(logger, configProvider))
+	proxy, err := s2sproxy.NewProxy(configProvider, logging.NewLoggerProvider(logger, configProvider), s2sproxy.Identity{Version: "test", MemberID: name})
 	if err != nil {
 		t.Fatalf("Failed to create proxy %s: %v", name, err)
 	}

--- a/proxy/testcerts_test.go
+++ b/proxy/testcerts_test.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testCA is a certificate authority and the leaves it signs, written to a temp directory.
+//
+// The committed fixtures under develop/certificates are two self-signed leaves that each trust the other directly.
+// They cannot express "signed by a different CA".
+// That distinction is the entire claim of peerServerTLSConfig.
+//
+// It lives here because proxy is its only consumer.
+type testCA struct {
+	dir      string
+	certPath string
+	keyPath  string
+	cert     *x509.Certificate
+	key      *rsa.PrivateKey
+}
+
+func newTestCA(t *testing.T, commonName string) *testCA {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	ca := &testCA{dir: t.TempDir(), cert: cert, key: key}
+	ca.certPath = writePEM(t, ca.dir, commonName+"-ca.pem", "CERTIFICATE", der)
+	ca.keyPath = writePEM(t, ca.dir, commonName+"-ca.key", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(key))
+	return ca
+}
+
+// issue returns paths to a leaf signed by this CA, with dnsName as its only SAN.
+//
+// Peers are dialed by IP.
+// The SAN has to be one name every pod's certificate shares rather than a per-pod name.
+// That is the property caServerName selects on.
+func (c *testCA) issue(t *testing.T, name, dnsName string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{dnsName},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, c.cert, &key.PublicKey, c.key)
+	require.NoError(t, err)
+
+	return writePEM(t, c.dir, name+".pem", "CERTIFICATE", der),
+		writePEM(t, c.dir, name+".key", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(key))
+}
+
+func writePEM(t *testing.T, dir, name, blockType string, der []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), 0o600))
+	return path
+}


### PR DESCRIPTION
Adds ProxyAdminService, a control-plane gRPC API that describes a proxy's cluster connections. One call describes the whole proxy deployment rather than the pod that happened to receive it.

## The admin plane

`adminplane.Serve` answers one RPC at whatever scope the caller asked for and the listener allows: this process, this deployment, or once across a mux to another organization. An endpoint supplies four functions. It inherits deadline budgeting, discovery, concurrency capping, dial lifecycle and the unreachable roster.

Three properties are structural rather than conventions each handler has to remember:

- `Serve` applies the narrowing `View` last. It refuses to answer a counterparty that has none.
- The peer listener refuses to forward. That is what keeps a group call to a single round of fan-out.
- A method outside the admin service passes through untouched. One yamux session serves one `grpc.Server`. On a mux this interceptor is therefore installed server-wide and also sees every replication call.

`Merge` takes members as a slice rather than a pre-folded value. An endpoint whose aggregate is not a sum can then still be expressed. Shard ownership is disjoint across pods. A configuration check wants to know whether the members agree rather than what they add up to.

Self is recognized after the call, not before it. A DNS record carries no identity. Every discovered address is dialed, this pod's own included. A reply bearing this pod's own id is then discarded.

## Three listeners, three roles

- The loopback operator listener is trusted local access. Any scope, forwarding allowed, nothing withheld.
- The peer listener serves sibling pods and refuses to forward.
- The mux listener is reached by another organization. It serves only listed methods. Its answer is built field by field rather than by deleting fields. A field added to the proto later is therefore not served across an organizational boundary until someone adds it there.

The mux listener withholds this deployment's shape. That shape is the per-pod rows carrying pod ids, addresses and versions. It also withholds every cluster connection belonging to a different migration.

Peer TLS does not reuse `encryption.GetServerTLSConfig`. That function sets `RequireAnyClientCert` and replaces `VerifyPeerCertificate` with one that logs the subject and returns nil. It never checks the chain. On a listener bound to the pod network the certificate is the only thing distinguishing a sibling from anything else that can reach it.

`NewProxy` gains an identity and an error return. The identity is supplied rather than read from config. A value in the shared config file would be identical on every replica. Deduplication by id would then collapse the whole deployment into a single member. The error return replaces a Fatal-then-continue that silently dropped a cluster connection when the log component was disabled.

## What the state means

A connection reports `CONNECTED` only when it holds as many connected sessions as it is configured to hold. A session that never established was never added to the manager. Counting only the sessions held would report a connection running at a third of its configured capacity as fully healthy. `mux_sessions_target` carries the configured count. The same comparison is available to whoever reads the response.

## Configuration

Each discovery provider gets its own typed block, selected by name. Every layered configuration tool in this stack deep-merges and cannot delete keys. Switching provider through a Helm override leaves the previous provider's block behind. It has to be inert. A single flat options map could not be switched at all under strict decoding.

`ProxyAdmin` is a value rather than a pointer because nil and an empty listen address already mean the same thing.

The counterparty method list is not resolved through `auth.AccessControl`, whose `IsAllowed` returns true for an empty list. That fail-open default is a compatibility promise the replication ACL depends on. Repeating it here would make the natural spelling of "off" the widest possible setting.

Validation composes through `S2SProxyConfig.Validate()`. A bad value names its own field path. Three checks cover a listener that would start up looking configured while being weaker than it reads:

- `proxyAdmin.listenAddress` must be loopback. That listener has no TLS and no authorization.
- `proxyAdmin.peer.tls.caServerName` is required whenever peer TLS is enabled. Siblings are dialed by IP. Without it the dial has no name to verify the sibling certificate against.
- `proxyAdmin.peer.tls.skipCAVerification` must be false. `GetClientTLSConfig` assigns it to `InsecureSkipVerify`.

## Metrics

The admin API answers an operator who asks. Alerting needs the same facts without one. The chart leaves that API's listener on loopback.

The session state breakdown is what nothing exported before. `mux_connection_active` is set to 1 on every observer tick until the session's lifetime ends. `num_muxes_active` is the size of the session map. A session failing its ping but still in the map therefore reads as healthy in both. Their label sets do not join in PromQL either. The sampler reads `mux.CountSessions`, the same function the admin API reads. The metric and the endpoint cannot disagree.

The admin listeners reuse the registered server metrics rather than declaring a second collector. A second `grpcprom.ServerMetrics` under the same namespace and subsystem panics at process start. The registry rejects a duplicate fully-qualified name. Metrics wrap the admin interceptor so its rejections land in `grpc_code`.

## Helm

The operator listener ships enabled on loopback. A query then needs only an exec or a port-forward rather than a config change.

The peer listener stays commented out. It is what lets one pod answer for the whole deployment. It binds the pod network. It should be a decision rather than a default.

When dns discovery is selected the name defaults to this release's headless Service. That Service already publishes one A record per endpoint. Nothing about it changes. Without the default, every install would hand-write a cluster-internal DNS name.

`POD_NAME` comes through the downward API so each pod names itself in an aggregated response. Two members reporting the same id are indistinguishable from one member answering twice.

## Testing

- `make lint`: 0 issues.
- `make bins`: passes.
- `go test -race -tags test_dep ./...`: every package passes, `proxy/test` at 58s.
- `make test` pins `-timeout=5m`. `proxy/test` exceeds that on a loaded machine while passing well inside it when the tree is not running in parallel.
- `helm unittest s2s-proxy/`: 9 tests pass. The configmap tests cover the case the config shape was designed around. Switching discovery provider through an override leaves the previous provider's block behind. The binary must still accept it under strict decoding.
- `make helm-example`: no drift.
- `make proto-lint` and `make proto-breaking`: pass.
- 9 test files and 47 test functions added.
- `proxy/proxyadmin_tls_test.go` builds a real CA and asserts that a leaf from a different CA is refused by the peer listener. That is the claim `peerServerTLSConfig` exists to make.
