### PR TITLE
Apply custom search attribute aliases to namespace replication tasks

### DIFF
--- a/config/cluster_conn_config.go
+++ b/config/cluster_conn_config.go
@@ -16,6 +16,7 @@ type (
 		ACLPolicy                  *ACLPolicy          `yaml:"aclPolicy"`
 		NamespaceTranslation       StringTranslator    `yaml:"namespaceTranslation"`
 		SearchAttributeTranslation SATranslationConfig `yaml:"searchAttributeTranslation"`
+		CustomSearchAttributes     CustomSAConfig      `yaml:"customSearchAttributes"`
 		RemoteClusterHealthCheck   HealthCheckConfig   `yaml:"remoteClusterHealthCheck"`
 		LocalClusterHealthCheck    HealthCheckConfig   `yaml:"localClusterHealthCheck"`
 		ShardCountConfig           ShardCountConfig    `yaml:"shardCount"`

--- a/config/cluster_conn_config.go
+++ b/config/cluster_conn_config.go
@@ -8,19 +8,19 @@ import (
 // Looking for examples? Check ./develop/sample-cluster-conn-config.yaml
 type (
 	ClusterConnConfig struct {
-		Name                       string              `yaml:"name"`
-		Local                      ClusterDefinition   `yaml:"local"`
-		Remote                     ClusterDefinition   `yaml:"remote"`
-		ReplicationEndpoint        string              `yaml:"replicationEndpoint"`
-		FVITranslation             IntMapping          `yaml:"failoverVersionIncrementTranslation"`
-		ACLPolicy                  *ACLPolicy          `yaml:"aclPolicy"`
-		NamespaceTranslation       StringTranslator    `yaml:"namespaceTranslation"`
-		SearchAttributeTranslation SATranslationConfig `yaml:"searchAttributeTranslation"`
-		CustomSearchAttributes     CustomSAConfig      `yaml:"customSearchAttributes"`
-		RemoteClusterHealthCheck   HealthCheckConfig   `yaml:"remoteClusterHealthCheck"`
-		LocalClusterHealthCheck    HealthCheckConfig   `yaml:"localClusterHealthCheck"`
-		ShardCountConfig           ShardCountConfig    `yaml:"shardCount"`
-		MemberlistConfig           *MemberlistConfig   `yaml:"memberlist"`
+		Name                         string              `yaml:"name"`
+		Local                        ClusterDefinition   `yaml:"local"`
+		Remote                       ClusterDefinition   `yaml:"remote"`
+		ReplicationEndpoint          string              `yaml:"replicationEndpoint"`
+		FVITranslation               IntMapping          `yaml:"failoverVersionIncrementTranslation"`
+		ACLPolicy                    *ACLPolicy          `yaml:"aclPolicy"`
+		NamespaceTranslation         StringTranslator    `yaml:"namespaceTranslation"`
+		SearchAttributeTranslation   SATranslationConfig `yaml:"searchAttributeTranslation"`
+		CustomSearchAttributeAliases CustomSAAliasConfig `yaml:"customSearchAttributeAliases"`
+		RemoteClusterHealthCheck     HealthCheckConfig   `yaml:"remoteClusterHealthCheck"`
+		LocalClusterHealthCheck      HealthCheckConfig   `yaml:"localClusterHealthCheck"`
+		ShardCountConfig             ShardCountConfig    `yaml:"shardCount"`
+		MemberlistConfig             *MemberlistConfig   `yaml:"memberlist"`
 	}
 	StringTranslator struct {
 		Mappings    []StringMapping `yaml:"mappings"`

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"maps"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -219,18 +218,6 @@ func (c *CustomSAConfig) IsEnabled() bool {
 	return len(c.NamespaceMappings) > 0
 }
 
-// ToMap returns the custom search attributes keyed by namespace name, where each inner map is
-// customer-provided search attribute name -> internal field name.
-func (c *CustomSAConfig) ToMap() map[string]map[string]string {
-	out := make(map[string]map[string]string, len(c.NamespaceMappings))
-	for _, ns := range c.NamespaceMappings {
-		attrs := make(map[string]string, len(ns.CustomSearchAttributes))
-		maps.Copy(attrs, ns.CustomSearchAttributes)
-		out[ns.Name] = attrs
-	}
-	return out
-}
-
 // Aliases returns the search attribute aliases for the given namespace, i.e. the reverse of the
 // configured mapping: internal field name -> customer-provided search attribute name.
 // It returns nil if the namespace has no custom search attributes configured.
@@ -249,19 +236,6 @@ func (c *CustomSAConfig) Aliases(namespace string) map[string]string {
 		return aliases
 	}
 	return nil
-}
-
-// Get returns the internal field name for the given customer-provided search attribute name
-// in the given namespace.
-func (c *CustomSAConfig) Get(namespace string, searchAttr string) (string, bool) {
-	for _, ns := range c.NamespaceMappings {
-		if ns.Name != namespace {
-			continue
-		}
-		internalName, found := ns.CustomSearchAttributes[searchAttr]
-		return internalName, found
-	}
-	return "", false
 }
 
 func (s *SATranslationConfig) IsEnabled() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"maps"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -66,17 +67,18 @@ type (
 		RemoteName string `yaml:"remoteFieldName"`
 	}
 
-	// CustomSAConfig holds the custom search attributes registered per namespace.
-	CustomSAConfig struct {
-		NamespaceMappings []CustomSANamespaceMapping `yaml:"namespaceMappings"`
+	// CustomSAAliasConfig holds the custom search attribute aliases registered per namespace.
+	CustomSAAliasConfig struct {
+		NamespaceMappings []CustomSAAliasNamespaceMapping `yaml:"namespaceMappings"`
 	}
 
-	// CustomSANamespaceMapping is the custom search attribute mapping for a single namespace.
-	// CustomSearchAttributes maps the search attribute name provided by the customer to the
-	// internal field name, e.g. {"CustomKeywordField": "Keyword02", "MyText": "Text01"}.
-	CustomSANamespaceMapping struct {
-		Name                   string            `yaml:"name"`
-		CustomSearchAttributes map[string]string `yaml:"customSearchAttributes"`
+	// CustomSAAliasNamespaceMapping is the custom search attribute alias mapping for a single
+	// namespace. CustomSearchAttributeAliases maps the internal field name to the search
+	// attribute name provided by the customer, e.g. {"Keyword02": "CustomKeywordField",
+	// "Text01": "MyText"}.
+	CustomSAAliasNamespaceMapping struct {
+		Name                         string            `yaml:"name"`
+		CustomSearchAttributeAliases map[string]string `yaml:"customSearchAttributeAliases"`
 	}
 
 	ProfilingConfig struct {
@@ -214,25 +216,23 @@ func (c *ProfilingConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return unmarshal((*plain)(c))
 }
 
-func (c *CustomSAConfig) IsEnabled() bool {
+func (c *CustomSAAliasConfig) IsEnabled() bool {
 	return len(c.NamespaceMappings) > 0
 }
 
-// Aliases returns the search attribute aliases for the given namespace, i.e. the reverse of the
-// configured mapping: internal field name -> customer-provided search attribute name.
-// It returns nil if the namespace has no custom search attributes configured.
-func (c *CustomSAConfig) Aliases(namespace string) map[string]string {
+// Aliases returns a copy of the configured search attribute aliases for the given namespace,
+// i.e. internal field name -> customer-provided search attribute name. It returns nil if the
+// namespace has no custom search attribute aliases configured.
+func (c *CustomSAAliasConfig) Aliases(namespace string) map[string]string {
 	for _, ns := range c.NamespaceMappings {
 		if ns.Name != namespace {
 			continue
 		}
-		if len(ns.CustomSearchAttributes) == 0 {
+		if len(ns.CustomSearchAttributeAliases) == 0 {
 			return nil
 		}
-		aliases := make(map[string]string, len(ns.CustomSearchAttributes))
-		for name, internalName := range ns.CustomSearchAttributes {
-			aliases[internalName] = name
-		}
+		aliases := make(map[string]string, len(ns.CustomSearchAttributeAliases))
+		maps.Copy(aliases, ns.CustomSearchAttributeAliases)
 		return aliases
 	}
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -231,6 +231,26 @@ func (c *CustomSAConfig) ToMap() map[string]map[string]string {
 	return out
 }
 
+// Aliases returns the search attribute aliases for the given namespace, i.e. the reverse of the
+// configured mapping: internal field name -> customer-provided search attribute name.
+// It returns nil if the namespace has no custom search attributes configured.
+func (c *CustomSAConfig) Aliases(namespace string) map[string]string {
+	for _, ns := range c.NamespaceMappings {
+		if ns.Name != namespace {
+			continue
+		}
+		if len(ns.CustomSearchAttributes) == 0 {
+			return nil
+		}
+		aliases := make(map[string]string, len(ns.CustomSearchAttributes))
+		for name, internalName := range ns.CustomSearchAttributes {
+			aliases[internalName] = name
+		}
+		return aliases
+	}
+	return nil
+}
+
 // Get returns the internal field name for the given customer-provided search attribute name
 // in the given namespace.
 func (c *CustomSAConfig) Get(namespace string, searchAttr string) (string, bool) {

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"maps"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -64,6 +65,19 @@ type (
 	SAMapping struct {
 		LocalName  string `yaml:"localFieldName"`
 		RemoteName string `yaml:"remoteFieldName"`
+	}
+
+	// CustomSAConfig holds the custom search attributes registered per namespace.
+	CustomSAConfig struct {
+		NamespaceMappings []CustomSANamespaceMapping `yaml:"namespaceMappings"`
+	}
+
+	// CustomSANamespaceMapping is the custom search attribute mapping for a single namespace.
+	// CustomSearchAttributes maps the search attribute name provided by the customer to the
+	// internal field name, e.g. {"CustomKeywordField": "Keyword02", "MyText": "Text01"}.
+	CustomSANamespaceMapping struct {
+		Name                   string            `yaml:"name"`
+		CustomSearchAttributes map[string]string `yaml:"customSearchAttributes"`
 	}
 
 	ProfilingConfig struct {
@@ -199,6 +213,35 @@ func (c *ProfilingConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	// Alias to avoid infinite recursion
 	type plain ProfilingConfig
 	return unmarshal((*plain)(c))
+}
+
+func (c *CustomSAConfig) IsEnabled() bool {
+	return len(c.NamespaceMappings) > 0
+}
+
+// ToMap returns the custom search attributes keyed by namespace name, where each inner map is
+// customer-provided search attribute name -> internal field name.
+func (c *CustomSAConfig) ToMap() map[string]map[string]string {
+	out := make(map[string]map[string]string, len(c.NamespaceMappings))
+	for _, ns := range c.NamespaceMappings {
+		attrs := make(map[string]string, len(ns.CustomSearchAttributes))
+		maps.Copy(attrs, ns.CustomSearchAttributes)
+		out[ns.Name] = attrs
+	}
+	return out
+}
+
+// Get returns the internal field name for the given customer-provided search attribute name
+// in the given namespace.
+func (c *CustomSAConfig) Get(namespace string, searchAttr string) (string, bool) {
+	for _, ns := range c.NamespaceMappings {
+		if ns.Name != namespace {
+			continue
+		}
+		internalName, found := ns.CustomSearchAttributes[searchAttr]
+		return internalName, found
+	}
+	return "", false
 }
 
 func (s *SATranslationConfig) IsEnabled() bool {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"maps"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +20,32 @@ type Tuple[K, V any] struct {
 
 func NewTuple[K, V any](k K, v V) Tuple[K, V] {
 	return Tuple[K, V]{k: k, v: v}
+}
+
+// ToMap returns the custom search attributes keyed by namespace name, where each inner map is
+// customer-provided search attribute name -> internal field name. Test-only: production code
+// reads the config through Aliases.
+func (c *CustomSAConfig) ToMap() map[string]map[string]string {
+	out := make(map[string]map[string]string, len(c.NamespaceMappings))
+	for _, ns := range c.NamespaceMappings {
+		attrs := make(map[string]string, len(ns.CustomSearchAttributes))
+		maps.Copy(attrs, ns.CustomSearchAttributes)
+		out[ns.Name] = attrs
+	}
+	return out
+}
+
+// Get returns the internal field name for the given customer-provided search attribute name
+// in the given namespace. Test-only: production code reads the config through Aliases.
+func (c *CustomSAConfig) Get(namespace string, searchAttr string) (string, bool) {
+	for _, ns := range c.NamespaceMappings {
+		if ns.Name != namespace {
+			continue
+		}
+		internalName, found := ns.CustomSearchAttributes[searchAttr]
+		return internalName, found
+	}
+	return "", false
 }
 
 func TestLoadS2SConfigMux(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,6 +76,21 @@ func TestBasic(t *testing.T) {
 	require.Contains(t, cc.ACLPolicy.AllowedMethods.AdminService, "StreamWorkflowReplicationMessages")
 	require.Equal(t, []string{"namespace1", "namespace2"}, cc.ACLPolicy.AllowedNamespaces)
 	require.True(t, cc.Remote.MuxAddressInfo.TLSConfig.SkipCAVerification)
+
+	customSAs := cc.CustomSearchAttributes
+	require.True(t, customSAs.IsEnabled())
+	require.Equal(t, map[string]map[string]string{
+		"namespace1": {
+			"CustomKeywordField": "Keyword02",
+			"CustomStringField":  "Text02",
+			"MyKeyword":          "Keyword01",
+			"MyText":             "Text01",
+		},
+	}, customSAs.ToMap())
+	require.Equal(t, NewTuple("Keyword02", true), NewTuple(customSAs.Get("namespace1", "CustomKeywordField")))
+	require.Equal(t, NewTuple("Text01", true), NewTuple(customSAs.Get("namespace1", "MyText")))
+	require.Equal(t, NewTuple("", false), NewTuple(customSAs.Get("namespace1", "UnknownField")))
+	require.Equal(t, NewTuple("", false), NewTuple(customSAs.Get("unknownNamespace", "MyText")))
 }
 
 func TestDefaultChart(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -91,6 +91,151 @@ func TestBasic(t *testing.T) {
 	require.Equal(t, NewTuple("Text01", true), NewTuple(customSAs.Get("namespace1", "MyText")))
 	require.Equal(t, NewTuple("", false), NewTuple(customSAs.Get("namespace1", "UnknownField")))
 	require.Equal(t, NewTuple("", false), NewTuple(customSAs.Get("unknownNamespace", "MyText")))
+	require.Equal(t, map[string]string{
+		"Keyword02": "CustomKeywordField",
+		"Text02":    "CustomStringField",
+		"Keyword01": "MyKeyword",
+		"Text01":    "MyText",
+	}, customSAs.Aliases("namespace1"))
+}
+
+func TestCustomSAConfigAliases(t *testing.T) {
+	cfg := CustomSAConfig{
+		NamespaceMappings: []CustomSANamespaceMapping{
+			{
+				Name: "namespace1",
+				CustomSearchAttributes: map[string]string{
+					"MyKeyword": "Keyword01",
+					"MyText":    "Text01",
+				},
+			},
+			{
+				Name: "namespace2",
+				CustomSearchAttributes: map[string]string{
+					"OtherKeyword": "Keyword01",
+				},
+			},
+			{
+				Name:                   "emptyNamespace",
+				CustomSearchAttributes: map[string]string{},
+			},
+			{
+				Name: "nilNamespace",
+			},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		namespace string
+		expected  map[string]string
+	}{
+		{
+			name:      "reverses the configured mapping",
+			namespace: "namespace1",
+			expected: map[string]string{
+				"Keyword01": "MyKeyword",
+				"Text01":    "MyText",
+			},
+		},
+		{
+			// Each namespace is independent: namespace2 reuses Keyword01 without
+			// affecting namespace1.
+			name:      "scoped per namespace",
+			namespace: "namespace2",
+			expected:  map[string]string{"Keyword01": "OtherKeyword"},
+		},
+		{
+			name:      "unknown namespace",
+			namespace: "unknownNamespace",
+			expected:  nil,
+		},
+		{
+			name:      "namespace with empty mapping",
+			namespace: "emptyNamespace",
+			expected:  nil,
+		},
+		{
+			name:      "namespace with nil mapping",
+			namespace: "nilNamespace",
+			expected:  nil,
+		},
+		{
+			name:      "empty namespace name",
+			namespace: "",
+			expected:  nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.expected, cfg.Aliases(c.namespace))
+		})
+	}
+}
+
+func TestCustomSAConfigAliasesEmptyConfig(t *testing.T) {
+	var cfg CustomSAConfig
+	require.False(t, cfg.IsEnabled())
+	require.Nil(t, cfg.Aliases("namespace1"))
+}
+
+// Two search attribute names mapped to the same internal field name cannot both be
+// represented in the reversed map, so one of them is dropped. Which one survives is
+// not deterministic, so this only pins down that the result stays well formed.
+func TestCustomSAConfigAliasesDuplicateInternalName(t *testing.T) {
+	cfg := CustomSAConfig{
+		NamespaceMappings: []CustomSANamespaceMapping{
+			{
+				Name: "namespace1",
+				CustomSearchAttributes: map[string]string{
+					"MyKeyword":    "Keyword01",
+					"OtherKeyword": "Keyword01",
+				},
+			},
+		},
+	}
+
+	aliases := cfg.Aliases("namespace1")
+	require.Len(t, aliases, 1)
+	require.Contains(t, []string{"MyKeyword", "OtherKeyword"}, aliases["Keyword01"])
+}
+
+// The first mapping wins when a namespace is listed more than once.
+func TestCustomSAConfigAliasesDuplicateNamespace(t *testing.T) {
+	cfg := CustomSAConfig{
+		NamespaceMappings: []CustomSANamespaceMapping{
+			{
+				Name:                   "namespace1",
+				CustomSearchAttributes: map[string]string{"MyKeyword": "Keyword01"},
+			},
+			{
+				Name:                   "namespace1",
+				CustomSearchAttributes: map[string]string{"MyText": "Text01"},
+			},
+		},
+	}
+
+	require.Equal(t, map[string]string{"Keyword01": "MyKeyword"}, cfg.Aliases("namespace1"))
+}
+
+// Aliases must not alias the configured map: mutating the result cannot corrupt config.
+func TestCustomSAConfigAliasesReturnsCopy(t *testing.T) {
+	cfg := CustomSAConfig{
+		NamespaceMappings: []CustomSANamespaceMapping{
+			{
+				Name:                   "namespace1",
+				CustomSearchAttributes: map[string]string{"MyKeyword": "Keyword01"},
+			},
+		},
+	}
+
+	aliases := cfg.Aliases("namespace1")
+	aliases["Keyword01"] = "mutated"
+	delete(aliases, "Keyword01")
+
+	require.Equal(t, map[string]string{"Keyword01": "MyKeyword"}, cfg.Aliases("namespace1"))
+	require.Equal(t, map[string]string{"MyKeyword": "Keyword01"}, cfg.NamespaceMappings[0].CustomSearchAttributes)
 }
 
 func TestDefaultChart(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,28 +22,28 @@ func NewTuple[K, V any](k K, v V) Tuple[K, V] {
 	return Tuple[K, V]{k: k, v: v}
 }
 
-// ToMap returns the custom search attributes keyed by namespace name, where each inner map is
-// customer-provided search attribute name -> internal field name. Test-only: production code
-// reads the config through Aliases.
-func (c *CustomSAConfig) ToMap() map[string]map[string]string {
+// ToMap returns the custom search attribute aliases keyed by namespace name, where each inner
+// map is internal field name -> customer-provided search attribute name. Test-only: production
+// code reads the config through Aliases.
+func (c *CustomSAAliasConfig) ToMap() map[string]map[string]string {
 	out := make(map[string]map[string]string, len(c.NamespaceMappings))
 	for _, ns := range c.NamespaceMappings {
-		attrs := make(map[string]string, len(ns.CustomSearchAttributes))
-		maps.Copy(attrs, ns.CustomSearchAttributes)
-		out[ns.Name] = attrs
+		aliases := make(map[string]string, len(ns.CustomSearchAttributeAliases))
+		maps.Copy(aliases, ns.CustomSearchAttributeAliases)
+		out[ns.Name] = aliases
 	}
 	return out
 }
 
-// Get returns the internal field name for the given customer-provided search attribute name
-// in the given namespace. Test-only: production code reads the config through Aliases.
-func (c *CustomSAConfig) Get(namespace string, searchAttr string) (string, bool) {
+// Get returns the customer-provided search attribute name aliased to the given internal field
+// name in the given namespace. Test-only: production code reads the config through Aliases.
+func (c *CustomSAAliasConfig) Get(namespace string, internalName string) (string, bool) {
 	for _, ns := range c.NamespaceMappings {
 		if ns.Name != namespace {
 			continue
 		}
-		internalName, found := ns.CustomSearchAttributes[searchAttr]
-		return internalName, found
+		alias, found := ns.CustomSearchAttributeAliases[internalName]
+		return alias, found
 	}
 	return "", false
 }
@@ -104,47 +104,47 @@ func TestBasic(t *testing.T) {
 	require.Equal(t, []string{"namespace1", "namespace2"}, cc.ACLPolicy.AllowedNamespaces)
 	require.True(t, cc.Remote.MuxAddressInfo.TLSConfig.SkipCAVerification)
 
-	customSAs := cc.CustomSearchAttributes
-	require.True(t, customSAs.IsEnabled())
+	customSAAliases := cc.CustomSearchAttributeAliases
+	require.True(t, customSAAliases.IsEnabled())
 	require.Equal(t, map[string]map[string]string{
 		"namespace1": {
-			"CustomKeywordField": "Keyword02",
-			"CustomStringField":  "Text02",
-			"MyKeyword":          "Keyword01",
-			"MyText":             "Text01",
+			"Keyword01": "MyKeyword",
+			"Keyword02": "CustomKeywordField",
+			"Text01":    "MyText",
+			"Text02":    "CustomStringField",
 		},
-	}, customSAs.ToMap())
-	require.Equal(t, NewTuple("Keyword02", true), NewTuple(customSAs.Get("namespace1", "CustomKeywordField")))
-	require.Equal(t, NewTuple("Text01", true), NewTuple(customSAs.Get("namespace1", "MyText")))
-	require.Equal(t, NewTuple("", false), NewTuple(customSAs.Get("namespace1", "UnknownField")))
-	require.Equal(t, NewTuple("", false), NewTuple(customSAs.Get("unknownNamespace", "MyText")))
+	}, customSAAliases.ToMap())
+	require.Equal(t, NewTuple("CustomKeywordField", true), NewTuple(customSAAliases.Get("namespace1", "Keyword02")))
+	require.Equal(t, NewTuple("MyText", true), NewTuple(customSAAliases.Get("namespace1", "Text01")))
+	require.Equal(t, NewTuple("", false), NewTuple(customSAAliases.Get("namespace1", "UnknownField")))
+	require.Equal(t, NewTuple("", false), NewTuple(customSAAliases.Get("unknownNamespace", "Text01")))
 	require.Equal(t, map[string]string{
-		"Keyword02": "CustomKeywordField",
-		"Text02":    "CustomStringField",
 		"Keyword01": "MyKeyword",
+		"Keyword02": "CustomKeywordField",
 		"Text01":    "MyText",
-	}, customSAs.Aliases("namespace1"))
+		"Text02":    "CustomStringField",
+	}, customSAAliases.Aliases("namespace1"))
 }
 
-func TestCustomSAConfigAliases(t *testing.T) {
-	cfg := CustomSAConfig{
-		NamespaceMappings: []CustomSANamespaceMapping{
+func TestCustomSAAliasConfigAliases(t *testing.T) {
+	cfg := CustomSAAliasConfig{
+		NamespaceMappings: []CustomSAAliasNamespaceMapping{
 			{
 				Name: "namespace1",
-				CustomSearchAttributes: map[string]string{
-					"MyKeyword": "Keyword01",
-					"MyText":    "Text01",
+				CustomSearchAttributeAliases: map[string]string{
+					"Keyword01": "MyKeyword",
+					"Text01":    "MyText",
 				},
 			},
 			{
 				Name: "namespace2",
-				CustomSearchAttributes: map[string]string{
-					"OtherKeyword": "Keyword01",
+				CustomSearchAttributeAliases: map[string]string{
+					"Keyword01": "OtherKeyword",
 				},
 			},
 			{
-				Name:                   "emptyNamespace",
-				CustomSearchAttributes: map[string]string{},
+				Name:                         "emptyNamespace",
+				CustomSearchAttributeAliases: map[string]string{},
 			},
 			{
 				Name: "nilNamespace",
@@ -158,7 +158,7 @@ func TestCustomSAConfigAliases(t *testing.T) {
 		expected  map[string]string
 	}{
 		{
-			name:      "reverses the configured mapping",
+			name:      "returns the configured aliases",
 			namespace: "namespace1",
 			expected: map[string]string{
 				"Keyword01": "MyKeyword",
@@ -166,8 +166,8 @@ func TestCustomSAConfigAliases(t *testing.T) {
 			},
 		},
 		{
-			// Each namespace is independent: namespace2 reuses Keyword01 without
-			// affecting namespace1.
+			// Each namespace is independent: namespace2 aliases Keyword01 to a different
+			// name without affecting namespace1.
 			name:      "scoped per namespace",
 			namespace: "namespace2",
 			expected:  map[string]string{"Keyword01": "OtherKeyword"},
@@ -201,44 +201,44 @@ func TestCustomSAConfigAliases(t *testing.T) {
 	}
 }
 
-func TestCustomSAConfigAliasesEmptyConfig(t *testing.T) {
-	var cfg CustomSAConfig
+func TestCustomSAAliasConfigAliasesEmptyConfig(t *testing.T) {
+	var cfg CustomSAAliasConfig
 	require.False(t, cfg.IsEnabled())
 	require.Nil(t, cfg.Aliases("namespace1"))
 }
 
-// Two search attribute names mapped to the same internal field name cannot both be
-// represented in the reversed map, so one of them is dropped. Which one survives is
-// not deterministic, so this only pins down that the result stays well formed.
-func TestCustomSAConfigAliasesDuplicateInternalName(t *testing.T) {
-	cfg := CustomSAConfig{
-		NamespaceMappings: []CustomSANamespaceMapping{
+// Distinct internal fields may share an alias name. Both entries are preserved; the server is
+// responsible for rejecting the namespace config if that is invalid.
+func TestCustomSAAliasConfigAliasesDuplicateAliasName(t *testing.T) {
+	cfg := CustomSAAliasConfig{
+		NamespaceMappings: []CustomSAAliasNamespaceMapping{
 			{
 				Name: "namespace1",
-				CustomSearchAttributes: map[string]string{
-					"MyKeyword":    "Keyword01",
-					"OtherKeyword": "Keyword01",
+				CustomSearchAttributeAliases: map[string]string{
+					"Keyword01": "MyKeyword",
+					"Keyword02": "MyKeyword",
 				},
 			},
 		},
 	}
 
-	aliases := cfg.Aliases("namespace1")
-	require.Len(t, aliases, 1)
-	require.Contains(t, []string{"MyKeyword", "OtherKeyword"}, aliases["Keyword01"])
+	require.Equal(t, map[string]string{
+		"Keyword01": "MyKeyword",
+		"Keyword02": "MyKeyword",
+	}, cfg.Aliases("namespace1"))
 }
 
 // The first mapping wins when a namespace is listed more than once.
-func TestCustomSAConfigAliasesDuplicateNamespace(t *testing.T) {
-	cfg := CustomSAConfig{
-		NamespaceMappings: []CustomSANamespaceMapping{
+func TestCustomSAAliasConfigAliasesDuplicateNamespace(t *testing.T) {
+	cfg := CustomSAAliasConfig{
+		NamespaceMappings: []CustomSAAliasNamespaceMapping{
 			{
-				Name:                   "namespace1",
-				CustomSearchAttributes: map[string]string{"MyKeyword": "Keyword01"},
+				Name:                         "namespace1",
+				CustomSearchAttributeAliases: map[string]string{"Keyword01": "MyKeyword"},
 			},
 			{
-				Name:                   "namespace1",
-				CustomSearchAttributes: map[string]string{"MyText": "Text01"},
+				Name:                         "namespace1",
+				CustomSearchAttributeAliases: map[string]string{"Text01": "MyText"},
 			},
 		},
 	}
@@ -247,12 +247,12 @@ func TestCustomSAConfigAliasesDuplicateNamespace(t *testing.T) {
 }
 
 // Aliases must not alias the configured map: mutating the result cannot corrupt config.
-func TestCustomSAConfigAliasesReturnsCopy(t *testing.T) {
-	cfg := CustomSAConfig{
-		NamespaceMappings: []CustomSANamespaceMapping{
+func TestCustomSAAliasConfigAliasesReturnsCopy(t *testing.T) {
+	cfg := CustomSAAliasConfig{
+		NamespaceMappings: []CustomSAAliasNamespaceMapping{
 			{
-				Name:                   "namespace1",
-				CustomSearchAttributes: map[string]string{"MyKeyword": "Keyword01"},
+				Name:                         "namespace1",
+				CustomSearchAttributeAliases: map[string]string{"Keyword01": "MyKeyword"},
 			},
 		},
 	}
@@ -262,7 +262,7 @@ func TestCustomSAConfigAliasesReturnsCopy(t *testing.T) {
 	delete(aliases, "Keyword01")
 
 	require.Equal(t, map[string]string{"Keyword01": "MyKeyword"}, cfg.Aliases("namespace1"))
-	require.Equal(t, map[string]string{"MyKeyword": "Keyword01"}, cfg.NamespaceMappings[0].CustomSearchAttributes)
+	require.Equal(t, map[string]string{"Keyword01": "MyKeyword"}, cfg.NamespaceMappings[0].CustomSearchAttributeAliases)
 }
 
 func TestDefaultChart(t *testing.T) {

--- a/develop/config/cluster-b-mux-server-proxy.yaml
+++ b/develop/config/cluster-b-mux-server-proxy.yaml
@@ -10,10 +10,10 @@ clusterConnections:
       connectionType: "mux-server"
       muxAddressInfo:
         address: "0.0.0.0:6334"
-    customSearchAttributes:
+    customSearchAttributeAliases:
       namespaceMappings:
         - name: "actions-b"
-          # search attribute name provided by customer -> internal field name
-          customSearchAttributes:
-            CustomKeywordField: "Keyword03"
-            CustomStringField: "Text02"
+          # internal field name -> search attribute name provided by customer
+          customSearchAttributeAliases:
+            Keyword03: "CustomKeywordField"
+            Text02: "CustomStringField"

--- a/develop/config/cluster-b-mux-server-proxy.yaml
+++ b/develop/config/cluster-b-mux-server-proxy.yaml
@@ -10,3 +10,10 @@ clusterConnections:
       connectionType: "mux-server"
       muxAddressInfo:
         address: "0.0.0.0:6334"
+    customSearchAttributes:
+      namespaceMappings:
+        - name: "actions-b"
+          # search attribute name provided by customer -> internal field name
+          customSearchAttributes:
+            CustomKeywordField: "Keyword03"
+            CustomStringField: "Text02"

--- a/develop/config/sample-cluster-conn-config.yaml
+++ b/develop/config/sample-cluster-conn-config.yaml
@@ -60,15 +60,15 @@ clusterConnections:
           mappings:
             - localFieldName: "localSearchAttribute"
               remoteFieldName: "remoteSearchAttribute"
-    customSearchAttributes:
+    customSearchAttributeAliases:
       namespaceMappings:
         - name: "namespace1"
-          # search attribute name provided by customer -> internal field name
-          customSearchAttributes:
-            CustomKeywordField: "Keyword02"
-            CustomStringField: "Text02"
-            MyKeyword: "Keyword01"
-            MyText: "Text01"
+          # internal field name -> search attribute name provided by customer
+          customSearchAttributeAliases:
+            Keyword01: "MyKeyword"
+            Keyword02: "CustomKeywordField"
+            Text01: "MyText"
+            Text02: "CustomStringField"
     remoteClusterHealthCheck:
       protocol: "http"
       listenAddress: "127.0.0.1:911"

--- a/develop/config/sample-cluster-conn-config.yaml
+++ b/develop/config/sample-cluster-conn-config.yaml
@@ -60,6 +60,15 @@ clusterConnections:
           mappings:
             - localFieldName: "localSearchAttribute"
               remoteFieldName: "remoteSearchAttribute"
+    customSearchAttributes:
+      namespaceMappings:
+        - name: "namespace1"
+          # search attribute name provided by customer -> internal field name
+          customSearchAttributes:
+            CustomKeywordField: "Keyword02"
+            CustomStringField: "Text02"
+            MyKeyword: "Keyword01"
+            MyText: "Text01"
     remoteClusterHealthCheck:
       protocol: "http"
       listenAddress: "127.0.0.1:911"

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -48,6 +48,9 @@ type (
 		// Failover Version Increment. Overrides the value returned by DescribeCluster
 		FVI                 int64
 		ReplicationEndpoint string
+		// CustomSearchAttributes are the per-namespace custom search attributes
+		// (customer-provided name -> internal field name). Inbound only.
+		CustomSearchAttributes config.CustomSAConfig
 	}
 )
 
@@ -221,9 +224,26 @@ func (s *adminServiceProxyServer) GetNamespaceReplicationMessages(ctx context.Co
 		// This is a duplicate of the grpc client metrics, but not everyone has metrics set up
 		s.loggers.Get(logging.ReplicationStreams).Error("Failed to get namespace replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
 			tag.Error(err), tag.Operation("GetNamespaceReplicationMessages"))
-	} else if tasks := resp.GetMessages().GetReplicationTasks(); len(tasks) > 0 {
-		s.loggers.Get(logging.ReplicationStreams).Info("Got namespace replication tasks", tag.NewStringTag("Cluster", in0.GetClusterName()),
-			tag.NewInt("TaskCount", len(tasks)), tag.Operation("GetNamespaceReplicationMessages"))
+	} else if s.overrides.CustomSearchAttributes.IsEnabled() {
+		// Set the custom search attribute aliases on namespace replication tasks for namespaces
+		// configured with custom search attributes. The aliases are the reverse of the configured
+		// mapping: customer-provided name -> internal field name becomes internal field name ->
+		// customer-provided name.
+		for _, task := range resp.GetMessages().GetReplicationTasks() {
+			attrs := task.GetNamespaceTaskAttributes()
+			if attrs == nil {
+				continue
+			}
+			aliases := s.overrides.CustomSearchAttributes.Aliases(attrs.GetInfo().GetName())
+			if len(aliases) == 0 {
+				continue
+			}
+			if attrs.Config != nil {
+				attrs.Config.CustomSearchAttributeAliases = aliases
+				s.loggers.Get(logging.ReplicationStreams).Info("Overrode custom search attribute aliases",
+					tag.WorkflowNamespace(attrs.GetInfo().GetName()), tag.Operation("GetNamespaceReplicationMessages"))
+			}
+		}
 	}
 
 	return

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -48,9 +48,9 @@ type (
 		// Failover Version Increment. Overrides the value returned by DescribeCluster
 		FVI                 int64
 		ReplicationEndpoint string
-		// CustomSearchAttributes are the per-namespace custom search attributes
-		// (customer-provided name -> internal field name). Inbound only.
-		CustomSearchAttributes config.CustomSAConfig
+		// CustomSearchAttributeAliases are the per-namespace custom search attribute aliases
+		// (internal field name -> customer-provided name). Inbound only.
+		CustomSearchAttributeAliases config.CustomSAAliasConfig
 	}
 )
 
@@ -224,17 +224,15 @@ func (s *adminServiceProxyServer) GetNamespaceReplicationMessages(ctx context.Co
 		// This is a duplicate of the grpc client metrics, but not everyone has metrics set up
 		s.loggers.Get(logging.AdminService).Error("Failed to get namespace replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
 			tag.Error(err), tag.Operation("GetNamespaceReplicationMessages"))
-	} else if s.overrides.CustomSearchAttributes.IsEnabled() {
+	} else if s.overrides.CustomSearchAttributeAliases.IsEnabled() {
 		// Set the custom search attribute aliases on namespace replication tasks for namespaces
-		// configured with custom search attributes. The aliases are the reverse of the configured
-		// mapping: customer-provided name -> internal field name becomes internal field name ->
-		// customer-provided name.
+		// configured with custom search attribute aliases.
 		for _, task := range resp.GetMessages().GetReplicationTasks() {
 			attrs := task.GetNamespaceTaskAttributes()
 			if attrs == nil {
 				continue
 			}
-			aliases := s.overrides.CustomSearchAttributes.Aliases(attrs.GetInfo().GetName())
+			aliases := s.overrides.CustomSearchAttributeAliases.Aliases(attrs.GetInfo().GetName())
 			if len(aliases) == 0 {
 				continue
 			}

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -252,16 +252,10 @@ func (s *adminServiceProxyServer) GetNamespaceReplicationMessages(ctx context.Co
 func (s *adminServiceProxyServer) GetReplicationMessages(ctx context.Context, in0 *adminservice.GetReplicationMessagesRequest) (resp *adminservice.GetReplicationMessagesResponse, err error) {
 	resp, err = s.adminClient.GetReplicationMessages(ctx, in0)
 	if err != nil {
-		s.loggers.Get(logging.ReplicationStreams).Error("Failed to get replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
+		s.loggers.Get(logging.AdminService).Error("Failed to get replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
 			tag.Error(err), tag.Operation("GetReplicationMessages"))
-	} else {
-		for shardID, messages := range resp.GetShardMessages() {
-			if tasks := messages.GetReplicationTasks(); len(tasks) > 0 {
-				s.loggers.Get(logging.ReplicationStreams).Info("Got replication tasks", tag.NewStringTag("Cluster", in0.GetClusterName()),
-					tag.NewInt32("ShardID", shardID), tag.NewInt("TaskCount", len(tasks)), tag.Operation("GetReplicationMessages"))
-			}
-		}
 	}
+
 	return
 }
 

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -222,7 +222,7 @@ func (s *adminServiceProxyServer) GetNamespaceReplicationMessages(ctx context.Co
 	resp, err = s.adminClient.GetNamespaceReplicationMessages(ctx, in0)
 	if err != nil {
 		// This is a duplicate of the grpc client metrics, but not everyone has metrics set up
-		s.loggers.Get(logging.ReplicationStreams).Error("Failed to get namespace replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
+		s.loggers.Get(logging.AdminService).Error("Failed to get namespace replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
 			tag.Error(err), tag.Operation("GetNamespaceReplicationMessages"))
 	} else if s.overrides.CustomSearchAttributes.IsEnabled() {
 		// Set the custom search attribute aliases on namespace replication tasks for namespaces
@@ -240,7 +240,7 @@ func (s *adminServiceProxyServer) GetNamespaceReplicationMessages(ctx context.Co
 			}
 			if attrs.Config != nil {
 				attrs.Config.CustomSearchAttributeAliases = aliases
-				s.loggers.Get(logging.ReplicationStreams).Info("Overrode custom search attribute aliases",
+				s.loggers.Get(logging.AdminService).Info("Overrode custom search attribute aliases",
 					tag.WorkflowNamespace(attrs.GetInfo().GetName()), tag.Operation("GetNamespaceReplicationMessages"))
 			}
 		}

--- a/proxy/adminservice.go
+++ b/proxy/adminservice.go
@@ -221,7 +221,11 @@ func (s *adminServiceProxyServer) GetNamespaceReplicationMessages(ctx context.Co
 		// This is a duplicate of the grpc client metrics, but not everyone has metrics set up
 		s.loggers.Get(logging.ReplicationStreams).Error("Failed to get namespace replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
 			tag.Error(err), tag.Operation("GetNamespaceReplicationMessages"))
+	} else if tasks := resp.GetMessages().GetReplicationTasks(); len(tasks) > 0 {
+		s.loggers.Get(logging.ReplicationStreams).Info("Got namespace replication tasks", tag.NewStringTag("Cluster", in0.GetClusterName()),
+			tag.NewInt("TaskCount", len(tasks)), tag.Operation("GetNamespaceReplicationMessages"))
 	}
+
 	return
 }
 
@@ -230,6 +234,13 @@ func (s *adminServiceProxyServer) GetReplicationMessages(ctx context.Context, in
 	if err != nil {
 		s.loggers.Get(logging.ReplicationStreams).Error("Failed to get replication messages", tag.NewStringTag("Cluster", in0.GetClusterName()),
 			tag.Error(err), tag.Operation("GetReplicationMessages"))
+	} else {
+		for shardID, messages := range resp.GetShardMessages() {
+			if tasks := messages.GetReplicationTasks(); len(tasks) > 0 {
+				s.loggers.Get(logging.ReplicationStreams).Info("Got replication tasks", tag.NewStringTag("Cluster", in0.GetClusterName()),
+					tag.NewInt32("ShardID", shardID), tag.NewInt("TaskCount", len(tasks)), tag.Operation("GetReplicationMessages"))
+			}
+		}
 	}
 	return
 }

--- a/proxy/adminservice_test.go
+++ b/proxy/adminservice_test.go
@@ -135,16 +135,17 @@ func (s *adminserviceSuite) TestAddOrUpdateRemoteCluster() {
 func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 	req := &adminservice.GetNamespaceReplicationMessagesRequest{ClusterName: "test-cluster"}
 
-	customSAs := func(mappings ...config.CustomSANamespaceMapping) config.CustomSAConfig {
-		return config.CustomSAConfig{NamespaceMappings: mappings}
+	customSAAliases := func(mappings ...config.CustomSAAliasNamespaceMapping) config.CustomSAAliasConfig {
+		return config.CustomSAAliasConfig{NamespaceMappings: mappings}
 	}
-	namespace1Mapping := config.CustomSANamespaceMapping{
+	namespace1Mapping := config.CustomSAAliasNamespaceMapping{
 		Name: "namespace1",
-		CustomSearchAttributes: map[string]string{
-			"MyKeyword": "Keyword01",
-			"MyText":    "Text01",
+		CustomSearchAttributeAliases: map[string]string{
+			"Keyword01": "MyKeyword",
+			"Text01":    "MyText",
 		},
 	}
+	// What the handler is expected to write onto the task.
 	namespace1Aliases := map[string]string{
 		"Keyword01": "MyKeyword",
 		"Text01":    "MyText",
@@ -205,7 +206,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "override matching namespace",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: makeResp(makeNSTask("namespace1", nil)),
 			expResp:  makeResp(makeNSTask("namespace1", namespace1Aliases)),
@@ -214,7 +215,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "replaces pre-existing aliases",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: makeResp(makeNSTask("namespace1", map[string]string{
 				"Keyword01": "SourceKeyword",
@@ -227,7 +228,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "mixed batch overrides only configured namespaces",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: makeResp(
 				makeNSTask("namespace1", nil),
@@ -242,18 +243,18 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "unconfigured namespace",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: makeResp(makeNSTask("unknownNamespace", nil)),
 			expResp:  makeResp(makeNSTask("unknownNamespace", nil)),
 		},
 		{
-			name: "namespace configured with no attributes",
+			name: "namespace configured with no aliases",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides: AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping, config.CustomSANamespaceMapping{
-					Name:                   "namespace2",
-					CustomSearchAttributes: map[string]string{},
+				overrides: AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping, config.CustomSAAliasNamespaceMapping{
+					Name:                         "namespace2",
+					CustomSearchAttributeAliases: map[string]string{},
 				})},
 			},
 			mockResp: makeResp(makeNSTask("namespace2", nil)),
@@ -265,7 +266,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "task with nil config is skipped",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: makeResp(makeNSTaskNilConfig("namespace1")),
 			expResp:  makeResp(makeNSTaskNilConfig("namespace1")),
@@ -274,7 +275,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "non-namespace tasks and nil entries",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: makeResp(
 				nil,
@@ -291,7 +292,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "nil messages",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			mockResp: &adminservice.GetNamespaceReplicationMessagesResponse{},
 			expResp:  &adminservice.GetNamespaceReplicationMessagesResponse{},
@@ -302,7 +303,7 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
 			name: "override applied with request translation disabled",
 			adminProxyServerInput: adminProxyServerInput{
 				metricLabels: []string{"inbound"},
-				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+				overrides:    AdminServiceOverrides{CustomSearchAttributeAliases: customSAAliases(namespace1Mapping)},
 			},
 			reqMetadata: map[string]string{
 				common.RequestTranslationHeaderName: "false",
@@ -333,11 +334,11 @@ func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessagesErro
 	observer := NewReplicationStreamObserver(log.NewTestLogger())
 	server := s.newAdminServiceProxyServer(adminProxyServerInput{
 		metricLabels: []string{"inbound"},
-		overrides: AdminServiceOverrides{CustomSearchAttributes: config.CustomSAConfig{
-			NamespaceMappings: []config.CustomSANamespaceMapping{
+		overrides: AdminServiceOverrides{CustomSearchAttributeAliases: config.CustomSAAliasConfig{
+			NamespaceMappings: []config.CustomSAAliasNamespaceMapping{
 				{
-					Name:                   "namespace1",
-					CustomSearchAttributes: map[string]string{"MyKeyword": "Keyword01"},
+					Name:                         "namespace1",
+					CustomSearchAttributeAliases: map[string]string{"Keyword01": "MyKeyword"},
 				},
 			},
 		}},

--- a/proxy/adminservice_test.go
+++ b/proxy/adminservice_test.go
@@ -2,11 +2,15 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+	namespacev1 "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/adminservicemock/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	replicationv1 "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	gomock "go.uber.org/mock/gomock"
 	"google.golang.org/grpc/metadata"
@@ -126,6 +130,223 @@ func (s *adminserviceSuite) TestAddOrUpdateRemoteCluster() {
 			s.Equal("[]", observer.PrintActiveStreams())
 		})
 	}
+}
+
+func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessages() {
+	req := &adminservice.GetNamespaceReplicationMessagesRequest{ClusterName: "test-cluster"}
+
+	customSAs := func(mappings ...config.CustomSANamespaceMapping) config.CustomSAConfig {
+		return config.CustomSAConfig{NamespaceMappings: mappings}
+	}
+	namespace1Mapping := config.CustomSANamespaceMapping{
+		Name: "namespace1",
+		CustomSearchAttributes: map[string]string{
+			"MyKeyword": "Keyword01",
+			"MyText":    "Text01",
+		},
+	}
+	namespace1Aliases := map[string]string{
+		"Keyword01": "MyKeyword",
+		"Text01":    "MyText",
+	}
+
+	// makeNSTask builds a namespace replication task. A nil aliases map leaves
+	// Config.CustomSearchAttributeAliases unset; use makeNSTaskNilConfig for a nil Config.
+	makeNSTask := func(ns string, aliases map[string]string) *replicationv1.ReplicationTask {
+		return &replicationv1.ReplicationTask{
+			TaskType: enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK,
+			Attributes: &replicationv1.ReplicationTask_NamespaceTaskAttributes{
+				NamespaceTaskAttributes: &replicationv1.NamespaceTaskAttributes{
+					Id:   "task-id-" + ns,
+					Info: &namespacev1.NamespaceInfo{Name: ns},
+					Config: &namespacev1.NamespaceConfig{
+						CustomSearchAttributeAliases: aliases,
+					},
+				},
+			},
+		}
+	}
+	makeNSTaskNilConfig := func(ns string) *replicationv1.ReplicationTask {
+		return &replicationv1.ReplicationTask{
+			TaskType: enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK,
+			Attributes: &replicationv1.ReplicationTask_NamespaceTaskAttributes{
+				NamespaceTaskAttributes: &replicationv1.NamespaceTaskAttributes{
+					Id:   "task-id-" + ns,
+					Info: &namespacev1.NamespaceInfo{Name: ns},
+				},
+			},
+		}
+	}
+	makeResp := func(tasks ...*replicationv1.ReplicationTask) *adminservice.GetNamespaceReplicationMessagesResponse {
+		return &adminservice.GetNamespaceReplicationMessagesResponse{
+			Messages: &replicationv1.ReplicationMessages{
+				ReplicationTasks:       tasks,
+				LastRetrievedMessageId: 1234,
+			},
+		}
+	}
+
+	cases := []struct {
+		name                  string
+		reqMetadata           map[string]string
+		adminProxyServerInput adminProxyServerInput
+		mockResp              *adminservice.GetNamespaceReplicationMessagesResponse
+		expResp               *adminservice.GetNamespaceReplicationMessagesResponse
+	}{
+		{
+			name: "no override config",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+			},
+			mockResp: makeResp(makeNSTask("namespace1", nil)),
+			expResp:  makeResp(makeNSTask("namespace1", nil)),
+		},
+		{
+			name: "override matching namespace",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: makeResp(makeNSTask("namespace1", nil)),
+			expResp:  makeResp(makeNSTask("namespace1", namespace1Aliases)),
+		},
+		{
+			name: "replaces pre-existing aliases",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: makeResp(makeNSTask("namespace1", map[string]string{
+				"Keyword01": "SourceKeyword",
+				"Bool01":    "SourceBool",
+			})),
+			expResp: makeResp(makeNSTask("namespace1", namespace1Aliases)),
+		},
+		{
+			// Only the configured namespace is touched; others pass through untouched.
+			name: "mixed batch overrides only configured namespaces",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: makeResp(
+				makeNSTask("namespace1", nil),
+				makeNSTask("namespace2", map[string]string{"Keyword01": "UntouchedKeyword"}),
+			),
+			expResp: makeResp(
+				makeNSTask("namespace1", namespace1Aliases),
+				makeNSTask("namespace2", map[string]string{"Keyword01": "UntouchedKeyword"}),
+			),
+		},
+		{
+			name: "unconfigured namespace",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: makeResp(makeNSTask("unknownNamespace", nil)),
+			expResp:  makeResp(makeNSTask("unknownNamespace", nil)),
+		},
+		{
+			name: "namespace configured with no attributes",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides: AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping, config.CustomSANamespaceMapping{
+					Name:                   "namespace2",
+					CustomSearchAttributes: map[string]string{},
+				})},
+			},
+			mockResp: makeResp(makeNSTask("namespace2", nil)),
+			expResp:  makeResp(makeNSTask("namespace2", nil)),
+		},
+		{
+			// Current behavior: a task with no Config is skipped, so the namespace
+			// replicates with no aliases at all rather than the configured ones.
+			name: "task with nil config is skipped",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: makeResp(makeNSTaskNilConfig("namespace1")),
+			expResp:  makeResp(makeNSTaskNilConfig("namespace1")),
+		},
+		{
+			name: "non-namespace tasks and nil entries",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: makeResp(
+				nil,
+				&replicationv1.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK},
+				makeNSTask("namespace1", nil),
+			),
+			expResp: makeResp(
+				nil,
+				&replicationv1.ReplicationTask{TaskType: enumsspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK},
+				makeNSTask("namespace1", namespace1Aliases),
+			),
+		},
+		{
+			name: "nil messages",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			mockResp: &adminservice.GetNamespaceReplicationMessagesResponse{},
+			expResp:  &adminservice.GetNamespaceReplicationMessagesResponse{},
+		},
+		{
+			// Unlike the FVI and ReplicationEndpoint overrides, this one does not honor
+			// the disable-translation header.
+			name: "override applied with request translation disabled",
+			adminProxyServerInput: adminProxyServerInput{
+				metricLabels: []string{"inbound"},
+				overrides:    AdminServiceOverrides{CustomSearchAttributes: customSAs(namespace1Mapping)},
+			},
+			reqMetadata: map[string]string{
+				common.RequestTranslationHeaderName: "false",
+			},
+			mockResp: makeResp(makeNSTask("namespace1", nil)),
+			expResp:  makeResp(makeNSTask("namespace1", namespace1Aliases)),
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.New(c.reqMetadata))
+			observer := NewReplicationStreamObserver(log.NewTestLogger())
+			server := s.newAdminServiceProxyServer(c.adminProxyServerInput, observer)
+			s.adminClientMock.EXPECT().GetNamespaceReplicationMessages(ctx, req).Return(c.mockResp, nil)
+			resp, err := server.GetNamespaceReplicationMessages(ctx, req)
+			s.NoError(err)
+			s.True(proto.Equal(c.expResp, resp), "expected %v, got %v", c.expResp, resp)
+			s.Equal("[]", observer.PrintActiveStreams())
+		})
+	}
+}
+
+func (s *adminserviceSuite) TestAPIOverrides_GetNamespaceReplicationMessagesError() {
+	req := &adminservice.GetNamespaceReplicationMessagesRequest{ClusterName: "test-cluster"}
+	expErr := errors.New("some error")
+
+	observer := NewReplicationStreamObserver(log.NewTestLogger())
+	server := s.newAdminServiceProxyServer(adminProxyServerInput{
+		metricLabels: []string{"inbound"},
+		overrides: AdminServiceOverrides{CustomSearchAttributes: config.CustomSAConfig{
+			NamespaceMappings: []config.CustomSANamespaceMapping{
+				{
+					Name:                   "namespace1",
+					CustomSearchAttributes: map[string]string{"MyKeyword": "Keyword01"},
+				},
+			},
+		}},
+	}, observer)
+	s.adminClientMock.EXPECT().GetNamespaceReplicationMessages(gomock.Any(), req).Return(nil, expErr)
+
+	resp, err := server.GetNamespaceReplicationMessages(context.Background(), req)
+	s.ErrorIs(err, expErr)
+	s.Nil(resp)
 }
 
 func (s *adminserviceSuite) TestAPIOverrides_FailoverVersionIncrement() {

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -188,7 +188,11 @@ func NewClusterConnection(lifetime context.Context, connConfig config.ClusterCon
 		managedClient:     cc.outboundClient,
 		nsTranslations:    nsTranslations.Inverse(),
 		saTranslations:    saTranslations.Inverse(),
-		overrides:         AdminServiceOverrides{connConfig.FVITranslation.Local, connConfig.ReplicationEndpoint},
+		overrides: AdminServiceOverrides{
+			FVI:                    connConfig.FVITranslation.Local,
+			ReplicationEndpoint:    connConfig.ReplicationEndpoint,
+			CustomSearchAttributes: connConfig.CustomSearchAttributes,
+		},
 		// TODO: There is no test checking that ACLPolicy isn't accidentally dropped
 		aclPolicy:         connConfig.ACLPolicy,
 		shardCountConfig:  connConfig.ShardCountConfig,

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -189,9 +189,9 @@ func NewClusterConnection(lifetime context.Context, connConfig config.ClusterCon
 		nsTranslations:    nsTranslations.Inverse(),
 		saTranslations:    saTranslations.Inverse(),
 		overrides: AdminServiceOverrides{
-			FVI:                    connConfig.FVITranslation.Local,
-			ReplicationEndpoint:    connConfig.ReplicationEndpoint,
-			CustomSearchAttributes: connConfig.CustomSearchAttributes,
+			FVI:                          connConfig.FVITranslation.Local,
+			ReplicationEndpoint:          connConfig.ReplicationEndpoint,
+			CustomSearchAttributeAliases: connConfig.CustomSearchAttributeAliases,
 		},
 		// TODO: There is no test checking that ACLPolicy isn't accidentally dropped
 		aclPolicy:         connConfig.ACLPolicy,


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

This is for cloud to self-hosted migration. In cloud, CSA mapping is not part of namespace attributes because the mapping was done out side of OSS. We will need to replicate CSAs to self-hosted server if the server uses CSA mapper (such as SQL-based visibility store)


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
