### PR TITLE
Register GRPCIntraProxyClientMetrics with Prometheus

### DIFF
--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -118,6 +118,7 @@ func init() {
 
 	prometheus.MustRegister(GRPCOutboundClientMetrics)
 	prometheus.MustRegister(GRPCInboundClientMetrics)
+	prometheus.MustRegister(GRPCIntraProxyClientMetrics)
 
 	// Mux Session
 	prometheus.MustRegister(MuxSessionOpen)


### PR DESCRIPTION
The `GRPCIntraProxyClientMetrics` metrics are missed during registration.

This PR adds those metrics.