### PR TITLE
Export SessionStateName and DesiredMuxCount from transport/mux

### DIFF
--- a/proxy/debug.go
+++ b/proxy/debug.go
@@ -10,7 +10,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 
 	"github.com/temporalio/s2s-proxy/transport/mux"
-	"github.com/temporalio/s2s-proxy/transport/mux/session"
 )
 
 // HandleDebugInfo is the HTTP handler for the proxy debug endpoint.
@@ -168,18 +167,7 @@ func getMuxConnectionsInfo(server contextAwareServer, direction string) []MuxCon
 	var connInfos []MuxConnectionInfo
 	for id, muxSession := range connections {
 		localAddr, remoteAddr := muxSession.GetConnectionInfo()
-		state := muxSession.State()
-		stateStr := "unknown"
-		if state != nil {
-			switch state.State {
-			case session.Connected:
-				stateStr = "connected"
-			case session.Closed:
-				stateStr = "closed"
-			case session.Error:
-				stateStr = "error"
-			}
-		}
+		stateStr := mux.SessionStateName(muxSession.State())
 
 		localAddrStr := ""
 		if localAddr != nil {

--- a/transport/mux/grpc_mux_manager.go
+++ b/transport/mux/grpc_mux_manager.go
@@ -21,14 +21,19 @@ type ConnListener interface {
 
 // NewGRPCMuxManager starts a MuxManager that will start a grpc.Server using the provided definition on every generated mux,
 // and will manage the mux connections of the provided grpcutil.MultiClientConn such that they match the list of available muxes
+// DesiredMuxCount is how many sessions a cluster definition asks for.
+func DesiredMuxCount(cd config.ClusterDefinition) int {
+	// sane default for existing configs
+	if cd.MuxCount == 0 {
+		return 10
+	}
+	return cd.MuxCount
+}
+
 // Caller usage: 1. Create the MultiClientConn, 2. call NewGRPCMuxManager, 3. MultiMuxManager.Start, 4. Use the grpcutil.MultiClientConn
 // grpc.Server's will be started on every inbound mux automatically.
 func NewGRPCMuxManager(ctx context.Context, name string, cd config.ClusterDefinition, listener ConnListener, serverDefinition *grpc.Server, logger log.Logger) (MultiMuxManager, error) {
-	// sane default for existing configs
-	muxCount := 10
-	if cd.MuxCount != 0 {
-		muxCount = cd.MuxCount
-	}
+	muxCount := DesiredMuxCount(cd)
 	connectionTypeName := string(cd.ConnectionType)
 	metricLabels := []string{cd.MuxAddressInfo.ConnectionString, connectionTypeName, name}
 	var muxProviderBuilder MuxProviderBuilder

--- a/transport/mux/state.go
+++ b/transport/mux/state.go
@@ -1,0 +1,29 @@
+package mux
+
+import (
+	"github.com/temporalio/s2s-proxy/transport/mux/session"
+)
+
+// Session state names.
+const (
+	SessionStateConnected = "connected"
+	SessionStateClosed    = "closed"
+	SessionStateErrored   = "error"
+	SessionStateUnknown   = "unknown"
+)
+
+// SessionStateName names a session's state. A nil info means the state has not been recorded yet.
+func SessionStateName(info *session.MuxSessionInfo) string {
+	if info == nil {
+		return SessionStateUnknown
+	}
+	switch info.State {
+	case session.Connected:
+		return SessionStateConnected
+	case session.Closed:
+		return SessionStateClosed
+	case session.Error:
+		return SessionStateErrored
+	}
+	return SessionStateUnknown
+}

--- a/transport/mux/state_test.go
+++ b/transport/mux/state_test.go
@@ -1,0 +1,34 @@
+package mux
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/transport/mux/session"
+)
+
+func TestSessionStateName(t *testing.T) {
+	cases := []struct {
+		name string
+		info *session.MuxSessionInfo
+		want string
+	}{
+		{name: "connected", info: &session.MuxSessionInfo{State: session.Connected}, want: SessionStateConnected},
+		{name: "closed", info: &session.MuxSessionInfo{State: session.Closed}, want: SessionStateClosed},
+		{name: "errored", info: &session.MuxSessionInfo{State: session.Error}, want: SessionStateErrored},
+		// A session added to the manager before its first health check has no recorded state.
+		{name: "not recorded", info: nil, want: SessionStateUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, SessionStateName(c.info))
+		})
+	}
+}
+
+func TestDesiredMuxCount(t *testing.T) {
+	require.Equal(t, 7, DesiredMuxCount(config.ClusterDefinition{MuxCount: 7}))
+	require.Equal(t, 10, DesiredMuxCount(config.ClusterDefinition{}))
+}


### PR DESCRIPTION
Consolidates mux logic for `SessionStateName` and `DesiredMuxCount` into single exported place.