### PR TITLE
Close the socket createTCPServer binds when its lifetime ends

### DIFF
--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -271,6 +271,10 @@ func createTCPServer(lifetime context.Context, c serverConfiguration) (contextAw
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid configuration for inbound server: %w", err)
 	}
+	// The socket is bound here, before Start. Close it when the lifetime ends so that a server
+	// which is built and then abandoned does not hold the port. Start registers its own close, and
+	// the second one is a no-op.
+	context.AfterFunc(lifetime, func() { _ = listener.Close() })
 	grpcServer, err := buildProxyServer(c, c.clusterDefinition.TcpServer.TLSConfig, observer.ReportStreamValue, lifetime)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create inbound server: %w", err)

--- a/proxy/cluster_connection_test.go
+++ b/proxy/cluster_connection_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -297,4 +298,37 @@ func TestMuxCCFailover(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "remote-EchoAdminService", resp.ClusterName, "Local cluster connection should have reconnected")
 	cancel()
+}
+
+// A cluster connection binds its sockets when it is built. Ending its lifetime releases them.
+// Nothing has to start for that to hold.
+//
+// The connection stays reachable across the assertion on purpose. An unreachable listener is closed
+// by its finalizer on the next GC cycle. That would report success whether or not the lifetime
+// released the port. A proxy holds its connections in a map for its whole life, so no finalizer
+// runs there.
+func TestTCPListenerIsReleasedWhenNeverStarted(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cc, err := NewClusterConnection(ctx, makeTCPClusterConfig("abandoned", localFVI, remoteFVI,
+		a.localProxyOutbound, a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound,
+		a.remoteProxyInbound), loggers)
+	require.NoError(t, err)
+
+	cancel() // never Started
+
+	// A TCP connection builds an inbound and an outbound server, and both bind a socket.
+	for _, address := range []string{a.localProxyInbound, a.localProxyOutbound} {
+		require.Eventually(t, func() bool {
+			l, err := net.Listen("tcp", address)
+			if err != nil {
+				return false
+			}
+			_ = l.Close()
+			return true
+		}, 5*time.Second, 50*time.Millisecond, "listener on %s was never released", address)
+	}
+	runtime.KeepAlive(cc)
 }


### PR DESCRIPTION
createTCPServer binds its listener before anything serves on it. The only close
was the one simpleGRPCServer.Start registers against the lifetime. A server that
is built and never started therefore held its port until the process exited.

Three paths reach that state:

  - buildProxyServer runs on the line after net.Listen. When it fails,
    createTCPServer returns with the socket already open.
  - NewClusterConnection builds an inbound server and then an outbound one. When
    the second fails, the first has already bound.
  - Any cluster connection that is built and then dropped without Start.

Registering the close at the bind covers all three. Start's own close then acts
on a socket that is already shut. That is a no-op.