### PR TITLE
Return an error from NewProxy during failure modes.

### DIFF
--- a/endtoendtest/echo_server.go
+++ b/endtoendtest/echo_server.go
@@ -119,10 +119,14 @@ func NewEchoServer(
 		}
 
 		configProvider := config.NewMockConfigProvider(*localClusterInfo.S2sProxyConfig)
-		proxy = s2sproxy.NewProxy(
+		var err error
+		proxy, err = s2sproxy.NewProxy(
 			configProvider,
 			logging.NewLoggerProvider(logger, configProvider),
 		)
+		if err != nil {
+			panic(err)
+		}
 
 		clientAddress = localProxyCfg.ClusterConnections[0].Local.TcpServer.ConnectionString
 	} else {

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -271,6 +271,8 @@ func createTCPServer(lifetime context.Context, c serverConfiguration) (contextAw
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid configuration for inbound server: %w", err)
 	}
+	// Ending the lifetime releases the port.
+	context.AfterFunc(lifetime, func() { _ = listener.Close() })
 	grpcServer, err := buildProxyServer(c, c.clusterDefinition.TcpServer.TLSConfig, observer.ReportStreamValue, lifetime)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create inbound server: %w", err)

--- a/proxy/cluster_connection_test.go
+++ b/proxy/cluster_connection_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -297,4 +298,66 @@ func TestMuxCCFailover(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "remote-EchoAdminService", resp.ClusterName, "Local cluster connection should have reconnected")
 	cancel()
+}
+
+func TestNewProxyReportsConfigurationErrors(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+
+	t.Run("no cluster connections", func(t *testing.T) {
+		_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{}), loggers)
+		require.EqualError(t, err, "cannot create proxy: clusterConnections is empty")
+	})
+
+	t.Run("a cluster connection that cannot be built", func(t *testing.T) {
+		a := getDynamicPlccAddresses(t)
+		broken := makeTCPClusterConfig("broken", localFVI, remoteFVI, a.localProxyOutbound,
+			a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound, a.remoteProxyInbound)
+		broken.Local.ConnectionType = "not-a-connection-type"
+
+		_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
+			ClusterConnections: []config.ClusterConnConfig{broken},
+		}), loggers)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `cannot create cluster connection "broken"`)
+	})
+}
+
+func TestNewProxyRejectsDuplicateClusterConnectionNames(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+	first := makeTCPClusterConfig("same", localFVI, remoteFVI, a.localProxyOutbound,
+		a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound, a.remoteProxyInbound)
+	second := makeTCPClusterConfig("same", remoteFVI, localFVI, a.remoteProxyOutbound,
+		a.remoteTemporalAddr, a.remoteProxyInbound, a.remoteProxyOutbound, a.localProxyInbound)
+
+	_, err := NewProxy(config.NewMockConfigProvider(config.S2SProxyConfig{
+		ClusterConnections: []config.ClusterConnConfig{first, second},
+	}), loggers)
+	require.EqualError(t, err, `cannot create proxy: duplicate cluster connection name "same"`)
+}
+
+func TestTCPListenerIsReleasedWhenNeverStarted(t *testing.T) {
+	loggers := logging.NewLoggerProvider(log.NewTestLogger(), config.NewMockConfigProvider(config.S2SProxyConfig{}))
+	a := getDynamicPlccAddresses(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cc, err := NewClusterConnection(ctx, makeTCPClusterConfig("abandoned", localFVI, remoteFVI,
+		a.localProxyOutbound, a.localTemporalAddr, a.localProxyInbound, a.localProxyOutbound,
+		a.remoteProxyInbound), loggers)
+	require.NoError(t, err)
+
+	cancel() // never Started
+
+	// A TCP connection builds an inbound and an outbound server, and both bind a socket.
+	for _, address := range []string{a.localProxyInbound, a.localProxyOutbound} {
+		require.Eventually(t, func() bool {
+			l, err := net.Listen("tcp", address)
+			if err != nil {
+				return false
+			}
+			_ = l.Close()
+			return true
+		}, 5*time.Second, 50*time.Millisecond, "listener on %s was never released", address)
+	}
+	runtime.KeepAlive(cc)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -37,7 +37,7 @@ type (
 	}
 )
 
-func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerProvider) *Proxy {
+func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerProvider) (*Proxy, error) {
 	s2sConfig := configProvider.GetS2SProxyConfig()
 	ctx, cancel := context.WithCancel(context.Background())
 	proxy := &Proxy{
@@ -47,7 +47,8 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 		logProvider:        logProvider,
 	}
 	if len(s2sConfig.ClusterConnections) == 0 {
-		panic(errors.New("cannot create proxy: clusterConnections is empty"))
+		cancel()
+		return nil, errors.New("cannot create proxy: clusterConnections is empty")
 	}
 	if s2sConfig.Metrics != nil {
 		proxy.metricsConfig = s2sConfig.Metrics
@@ -55,13 +56,18 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 	proxy.profilingConfig = s2sConfig.ProfilingConfig
 
 	for _, clusterCfg := range s2sConfig.ClusterConnections {
+		id := migrationId{clusterCfg.Name}
+		// Error on duplicate cluster connection names
+		if _, duplicate := proxy.clusterConnections[id]; duplicate {
+			cancel()
+			return nil, fmt.Errorf("cannot create proxy: duplicate cluster connection name %q", clusterCfg.Name)
+		}
 		cc, err := NewClusterConnection(ctx, clusterCfg, logProvider)
 		if err != nil {
-			logProvider.Get("init").Fatal("Incorrectly configured Mux cluster connection", tag.Error(err), tag.NewStringTag("name", clusterCfg.Name))
-			continue
+			cancel()
+			return nil, fmt.Errorf("cannot create cluster connection %q: %w", clusterCfg.Name, err)
 		}
-		migrationId := migrationId{clusterCfg.Name}
-		proxy.clusterConnections[migrationId] = cc
+		proxy.clusterConnections[id] = cc
 	}
 	// TODO: correctly host multiple health checks
 	if len(s2sConfig.ClusterConnections) > 0 && s2sConfig.ClusterConnections[0].LocalClusterHealthCheck.ListenAddress != "" {
@@ -72,7 +78,7 @@ func NewProxy(configProvider config.ConfigProvider, logProvider logging.LoggerPr
 	}
 
 	metrics.NewProxyCount.Inc()
-	return proxy
+	return proxy, nil
 }
 
 func (s *Proxy) startHealthCheckHandler(lifetime context.Context, healthChecker HealthChecker, cfg config.HealthCheckConfig) (*http.Server, error) {

--- a/proxy/test/test_common.go
+++ b/proxy/test/test_common.go
@@ -353,12 +353,12 @@ func createProxy(
 	}
 
 	configProvider := &simpleConfigProvider{cfg: *cfg}
-	proxy := s2sproxy.NewProxy(configProvider, logging.NewLoggerProvider(logger, configProvider))
-	if proxy == nil {
-		t.Fatalf("Failed to create proxy %s", name)
+	proxy, err := s2sproxy.NewProxy(configProvider, logging.NewLoggerProvider(logger, configProvider))
+	if err != nil {
+		t.Fatalf("Failed to create proxy %s: %v", name, err)
 	}
 
-	err := proxy.Start()
+	err = proxy.Start()
 	if err != nil {
 		t.Fatalf("Failed to start proxy %s: %v", name, err)
 	}


### PR DESCRIPTION
`NewProxy` did not error during failure modes - it either panicked from insode or logged fatal and continue. Neither of these are particularly great.

Instead, we opt to return an error - and cascade accordingly. 

Also added:
- A duplicate cluster connection name is rejected. Connections are keyed by name, previously a repeat replaced the first in the map, now it errors.
-  createTCPServer closes its listener when the lifetime ends. It binds the socket before anything serves on it. 