### PR TITLE
Add CountSessions to summarise mux session state

### DIFF
--- a/transport/mux/grpc_mux_manager.go
+++ b/transport/mux/grpc_mux_manager.go
@@ -19,8 +19,6 @@ type ConnListener interface {
 	OnConnectionListUpdate(map[string]session.ManagedMuxSession)
 }
 
-// NewGRPCMuxManager starts a MuxManager that will start a grpc.Server using the provided definition on every generated mux,
-// and will manage the mux connections of the provided grpcutil.MultiClientConn such that they match the list of available muxes
 // DesiredMuxCount is how many sessions a cluster definition asks for.
 func DesiredMuxCount(cd config.ClusterDefinition) int {
 	// sane default for existing configs
@@ -30,6 +28,9 @@ func DesiredMuxCount(cd config.ClusterDefinition) int {
 	return cd.MuxCount
 }
 
+// NewGRPCMuxManager starts a MuxManager that will start a grpc.Server using the provided definition on every generated mux,
+// and will manage the mux connections of the provided grpcutil.MultiClientConn such that they match the list of available muxes
+//
 // Caller usage: 1. Create the MultiClientConn, 2. call NewGRPCMuxManager, 3. MultiMuxManager.Start, 4. Use the grpcutil.MultiClientConn
 // grpc.Server's will be started on every inbound mux automatically.
 func NewGRPCMuxManager(ctx context.Context, name string, cd config.ClusterDefinition, listener ConnListener, serverDefinition *grpc.Server, logger log.Logger) (MultiMuxManager, error) {

--- a/transport/mux/multi_mux_manager.go
+++ b/transport/mux/multi_mux_manager.go
@@ -169,7 +169,9 @@ func (m *multiMuxManager) Start() {
 				}
 				m.muxesLock.RUnlock()
 				m.logger.Info("MuxManager status", tag.NewBoolTag("shutdown", m.hasShutDown.IsShutdown()),
-					tag.Name(m.name), tag.NewStringTag("sessions", sb.String()))
+					tag.Name(m.name),
+					tag.NewStringTag("counts", CountSessions(m).String()),
+					tag.NewStringTag("sessions", sb.String()))
 			}
 		}()
 		// Allow the mux provider some time to provide connections

--- a/transport/mux/state.go
+++ b/transport/mux/state.go
@@ -1,6 +1,8 @@
 package mux
 
 import (
+	"fmt"
+
 	"github.com/temporalio/s2s-proxy/transport/mux/session"
 )
 
@@ -26,4 +28,41 @@ func SessionStateName(info *session.MuxSessionInfo) string {
 		return SessionStateErrored
 	}
 	return SessionStateUnknown
+}
+
+// SessionCounts summarises the sessions held by a MultiMuxManager.
+type SessionCounts struct {
+	Connected int
+	Errored   int
+	Closed    int
+	Total     int
+}
+
+// CountSessions summarises a mux manager's sessions.
+func CountSessions(m MultiMuxManager) SessionCounts {
+	var c SessionCounts
+	if m == nil {
+		return c
+	}
+	for _, conn := range m.GetMuxConnections() {
+		c.Total++
+		state := conn.State()
+		if state == nil {
+			continue
+		}
+		switch state.State {
+		case session.Connected:
+			c.Connected++
+		case session.Error:
+			c.Errored++
+		case session.Closed:
+			c.Closed++
+		}
+	}
+	return c
+}
+
+// String renders the counts for a log line, as "connected=3/4 errored=0 closed=1".
+func (c SessionCounts) String() string {
+	return fmt.Sprintf("connected=%d/%d errored=%d closed=%d", c.Connected, c.Total, c.Errored, c.Closed)
 }

--- a/transport/mux/state_test.go
+++ b/transport/mux/state_test.go
@@ -32,3 +32,71 @@ func TestDesiredMuxCount(t *testing.T) {
 	require.Equal(t, 7, DesiredMuxCount(config.ClusterDefinition{MuxCount: 7}))
 	require.Equal(t, 10, DesiredMuxCount(config.ClusterDefinition{}))
 }
+
+// stubManager reports a fixed session set. CountSessions reaches only GetMuxConnections.
+type stubManager struct {
+	MultiMuxManager
+	sessions map[string]session.ManagedMuxSession
+}
+
+func (s stubManager) GetMuxConnections() map[string]session.ManagedMuxSession { return s.sessions }
+
+type stubSession struct {
+	session.ManagedMuxSession
+	info *session.MuxSessionInfo
+}
+
+func (s stubSession) State() *session.MuxSessionInfo { return s.info }
+
+func TestCountSessions(t *testing.T) {
+	inState := func(st session.MuxSessionState) session.ManagedMuxSession {
+		return stubSession{info: &session.MuxSessionInfo{State: st}}
+	}
+
+	cases := []struct {
+		name    string
+		manager MultiMuxManager
+		want    SessionCounts
+	}{
+		{
+			// Reached when a cluster connection is not multiplexed.
+			name:    "a nil manager holds nothing",
+			manager: nil,
+			want:    SessionCounts{},
+		},
+		{
+			name:    "no sessions",
+			manager: stubManager{sessions: map[string]session.ManagedMuxSession{}},
+			want:    SessionCounts{},
+		},
+		{
+			name: "one of each",
+			manager: stubManager{sessions: map[string]session.ManagedMuxSession{
+				"a": inState(session.Connected),
+				"b": inState(session.Closed),
+				"c": inState(session.Error),
+			}},
+			want: SessionCounts{Connected: 1, Closed: 1, Errored: 1, Total: 3},
+		},
+		{
+			// A session with no recorded state counts toward Total and nothing else.
+			name: "state not yet recorded",
+			manager: stubManager{sessions: map[string]session.ManagedMuxSession{
+				"a": stubSession{info: nil},
+			}},
+			want: SessionCounts{Total: 1},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, CountSessions(c.manager))
+		})
+	}
+}
+
+func TestSessionCountsString(t *testing.T) {
+	require.Equal(t, "connected=0/0 errored=0 closed=0", SessionCounts{}.String())
+	require.Equal(t, "connected=3/5 errored=1 closed=1",
+		SessionCounts{Connected: 3, Errored: 1, Closed: 1, Total: 5}.String())
+}


### PR DESCRIPTION
## Summary

We need more detail to breakdown state of a mux manager's sessions. 

Introduces `CountSessions` which returns a breakdown: connected, errored, closed and total.

The manager's existing once-a-minute `"MuxManager status"` log line prints these. In future, these will be used for across-group aggregation of state. 

It will log:

```
MuxManager status  {"component": "MuxManager-a", "shutdown": false, "name": "a",
                    "counts": "connected=3/4 errored=1 closed=0", "sessions": "..."}
```

Where connected is logging: connected / total - and the remaining indicates the state of non-connected muxes.
