### PR TITLE
[no-impl] Pass a closure to visitDataBlobs

### DIFF
--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -137,6 +137,11 @@ type stringMatcher func(name string) (string, bool)
 // It returns whether anything was matched and any error it encountered.
 type visitor func(logger log.Logger, obj any, match stringMatcher) (bool, error)
 
+// blobVisitor visits the history events deserialized from a data blob. Callers close over
+// whatever matching state they need, since a data blob starts a fresh traversal that cannot
+// see the enclosing message.
+type blobVisitor func(events []*history.HistoryEvent) (bool, error)
+
 // visitNamespace uses reflection to recursively visit all fields
 // in the given object. When it finds namespace string fields, it invokes
 // the provided match function.
@@ -180,7 +185,9 @@ func visitNamespace(logger log.Logger, obj any, match stringMatcher) (bool, erro
 			}
 			return visit.Skip, nil
 		} else if dataBlobFieldNames[fieldType.Name] {
-			changed, err := visitDataBlobs(logger, vwp, match, visitNamespace)
+			changed, err := visitDataBlobs(logger, vwp, func(events []*history.HistoryEvent) (bool, error) {
+				return visitNamespace(logger, events, match)
+			})
 			matched = matched || changed
 			if err != nil {
 				return visit.Stop, err
@@ -225,7 +232,9 @@ func visitSearchAttributes(logger log.Logger, obj any, match stringMatcher) (boo
 			return action, nil
 		}
 		if dataBlobFieldNames[fieldType.Name] {
-			changed, err := visitDataBlobs(logger, vwp, match, visitSearchAttributes)
+			changed, err := visitDataBlobs(logger, vwp, func(events []*history.HistoryEvent) (bool, error) {
+				return visitSearchAttributes(logger, events, match)
+			})
 			matched = matched || changed
 			if err != nil {
 				return visit.Stop, err
@@ -287,10 +296,10 @@ func getParentFieldType(vwp visit.ValueWithParent) (result reflect.StructField, 
 	return fieldType, action
 }
 
-func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, match stringMatcher, visitor visitor) (bool, error) {
+func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, bv blobVisitor) (bool, error) {
 	switch evt := vwp.Interface().(type) {
 	case []*common.DataBlob:
-		newEvts, matched, changed, err := translateDataBlobs(logger, match, visitor, evt...)
+		newEvts, matched, changed, err := translateDataBlobs(logger, bv, evt...)
 		if err != nil {
 			return matched, err
 		}
@@ -301,7 +310,7 @@ func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, match stringMa
 		}
 		return matched, nil
 	case *common.DataBlob:
-		newEvt, matched, changed, err := translateOneDataBlob(logger, match, visitor, evt)
+		newEvt, matched, changed, err := translateOneDataBlob(logger, bv, evt)
 		if err != nil {
 			return matched, err
 		}
@@ -316,9 +325,9 @@ func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, match stringMa
 	}
 }
 
-func translateDataBlobs(logger log.Logger, match stringMatcher, visitor visitor, blobs ...*common.DataBlob) (result []*common.DataBlob, anyMatched, anyChanged bool, retErr error) {
+func translateDataBlobs(logger log.Logger, bv blobVisitor, blobs ...*common.DataBlob) (result []*common.DataBlob, anyMatched, anyChanged bool, retErr error) {
 	for i, blob := range blobs {
-		newBlob, matched, changed, err := translateOneDataBlob(logger, match, visitor, blob)
+		newBlob, matched, changed, err := translateOneDataBlob(logger, bv, blob)
 		anyChanged = anyChanged || changed
 		anyMatched = anyMatched || matched
 		if err != nil {
@@ -329,7 +338,7 @@ func translateDataBlobs(logger log.Logger, match stringMatcher, visitor visitor,
 	return blobs, anyMatched, anyChanged, nil
 }
 
-func translateOneDataBlob(logger log.Logger, match stringMatcher, visitor visitor, blob *common.DataBlob) (result *common.DataBlob, matched, changed bool, retErr error) {
+func translateOneDataBlob(logger log.Logger, bv blobVisitor, blob *common.DataBlob) (result *common.DataBlob, matched, changed bool, retErr error) {
 	if blob == nil || len(blob.Data) == 0 {
 		return blob, matched, changed, nil
 	}
@@ -356,7 +365,7 @@ func translateOneDataBlob(logger log.Logger, match stringMatcher, visitor visito
 		}
 	}
 
-	m, err := visitor(logger, events, match)
+	m, err := bv(events)
 	matched = matched || m
 	if err != nil {
 		return blob, matched, changed, err

--- a/interceptor/reflection.go
+++ b/interceptor/reflection.go
@@ -296,10 +296,10 @@ func getParentFieldType(vwp visit.ValueWithParent) (result reflect.StructField, 
 	return fieldType, action
 }
 
-func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, bv blobVisitor) (bool, error) {
+func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, visitEvents blobVisitor) (bool, error) {
 	switch evt := vwp.Interface().(type) {
 	case []*common.DataBlob:
-		newEvts, matched, changed, err := translateDataBlobs(logger, bv, evt...)
+		newEvts, matched, changed, err := translateDataBlobs(logger, visitEvents, evt...)
 		if err != nil {
 			return matched, err
 		}
@@ -310,7 +310,7 @@ func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, bv blobVisitor
 		}
 		return matched, nil
 	case *common.DataBlob:
-		newEvt, matched, changed, err := translateOneDataBlob(logger, bv, evt)
+		newEvt, matched, changed, err := translateOneDataBlob(logger, visitEvents, evt)
 		if err != nil {
 			return matched, err
 		}
@@ -325,9 +325,9 @@ func visitDataBlobs(logger log.Logger, vwp visit.ValueWithParent, bv blobVisitor
 	}
 }
 
-func translateDataBlobs(logger log.Logger, bv blobVisitor, blobs ...*common.DataBlob) (result []*common.DataBlob, anyMatched, anyChanged bool, retErr error) {
+func translateDataBlobs(logger log.Logger, visitEvents blobVisitor, blobs ...*common.DataBlob) (result []*common.DataBlob, anyMatched, anyChanged bool, retErr error) {
 	for i, blob := range blobs {
-		newBlob, matched, changed, err := translateOneDataBlob(logger, bv, blob)
+		newBlob, matched, changed, err := translateOneDataBlob(logger, visitEvents, blob)
 		anyChanged = anyChanged || changed
 		anyMatched = anyMatched || matched
 		if err != nil {
@@ -338,7 +338,7 @@ func translateDataBlobs(logger log.Logger, bv blobVisitor, blobs ...*common.Data
 	return blobs, anyMatched, anyChanged, nil
 }
 
-func translateOneDataBlob(logger log.Logger, bv blobVisitor, blob *common.DataBlob) (result *common.DataBlob, matched, changed bool, retErr error) {
+func translateOneDataBlob(logger log.Logger, visitEvents blobVisitor, blob *common.DataBlob) (result *common.DataBlob, matched, changed bool, retErr error) {
 	if blob == nil || len(blob.Data) == 0 {
 		return blob, matched, changed, nil
 	}
@@ -365,7 +365,7 @@ func translateOneDataBlob(logger log.Logger, bv blobVisitor, blob *common.DataBl
 		}
 	}
 
-	m, err := bv(events)
+	m, err := visitEvents(events)
 	matched = matched || m
 	if err != nil {
 		return blob, matched, changed, err


### PR DESCRIPTION
## The main idea

The functions that open a history blob need to hand the events inside to someone. Today that someone only needs one thing, the matcher, so passing the matcher as a parameter works fine.

That is about to stop being true. The next change needs to also pass in the namespace id, and the namespace id is only known at the call site, read off the message just before the blob is opened. If we keep passing things as parameters, all three functions in the chain grow a parameter now, and another one next time.

So instead of the helpers being told what to pass along, the caller hands them a closure and they just call it. The caller decides what to carry in.

## What was changed

`visitDataBlobs`, `translateDataBlobs` and `translateOneDataBlob` took a `stringMatcher` plus a `visitor` function. They now take one `blobVisitor` closure. The two callers wrap their existing call in it.

Before:

```go
visitDataBlobs(logger, vwp, match, visitNamespace)
```

After:

```go
visitDataBlobs(logger, vwp, func(events []*history.HistoryEvent) (bool, error) {
    return visitNamespace(logger, events, match)
})
```

And this is the call that needs it, in a later PR. Note that `match` alone is no longer enough:

```go
nsID := resolveNamespaceID(vwp, fallbackNamespaceID)
visitDataBlobs(logger, vwp, func(events []*history.HistoryEvent) (bool, error) {
    return visitSearchAttributes(logger, events, resolve, nsID)
})
```

One file, no behaviour change. Split out on its own so the change that follows is easier to read.

## Checklist

1. First step toward CGSCE-639.

2. How was this tested:

```sh
make generate-test-certs
go test -race -timeout=12m -tags test_dep -count=1 ./...
make lint
```

Both clean. No test file changed, which is the main thing I wanted to be true here.

One spot worth a second look. The `matched` and `changed` return values are handled exactly as before. Those two together decide whether a blob is written back, and no test tells them apart, so a mistake there would be quiet.

3. Any docs updates needed?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
