### PR TITLE
Add KEK and DEK metrics for encryption

### DIFF
--- a/encryption/crypto_meter.go
+++ b/encryption/crypto_meter.go
@@ -1,0 +1,258 @@
+package encryption
+
+import (
+	"iter"
+	"maps"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+
+	"github.com/temporalio/s2s-proxy/metrics"
+)
+
+type (
+	// cryptoMeter records the encryption metrics. It is the [cryptoOpMeter] a
+	// [KeyFactory] reports KEK operations to, and it is the [crypto.Observer] a
+	// vault reports its own envelope, cache, and rotation events to. Both sides
+	// land in the same place so a single meter covers a whole encryption
+	// pipeline.
+	//
+	// Every label combination that can occur in normal operation is resolved to a
+	// handle up front (see [newCryptoMeterFor]), because these metrics are
+	// recorded on the request path and resolving labels per call means hashing
+	// the label values and taking the vector's lock every time. A combination
+	// that was not anticipated still records, just by the slower path, so a new
+	// provider or a new rotation reason is never silently dropped.
+	//
+	// A cryptoMeter never changes after construction and the underlying
+	// collectors are safe for concurrent use, so one may be shared freely. That
+	// matters: [crypto.Observer] requires it.
+	cryptoMeter struct {
+		cryptoCollectors
+
+		kekOpHandle       map[kekOpKey]prometheus.Counter
+		kekDurHandle      map[kekDurKey]prometheus.Observer
+		dekOpHandle       map[dekOpKey]prometheus.Counter
+		dekDurHandle      map[string]prometheus.Observer
+		dekRotationHandle map[string]prometheus.Counter
+	}
+
+	// cryptoCollectors is the set of collectors a [cryptoMeter] writes to. It
+	// exists so the meter's wiring is separable from the process-wide collectors
+	// in [metrics], which are registered once in that package's init and cannot
+	// be reset.
+	cryptoCollectors struct {
+		kekOps       *prometheus.CounterVec
+		kekOpDur     *prometheus.HistogramVec
+		cacheHits    prometheus.Counter
+		cacheMisses  prometheus.Counter
+		cacheSize    prometheus.Gauge
+		dekOps       *prometheus.CounterVec
+		dekOpDur     *prometheus.HistogramVec
+		dekRotations *prometheus.CounterVec
+	}
+
+	// kekOpKey identifies one series of the KEK operation counter.
+	kekOpKey struct {
+		provider  string
+		operation string
+		result    string
+	}
+
+	// kekDurKey identifies one series of the KEK duration histogram, which does
+	// not break out the result: a failure's latency belongs with the successes it
+	// is being compared against.
+	kekDurKey struct {
+		provider  string
+		operation string
+	}
+
+	// dekOpKey identifies one series of the DEK operation counter. No provider
+	// appears here because the AES step uses no KMS.
+	dekOpKey struct {
+		operation string
+		result    string
+	}
+)
+
+// NewCryptoMeter returns a cryptoMeter recording to the process-wide encryption
+// collectors.
+func NewCryptoMeter() CryptoMeter {
+	return newCryptoMeterFor(cryptoCollectors{
+		kekOps:       metrics.EncryptionKEKOps,
+		kekOpDur:     metrics.EncryptionKEKOpDur,
+		cacheHits:    metrics.EncryptionDEKCacheHits,
+		cacheMisses:  metrics.EncryptionDEKCacheMisses,
+		cacheSize:    metrics.EncryptionDEKCacheSize,
+		dekOps:       metrics.EncryptionDEKOps,
+		dekOpDur:     metrics.EncryptionDEKOpDur,
+		dekRotations: metrics.EncryptionDEKRotations,
+	})
+}
+
+// newCryptoMeterFor returns a cryptoMeter recording to c, with a handle
+// resolved for every label combination the code paths below can produce: each
+// provider [cryptoProviders] names crossed with the KEK operations and results,
+// each DEK operation crossed with the results, and each rotation reason.
+//
+// Providers are deduplicated on the way in. Several schemes map onto one label,
+// so the values of cryptoProviders repeat, and priming the same handle twice
+// would be wasted work.
+func newCryptoMeterFor(c cryptoCollectors) *cryptoMeter {
+	m := &cryptoMeter{
+		cryptoCollectors: cryptoCollectors{
+			kekOps:       c.kekOps,
+			kekOpDur:     c.kekOpDur,
+			cacheHits:    c.cacheHits,
+			cacheMisses:  c.cacheMisses,
+			cacheSize:    c.cacheSize,
+			dekOps:       c.dekOps,
+			dekOpDur:     c.dekOpDur,
+			dekRotations: c.dekRotations,
+		},
+		kekOpHandle:       make(map[kekOpKey]prometheus.Counter),
+		kekDurHandle:      make(map[kekDurKey]prometheus.Observer),
+		dekOpHandle:       make(map[dekOpKey]prometheus.Counter),
+		dekDurHandle:      make(map[string]prometheus.Observer),
+		dekRotationHandle: make(map[string]prometheus.Counter),
+	}
+
+	uniq := func(seq iter.Seq[string]) iter.Seq[string] {
+		return func(yield func(string) bool) {
+			seen := make(map[string]struct{})
+			for v := range seq {
+				if _, exists := seen[v]; exists {
+					continue
+				}
+
+				seen[v] = struct{}{}
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+
+	results := []string{"success", "error"}
+	for p := range uniq(maps.Values(cryptoProviders)) {
+		for _, op := range []string{"wrap", "unwrap"} {
+			m.kekDurHandle[kekDurKey{p, op}] = m.kekOpDur.WithLabelValues(p, op)
+
+			for _, r := range results {
+				m.kekOpHandle[kekOpKey{p, op, r}] = m.kekOps.WithLabelValues(p, op, r)
+			}
+		}
+	}
+
+	for _, op := range []string{"encrypt", "decrypt"} {
+		m.dekDurHandle[op] = m.dekOpDur.WithLabelValues(op)
+		for _, res := range results {
+			m.dekOpHandle[dekOpKey{op, res}] = m.dekOps.WithLabelValues(op, res)
+		}
+	}
+
+	for _, reason := range []string{"scheduled", "on_demand", "initial"} {
+		m.dekRotationHandle[reason] = m.dekRotations.WithLabelValues(reason)
+	}
+
+	return m
+}
+
+// Op records one KEK operation, counting it and observing its duration. It
+// implements [cryptoOpMeter], so see that interface for what the labels mean.
+func (m *cryptoMeter) Op(provider, operation, result string, seconds float64) {
+	if c, ok := m.kekOpHandle[kekOpKey{provider, operation, result}]; ok {
+		c.Inc()
+	} else {
+		m.kekOps.WithLabelValues(provider, operation, result).Inc()
+	}
+
+	if o, ok := m.kekDurHandle[kekDurKey{provider, operation}]; ok {
+		o.Observe(seconds)
+	} else {
+		m.kekOpDur.WithLabelValues(provider, operation).Observe(seconds)
+	}
+}
+
+// Observe records a vault event, implementing [crypto.Observer]. An event of a
+// type this meter has no metric for is dropped rather than being an error: the
+// event set belongs to the crypto package and may grow.
+func (m *cryptoMeter) Observe(e crypto.Event) {
+	switch ev := e.(type) {
+	case crypto.EnvelopeEvent:
+		m.envelopeOp(ev)
+	case crypto.CacheEvent:
+		m.cacheAccess(ev)
+	case crypto.RotationEvent:
+		m.rotated(ev)
+	}
+}
+
+// envelopeOp records the AES step of one envelope operation. Note the metric is
+// the AES step alone, not the operation as a whole: the KEK calls around it are
+// already covered by [cryptoMeter.Op], and folding them in would bury a
+// microsecond of AES under a KMS round trip.
+//
+// So the result label comes from CryptoErr rather than Err. A seal that
+// encrypts fine and then fails to wrap its DEK counts as a successful DEK
+// operation and a failed KEK one, which is what actually happened.
+func (m *cryptoMeter) envelopeOp(e crypto.EnvelopeEvent) {
+	// No AES step, no DEK operation to record. CryptoAttempted is the only sound
+	// test for that: a zero Crypto cannot distinguish a step that never ran from
+	// one that finished inside the clock's resolution, so treating a zero as
+	// "never ran" would undercount both fast successes and fast failures.
+	if !e.CryptoAttempted {
+		return
+	}
+
+	// Every observation from here is a real measurement, including a zero, which
+	// belongs in the lowest bucket rather than being withheld.
+	op := e.Op.String()
+	m.countDEKOp(op, resultLabel(e.CryptoErr))
+	m.observeDEKDur(op, e.Crypto.Seconds())
+}
+
+// cacheAccess records a DEK cache access, and the resulting cache size along
+// with it. The size is a gauge the cache never reports on its own, so an access
+// is the only occasion to set it.
+func (m *cryptoMeter) cacheAccess(e crypto.CacheEvent) {
+	if e.Hit {
+		m.cacheHits.Inc()
+	} else {
+		m.cacheMisses.Inc()
+	}
+
+	m.cacheSize.Set(float64(e.Size))
+}
+
+// rotated counts a DEK rotation against its reason.
+func (m *cryptoMeter) rotated(e crypto.RotationEvent) {
+	reason := e.Reason.String()
+	if c, ok := m.dekRotationHandle[reason]; ok {
+		c.Inc()
+		return
+	}
+
+	m.dekRotations.WithLabelValues(reason).Inc()
+}
+
+// countDEKOp counts one DEK operation, by handle where one was primed.
+func (m *cryptoMeter) countDEKOp(op, result string) {
+	if c, ok := m.dekOpHandle[dekOpKey{op, result}]; ok {
+		c.Inc()
+		return
+	}
+
+	m.dekOps.WithLabelValues(op, result).Inc()
+}
+
+// observeDEKDur observes a DEK operation duration, by handle where one was
+// primed.
+func (m *cryptoMeter) observeDEKDur(op string, seconds float64) {
+	if o, ok := m.dekDurHandle[op]; ok {
+		o.Observe(seconds)
+		return
+	}
+
+	m.dekOpDur.WithLabelValues(op).Observe(seconds)
+}

--- a/encryption/crypto_meter_test.go
+++ b/encryption/crypto_meter_test.go
@@ -1,0 +1,311 @@
+package encryption
+
+import (
+	"cmp"
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+
+	"github.com/temporalio/s2s-proxy/metrics"
+)
+
+func TestNewCryptoMeterPrimesHandles(t *testing.T) {
+	m := newCryptoMeterFor(testCollectors())
+
+	byProvider := map[string]int{}
+	for k := range m.kekDurHandle {
+		byProvider[k.provider]++
+	}
+	require.Equal(t, map[string]int{"aws": 2, "gcp": 2, "azure": 2, "testing": 2}, byProvider)
+
+	require.Len(t, m.kekOpHandle, 16, "4 providers x 2 operations x 2 results")
+	require.Contains(t, m.kekOpHandle, kekOpKey{"aws", "wrap", "success"})
+	require.Contains(t, m.kekOpHandle, kekOpKey{"testing", "unwrap", "error"})
+
+	require.ElementsMatch(t, []dekOpKey{
+		{"encrypt", "success"},
+		{"encrypt", "error"},
+		{"decrypt", "success"},
+		{"decrypt", "error"},
+	}, slices.Collect(maps.Keys(m.dekOpHandle)))
+	require.Equal(t, []string{"decrypt", "encrypt"}, sortedKeys(m.dekDurHandle))
+	require.Equal(t, []string{"initial", "on_demand", "scheduled"}, sortedKeys(m.dekRotationHandle))
+}
+
+func TestNewCryptoMeterUsesTheProcessCollectors(t *testing.T) {
+	m := NewCryptoMeter().(*cryptoMeter)
+
+	require.Same(t, metrics.EncryptionKEKOps, m.kekOps)
+	require.Same(t, metrics.EncryptionKEKOpDur, m.kekOpDur)
+	require.Same(t, metrics.EncryptionDEKCacheHits, m.cacheHits)
+	require.Same(t, metrics.EncryptionDEKCacheMisses, m.cacheMisses)
+	require.Same(t, metrics.EncryptionDEKCacheSize, m.cacheSize)
+	require.Same(t, metrics.EncryptionDEKOps, m.dekOps)
+	require.Same(t, metrics.EncryptionDEKOpDur, m.dekOpDur)
+	require.Same(t, metrics.EncryptionDEKRotations, m.dekRotations)
+}
+
+func TestCryptoMeterOp(t *testing.T) {
+	t.Run("a primed label set", func(t *testing.T) {
+		c := testCollectors()
+		newCryptoMeterFor(c).Op("aws", "wrap", "success", 0.5)
+
+		require.Equal(t, 1.0, counter(c.kekOps, "aws", "wrap", "success"))
+		requireObserved(t, c.kekOpDur.WithLabelValues("aws", "wrap"), 1, 0.5)
+
+		// Nothing bled into the neighbouring series.
+		require.Zero(t, counter(c.kekOps, "aws", "wrap", "error"))
+		require.Zero(t, counter(c.kekOps, "aws", "unwrap", "success"))
+		requireObserved(t, c.kekOpDur.WithLabelValues("aws", "unwrap"), 0, 0)
+	})
+
+	t.Run("an unprimed provider still records", func(t *testing.T) {
+		c := testCollectors()
+		newCryptoMeterFor(c).Op("vault", "wrap", "success", 0.25)
+
+		require.Equal(t, 1.0, counter(c.kekOps, "vault", "wrap", "success"))
+		requireObserved(t, c.kekOpDur.WithLabelValues("vault", "wrap"), 1, 0.25)
+	})
+
+	t.Run("an unprimed result still records", func(t *testing.T) {
+		// The result is unknown but the provider and operation are not, so the
+		// counter takes the fallback while the histogram uses its primed handle.
+		c := testCollectors()
+		newCryptoMeterFor(c).Op("aws", "wrap", "cancelled", 0.125)
+
+		require.Equal(t, 1.0, counter(c.kekOps, "aws", "wrap", "cancelled"))
+		requireObserved(t, c.kekOpDur.WithLabelValues("aws", "wrap"), 1, 0.125)
+	})
+
+	t.Run("repeated operations accumulate", func(t *testing.T) {
+		c := testCollectors()
+		m := newCryptoMeterFor(c)
+		m.Op("gcp", "unwrap", "error", 1)
+		m.Op("gcp", "unwrap", "error", 2)
+
+		require.Equal(t, 2.0, counter(c.kekOps, "gcp", "unwrap", "error"))
+		requireObserved(t, c.kekOpDur.WithLabelValues("gcp", "unwrap"), 2, 3)
+	})
+}
+
+func TestCryptoMeterObserveEnvelope(t *testing.T) {
+	boom := errors.New("kms unavailable")
+
+	cases := []struct {
+		name  string
+		event crypto.EnvelopeEvent
+		// wantOp is empty when nothing at all should be recorded.
+		wantOp     string
+		wantResult string
+		wantSum    float64
+	}{
+		{
+			name: "an operation with no AES step records nothing",
+			// The duration is set to prove it is ignored: without CryptoAttempted
+			// there is no measurement here to believe.
+			event: crypto.EnvelopeEvent{Op: crypto.OpEncrypt, Err: boom, Crypto: time.Second},
+		},
+		{
+			name:       "a successful encrypt",
+			event:      crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true, Crypto: 250 * time.Microsecond},
+			wantOp:     "encrypt",
+			wantResult: "success",
+			wantSum:    0.00025,
+		},
+		{
+			name:       "a zero duration is still an observation",
+			event:      crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true},
+			wantOp:     "encrypt",
+			wantResult: "success",
+		},
+		{
+			name:       "a failed AES step",
+			event:      crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true, CryptoErr: boom, Err: boom},
+			wantOp:     "encrypt",
+			wantResult: "error",
+		},
+		{
+			name: "an encrypt whose wrap failed afterwards",
+			// The AES step itself succeeded, so that is what this metric reports.
+			// The wrap failure belongs to the KEK metrics.
+			event:      crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true, Err: boom},
+			wantOp:     "encrypt",
+			wantResult: "success",
+		},
+		{
+			name:       "a successful decrypt",
+			event:      crypto.EnvelopeEvent{Op: crypto.OpDecrypt, CryptoAttempted: true, Crypto: time.Millisecond},
+			wantOp:     "decrypt",
+			wantResult: "success",
+			wantSum:    0.001,
+		},
+		{
+			name:       "an unrecognised operation is labelled rather than dropped",
+			event:      crypto.EnvelopeEvent{Op: crypto.Operation(200), CryptoAttempted: true},
+			wantOp:     "unknown",
+			wantResult: "success",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := testCollectors()
+			newCryptoMeterFor(c).Observe(tc.event)
+			requireOnlyDEKOp(t, c, tc.wantOp, tc.wantResult, tc.wantSum)
+		})
+	}
+}
+
+func TestCryptoMeterObserveCache(t *testing.T) {
+	t.Run("a hit", func(t *testing.T) {
+		c := testCollectors()
+		newCryptoMeterFor(c).Observe(crypto.CacheEvent{Hit: true, Size: 7})
+
+		require.Equal(t, 1.0, testutil.ToFloat64(c.cacheHits))
+		require.Zero(t, testutil.ToFloat64(c.cacheMisses))
+		require.Equal(t, 7.0, testutil.ToFloat64(c.cacheSize))
+	})
+
+	t.Run("a miss", func(t *testing.T) {
+		c := testCollectors()
+		newCryptoMeterFor(c).Observe(crypto.CacheEvent{Size: 1})
+
+		require.Zero(t, testutil.ToFloat64(c.cacheHits))
+		require.Equal(t, 1.0, testutil.ToFloat64(c.cacheMisses))
+		require.Equal(t, 1.0, testutil.ToFloat64(c.cacheSize))
+	})
+
+	t.Run("the size is the latest reported and not a total", func(t *testing.T) {
+		c := testCollectors()
+		m := newCryptoMeterFor(c)
+		m.Observe(crypto.CacheEvent{Hit: true, Size: 5})
+		m.Observe(crypto.CacheEvent{Hit: true, Size: 3})
+
+		require.Equal(t, 2.0, testutil.ToFloat64(c.cacheHits))
+		require.Equal(t, 3.0, testutil.ToFloat64(c.cacheSize), "an eviction brings the gauge back down")
+	})
+
+	t.Run("an empty cache reports a zero size", func(t *testing.T) {
+		c := testCollectors()
+		newCryptoMeterFor(c).Observe(crypto.CacheEvent{})
+
+		require.Zero(t, testutil.ToFloat64(c.cacheSize))
+	})
+}
+
+func TestCryptoMeterObserveRotation(t *testing.T) {
+	reasons := []string{"scheduled", "on_demand", "initial", "unknown"}
+
+	cases := []struct {
+		name   string
+		reason crypto.RotationReason
+		want   string
+	}{
+		{"scheduled", crypto.RotationScheduled, "scheduled"},
+		{"on demand", crypto.RotationOnDemand, "on_demand"},
+		{"initial", crypto.RotationInitial, "initial"},
+		{"unrecognised reasons are labelled rather than dropped", crypto.RotationReason(200), "unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := testCollectors()
+			newCryptoMeterFor(c).Observe(crypto.RotationEvent{Namespace: "ns", Reason: tc.reason})
+
+			for _, r := range reasons {
+				want := 0.0
+				if r == tc.want {
+					want = 1
+				}
+
+				require.Equal(t, want, counter(c.dekRotations, r), "counter for %s", r)
+			}
+		})
+	}
+}
+
+func TestCryptoMeterObserveIgnoresPointerEvents(t *testing.T) {
+	// A vault reports its events by value and the type switch matches value
+	// types, so a pointer satisfies crypto.Event and then matches no case. This
+	// pins that down: it is a silent drop, not a panic.
+	c := testCollectors()
+	newCryptoMeterFor(c).Observe(&crypto.EnvelopeEvent{Op: crypto.OpEncrypt, CryptoAttempted: true})
+
+	requireOnlyDEKOp(t, c, "", "", 0)
+}
+
+// testCollectors mirrors the encryption collectors in [metrics], built fresh and
+// left unregistered so each test observes only its own recordings. Those are
+// process-wide and registered in that package's init, which makes them useless
+// for asserting an exact value.
+func testCollectors() cryptoCollectors {
+	return cryptoCollectors{
+		kekOps:       metrics.DefaultCounterVec("enc_kek_ops_total", "KEK operations", "provider", "operation", "result"),
+		kekOpDur:     metrics.DefaultHistogramVec("enc_kek_op_duration_secs", "KEK operation duration", "provider", "operation"),
+		cacheHits:    metrics.DefaultCounter("enc_dek_cache_hits_total", "DEK cache hits"),
+		cacheMisses:  metrics.DefaultCounter("enc_dek_cache_misses_total", "DEK cache misses"),
+		cacheSize:    metrics.DefaultGauge("enc_dek_cache_size", "DEK cache entries"),
+		dekOps:       metrics.DefaultCounterVec("enc_dek_ops_total", "DEK operations", "operation", "result"),
+		dekOpDur:     metrics.BucketedHistogramVec("enc_dek_op_duration_secs", "DEK operation duration", prometheus.ExponentialBuckets(0.00001, 4, 7), "operation"),
+		dekRotations: metrics.DefaultCounterVec("enc_dek_rotations_total", "DEK rotations", "reason"),
+	}
+}
+
+// sortedKeys returns the keys of m in ascending order, so a handle map can be
+// compared whole rather than key by key.
+func sortedKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := slices.Collect(maps.Keys(m))
+	slices.Sort(keys)
+
+	return keys
+}
+
+// counter reads the current value of one series of vec.
+func counter(vec *prometheus.CounterVec, labels ...string) float64 {
+	return testutil.ToFloat64(vec.WithLabelValues(labels...))
+}
+
+// requireObserved asserts that o recorded count observations totalling sum.
+// Reading a histogram takes more than [testutil.ToFloat64], which handles only
+// counters and gauges.
+func requireObserved(t *testing.T, o prometheus.Observer, count uint64, sum float64) {
+	t.Helper()
+
+	var m dto.Metric
+	require.NoError(t, o.(prometheus.Histogram).Write(&m))
+	require.Equal(t, count, m.GetHistogram().GetSampleCount())
+	require.InDelta(t, sum, m.GetHistogram().GetSampleSum(), 0.000001)
+}
+
+// requireOnlyDEKOp asserts that op/result is the one DEK series recorded, with
+// sum as its duration total. An empty op asserts nothing was recorded at all.
+func requireOnlyDEKOp(t *testing.T, c cryptoCollectors, op, result string, sum float64) {
+	t.Helper()
+
+	for _, o := range []string{"encrypt", "decrypt", "unknown"} {
+		for _, r := range []string{"success", "error"} {
+			want := 0.0
+			if o == op && r == result {
+				want = 1
+			}
+
+			require.Equal(t, want, counter(c.dekOps, o, r), "counter for %s/%s", o, r)
+		}
+
+		var wantCount uint64
+		var wantSum float64
+		if o == op {
+			wantCount, wantSum = 1, sum
+		}
+
+		requireObserved(t, c.dekOpDur.WithLabelValues(o), wantCount, wantSum)
+	}
+}

--- a/encryption/keys.go
+++ b/encryption/keys.go
@@ -1,0 +1,147 @@
+package encryption
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+// testingKeyScheme addresses a local in-process key. Unlike the cloud KMS
+// schemes it carries its own key material inline, which is what
+// [safeKeyString] exists to strip.
+const testingKeyScheme = "testing://"
+
+// cryptoProviders maps a key URI scheme onto the provider label its metrics
+// carry. Schemes may share a label: both local schemes report as "testing", so
+// a key that never should have left a developer's laptop is one series on a
+// dashboard rather than two. A scheme that is absent here is its own label, so
+// a scheme registered on the underlying factory still produces usable metrics
+// without being listed.
+var cryptoProviders = map[string]string{
+	"awskms":        "aws",
+	"gcpkms":        "gcp",
+	"azurekeyvault": "azure",
+	"base64key":     "testing",
+	"testing":       "testing",
+}
+
+type (
+	// KeyFactory opens [crypto.KEK]s and wraps each one so the KMS calls it makes
+	// are timed and counted. It adds nothing else: every URI scheme
+	// [crypto.KeyFactory] serves works here, and behaves the same way.
+	//
+	// A KeyFactory never changes after construction, so one may be shared by any
+	// number of goroutines opening keys at once.
+	KeyFactory struct {
+		kf    *crypto.KeyFactory
+		meter CryptoMeter
+	}
+
+	// cryptoKey is a [crypto.KEK] that reports the duration and outcome of every
+	// wrap and unwrap it performs. Only Encrypt and Decrypt are measured; ID and
+	// Close come straight from the embedded KEK.
+	cryptoKey struct {
+		crypto.KEK
+		provider string
+		meter    CryptoMeter
+	}
+
+	// CryptoMeter records KEK operations.
+	CryptoMeter interface {
+		// Op records one completed KEK operation, where operation is "wrap" or
+		// "unwrap", result is "success" or "error", and seconds is how long the call
+		// took.
+		Op(provider, operation, result string, seconds float64)
+	}
+)
+
+// NewKeyFactory returns a KeyFactory reporting to m the operations of every key
+// it opens.
+func NewKeyFactory(m CryptoMeter) *KeyFactory {
+	return &KeyFactory{
+		kf:    crypto.NewKeyFactory(),
+		meter: m,
+	}
+}
+
+// Create opens the key addressed by uri and wraps it so its wrap and unwrap
+// calls are measured under the provider label the URI scheme implies (see
+// [providerFor]). Which schemes are valid, and what a bad or unreachable key
+// looks like, is left to [crypto.KeyFactory.Create].
+//
+// Close the returned key when it is no longer needed.
+func (f *KeyFactory) Create(ctx context.Context, uri string) (crypto.KEK, error) {
+	k, err := f.kf.Create(ctx, uri)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KEK: %w", err)
+	}
+
+	return &cryptoKey{
+		KEK:      k,
+		provider: providerFor(uri),
+		meter:    f.meter,
+	}, nil
+}
+
+// Encrypt wraps b for ns, recording the call as a "wrap" against the key's
+// provider. The duration is recorded whether the call succeeded or not, so a
+// KMS that is timing out shows up as latency and not only as errors.
+func (m *cryptoKey) Encrypt(ctx context.Context, ns string, b []byte) ([]byte, error) {
+	start := time.Now()
+	ct, err := m.KEK.Encrypt(ctx, ns, b)
+	m.meter.Op(m.provider, "wrap", resultLabel(err), time.Since(start).Seconds())
+
+	return ct, err
+}
+
+// Decrypt unwraps b, recording the call as an "unwrap" against the key's
+// provider on the same terms as [cryptoKey.Encrypt].
+func (m *cryptoKey) Decrypt(ctx context.Context, b []byte) ([]byte, error) {
+	start := time.Now()
+	pt, err := m.KEK.Decrypt(ctx, b)
+	m.meter.Op(m.provider, "unwrap", resultLabel(err), time.Since(start).Seconds())
+
+	return pt, err
+}
+
+// providerFor returns the metrics provider label for a key URI: its scheme, run
+// through [cryptoProviders], lowercased because URI schemes are
+// case-insensitive and a caller may spell one any way it likes.
+//
+// The scheme is whatever precedes the first colon. A URI without one is not a
+// URI [crypto.KeyFactory.Create] would have opened, so there is nothing to
+// guard against here: the whole string becomes the label, and a label from a
+// key that never opened never reaches a metric.
+func providerFor(uri string) string {
+	provider, _, _ := strings.Cut(uri, ":")
+	provider = strings.ToLower(provider)
+	if p, ok := cryptoProviders[provider]; ok {
+		return p
+	}
+
+	return provider
+}
+
+// resultLabel is the metrics result label for an operation that returned err.
+func resultLabel(err error) string {
+	if err != nil {
+		return "error"
+	}
+
+	return "success"
+}
+
+// safeKeyString returns uri with the key material a [testingKeyScheme] URI
+// carries inline replaced, so the URI is safe to log or report in an error.
+// Every other scheme names a key rather than carrying it, and that name is what
+// makes a report useful, so those are returned unchanged.
+func safeKeyString(uri string) string {
+	if len(uri) < len(testingKeyScheme) || !strings.EqualFold(uri[:len(testingKeyScheme)], testingKeyScheme) {
+		return uri
+	}
+
+	return testingKeyScheme + "<redacted>"
+}

--- a/encryption/keys_test.go
+++ b/encryption/keys_test.go
@@ -1,0 +1,202 @@
+package encryption
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/temporal-proxy/pkg/crypto"
+)
+
+type (
+	// fakeOpMeter records the KEK operations reported to it, in order.
+	fakeOpMeter struct {
+		ops []recordedOp
+	}
+
+	recordedOp struct {
+		provider  string
+		operation string
+		result    string
+		seconds   float64
+	}
+
+	stubKEK struct {
+		// A nil embedded KEK means any method these tests do not exercise panics
+		// rather than quietly returning a zero value.
+		crypto.KEK
+
+		gotNS string
+		gotIn []byte
+		out   []byte
+		err   error
+	}
+)
+
+func TestProviderFor(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"aws", "awskms://alias/replication", "aws"},
+		{"gcp", "gcpkms://projects/p/locations/l/keyRings/r/cryptoKeys/k", "gcp"},
+		{"azure", "azurekeyvault://vault.vault.azure.net/keys/k", "azure"},
+		{"testing", "testing://", "testing"},
+		{"testing with material", "testing://c2Vjcg==", "testing"},
+		{"base64key shares the testing label", "base64key://c2Vjcg==", "testing"},
+		{"scheme match is case insensitive", "AWSKMS://alias/replication", "aws"},
+		{"unmapped scheme is its own label", "vault://secret/key", "vault"},
+		{"unmapped scheme is lowercased", "VAULT://secret/key", "vault"},
+		{"no scheme yields the whole string", "not-a-uri", "not-a-uri"},
+		{"empty URI yields an empty label", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, providerFor(tc.uri))
+		})
+	}
+}
+
+func TestKeyFactoryCreate(t *testing.T) {
+	t.Run("opens a key and measures it", func(t *testing.T) {
+		meter := &fakeOpMeter{}
+		k, err := NewKeyFactory(meter).Create(t.Context(), "testing://")
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, k.Close()) })
+
+		// The wrapper is transparent apart from the metering: the ID is the
+		// underlying key's, which is what the decrypt path looks a KEK up by.
+		require.Equal(t, "base64key://", k.ID())
+		require.Empty(t, meter.ops, "opening a key is not itself a KEK operation")
+	})
+
+	t.Run("reports an unopenable key", func(t *testing.T) {
+		k, err := NewKeyFactory(&fakeOpMeter{}).Create(t.Context(), "vault://secret/key")
+		require.Nil(t, k)
+		require.ErrorContains(t, err, "error creating KEK: key factory not found for scheme: vault")
+	})
+}
+
+func TestCryptoKeyMeasuresOperations(t *testing.T) {
+	boom := errors.New("kms unavailable")
+
+	newKey := func(stub *stubKEK) (*cryptoKey, *fakeOpMeter) {
+		meter := &fakeOpMeter{}
+		return &cryptoKey{KEK: stub, provider: "aws", meter: meter}, meter
+	}
+
+	t.Run("a successful wrap", func(t *testing.T) {
+		stub := &stubKEK{out: []byte("wrapped")}
+		k, meter := newKey(stub)
+
+		ct, err := k.Encrypt(t.Context(), "namespace", []byte("dek"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("wrapped"), ct)
+		require.Equal(t, "namespace", stub.gotNS, "the namespace reaches the underlying key")
+		require.Equal(t, []byte("dek"), stub.gotIn)
+		requireOp(t, meter, "aws", "wrap", "success")
+	})
+
+	t.Run("a failed wrap is still measured", func(t *testing.T) {
+		k, meter := newKey(&stubKEK{err: boom})
+
+		_, err := k.Encrypt(t.Context(), "namespace", []byte("dek"))
+		require.ErrorIs(t, err, boom, "the underlying error is returned as-is")
+		requireOp(t, meter, "aws", "wrap", "error")
+	})
+
+	t.Run("a successful unwrap", func(t *testing.T) {
+		stub := &stubKEK{out: []byte("dek")}
+		k, meter := newKey(stub)
+
+		pt, err := k.Decrypt(t.Context(), []byte("wrapped"))
+		require.NoError(t, err)
+		require.Equal(t, []byte("dek"), pt)
+		require.Equal(t, []byte("wrapped"), stub.gotIn)
+		requireOp(t, meter, "aws", "unwrap", "success")
+	})
+
+	t.Run("a failed unwrap is still measured", func(t *testing.T) {
+		k, meter := newKey(&stubKEK{err: boom})
+
+		_, err := k.Decrypt(t.Context(), []byte("wrapped"))
+		require.ErrorIs(t, err, boom)
+		requireOp(t, meter, "aws", "unwrap", "error")
+	})
+}
+
+func TestCryptoKeyRoundTrip(t *testing.T) {
+	meter := &fakeOpMeter{}
+	k, err := NewKeyFactory(meter).Create(t.Context(), "TESTING://")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, k.Close()) })
+
+	ct, err := k.Encrypt(t.Context(), "namespace", []byte("dek"))
+	require.NoError(t, err)
+
+	pt, err := k.Decrypt(t.Context(), ct)
+	require.NoError(t, err)
+	require.Equal(t, []byte("dek"), pt)
+
+	// The provider comes from the URI scheme, however it was spelled, and both
+	// halves of the round trip are reported separately.
+	require.Len(t, meter.ops, 2)
+	require.Equal(t, "testing", meter.ops[0].provider)
+	require.Equal(t, "wrap", meter.ops[0].operation)
+	require.Equal(t, "success", meter.ops[0].result)
+	require.Equal(t, "testing", meter.ops[1].provider)
+	require.Equal(t, "unwrap", meter.ops[1].operation)
+	require.Equal(t, "success", meter.ops[1].result)
+}
+
+func TestSafeKeyString(t *testing.T) {
+	cases := []struct {
+		name string
+		uri  string
+		want string
+	}{
+		{"inline key material is stripped", "testing://c2VjcmV0", "testing://<redacted>"},
+		{"scheme match is case insensitive", "TESTING://c2VjcmV0", "testing://<redacted>"},
+		{"a bare testing key is redacted too", "testing://", "testing://<redacted>"},
+		{"an AWS key names a key rather than carrying one", "awskms://alias/replication", "awskms://alias/replication"},
+		{"a GCP key is unchanged", "gcpkms://projects/p/locations/l", "gcpkms://projects/p/locations/l"},
+		{"a truncated scheme is unchanged", "testing:", "testing:"},
+		{"an empty URI is unchanged", "", ""},
+		// A testing key's ID is its material behind gocloud's own scheme, and only
+		// the scheme a caller writes is redacted, not that one.
+		{"base64key is not redacted", "base64key://c2VjcmV0", "base64key://c2VjcmV0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, safeKeyString(tc.uri))
+		})
+	}
+}
+
+func (m *fakeOpMeter) Op(provider, operation, result string, seconds float64) {
+	m.ops = append(m.ops, recordedOp{provider, operation, result, seconds})
+}
+
+// requireOp asserts that meter recorded exactly one operation, matching the
+// given labels and carrying a usable duration.
+func requireOp(t *testing.T, meter *fakeOpMeter, provider, operation, result string) {
+	t.Helper()
+
+	require.Len(t, meter.ops, 1)
+	require.Equal(t, recordedOp{provider, operation, result, meter.ops[0].seconds}, meter.ops[0])
+	require.GreaterOrEqual(t, meter.ops[0].seconds, 0.0, "a duration is always recorded")
+}
+
+func (k *stubKEK) Encrypt(_ context.Context, ns string, dek []byte) ([]byte, error) {
+	k.gotNS, k.gotIn = ns, dek
+	return k.out, k.err
+}
+
+func (k *stubKEK) Decrypt(_ context.Context, dek []byte) ([]byte, error) {
+	k.gotIn = dek
+	return k.out, k.err
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/keilerkonzept/visit v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/stretchr/testify v1.12.1
 	github.com/temporalio/temporal-proxy v0.5.2
 	github.com/urfave/cli/v2 v2.27.7
@@ -167,7 +168,6 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -116,7 +116,18 @@ func DefaultHistogramVec(name string, help string, labels ...string) *prometheus
 		Name:      SanitizeForPrometheus(name),
 		Help:      help,
 		// TODO: Native histograms aren't supported in our Grafana just yet
-		//NativeHistogramBucketFactor: 1.1,
+		// NativeHistogramBucketFactor: 1.1,
+	}, labels)
+}
+
+// BucketedHistogramVec provides a HistogramVec similar to [DefaultHistogramVec] but with the custom bucket sizes.
+func BucketedHistogramVec(name string, help string, buckets []float64, labels ...string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "temporal",
+		Subsystem: "s2s_proxy",
+		Name:      SanitizeForPrometheus(name),
+		Buckets:   buckets,
+		Help:      help,
 	}, labels)
 }
 

--- a/metrics/prometheus_defs.go
+++ b/metrics/prometheus_defs.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// This file is structured by package first, then by file.
-	//So /proxy/health_check.go, /proxy/proxy.go, and then /transport/mux_connection_manager.go
+	// So /proxy/health_check.go, /proxy/proxy.go, and then /transport/mux_connection_manager.go
 
 	// /proxy/adminservice.go
 
@@ -67,6 +67,16 @@ var (
 	// Connection provider
 	ReceiverError    = DefaultCounterVec("receiver_error", "Number of errors observed from connection receiver", append(muxManagerLabels, "error")...)
 	EstablisherError = DefaultCounterVec("establisher_error", "Number of errors observed from connection establisher", muxManagerLabels...)
+
+	// Encryption
+	EncryptionKEKOps         = DefaultCounterVec("enc_kek_ops_total", "Total KEK operations (DEK wrap/unwrap), labeled by provider, operation, and result", "provider", "operation", "result")
+	EncryptionKEKOpDur       = DefaultHistogramVec("enc_kek_op_duration_secs", "Duration of KEK operations in seconds, labeled by provider and operation", "provider", "operation")
+	EncryptionDEKCacheHits   = DefaultCounterVec("enc_dek_cache_hits_total", "Total DEK cache hits").WithLabelValues()
+	EncryptionDEKCacheMisses = DefaultCounterVec("enc_dek_cache_misses_total", "Total DEK cache misses").WithLabelValues()
+	EncryptionDEKCacheSize   = DefaultGauge("enc_dek_cache_size", "Current number of entries in the DEK cache")
+	EncryptionDEKOps         = DefaultCounterVec("enc_dek_ops_total", "Total DEK operations (payload encrypt/decrypt), labeled by operation and result", "operation", "result")
+	EncryptionDEKOpDur       = BucketedHistogramVec("enc_dek_op_duration_secs", "Duration of the AES-256-GCM step alone in seconds, excluding any KEK wrap or unwrap, labeled by operation", prometheus.ExponentialBuckets(0.00001, 4, 7), "operation")
+	EncryptionDEKRotations   = DefaultCounterVec("enc_dek_rotations_total", "Total DEK rotations, labeled by reason", "reason")
 
 	// Translation interceptor
 
@@ -135,6 +145,19 @@ func init() {
 	prometheus.MustRegister(EstablisherError)
 	prometheus.MustRegister(MuxServerDisconnected)
 	prometheus.MustRegister(NumMuxesActive)
+
+	// Encryption
+	prometheus.MustRegister(
+
+		EncryptionKEKOps,
+		EncryptionKEKOpDur,
+		EncryptionDEKCacheHits,
+		EncryptionDEKCacheMisses,
+		EncryptionDEKCacheSize,
+		EncryptionDEKOps,
+		EncryptionDEKOpDur,
+		EncryptionDEKRotations,
+	)
 
 	prometheus.MustRegister(TranslationCount)
 	prometheus.MustRegister(TranslationErrors)


### PR DESCRIPTION
The encryption pipeline needs telemetry, so a slow or failing KMS won't be invisible, and we can tell a DEK cache miss from a rotation.

The two layers are measured separately. A `KeyFactory` wraps every KEK it opens, so wrap and unwrap calls are timed and counted against the provider its URI names, and a `CryptoMeter` serves as the vault's `crypto.Observer` for envelope, cache, and rotation events. Keeping them apart is the point: the AES step is measured on its own, so microseconds of symmetric crypto are not buried under a KMS round trip. For the same reason, a seal that encrypts and then fails to wrap its DEK counts as a successful DEK operation and a failed KEK one, which is what actually happened.

Label combinations that occur in normal operation are resolved to handles at construction time, since they are recorded on the request path. Anything unanticipated is still recorded by the slower path rather than being dropped, so a provider or rotation reason added later still appears in the metrics.