### PR TITLE
VLN-1735: remediate checkout-below-v7

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
             ref: ${{ github.ref || inputs.commit || 'main' }}
 

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -20,7 +20,7 @@ jobs:
     name: lint, breaking and generation drift - pull request
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,7 +22,7 @@ jobs:
     name: lint - pull request
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -50,7 +50,7 @@ jobs:
     name: build and unittest - pull request
     steps:
       - name: Checkout
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>checkout-below-v7</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/s2s-proxy</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1735">VLN-1735</a></td></tr>
</table>

## Summary

- `.github/workflows/docker.yaml`: Updated the `actions/checkout` pin to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- `.github/workflows/pull-request.yml`: Updated both `actions/checkout` pins to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- `.github/workflows/proto.yml`: Updated the `actions/checkout` pin to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base