### PR TITLE
Apply top-level configOverride keys in the Helm chart

### DIFF
--- a/charts/s2s-proxy/templates/_helpers.tpl
+++ b/charts/s2s-proxy/templates/_helpers.tpl
@@ -72,6 +72,15 @@ Merge default config with overrides
 {{- end }}
 {{- $_ := set $merged "clusterConnections" $mergedClusterConnections -}}
 
+{{/*
+Merge every other top-level key of configOverride.
+deepCopy the source: sprig mergeOverwrite mutates its first argument.
+The loop above writes defaults into .Values.configOverride.clusterConnections in place.
+The binary decodes config with KnownFields(true).
+An unrecognised top-level key crashes the proxy on startup.
+*/}}
+{{- $merged = mergeOverwrite $merged (omit $overrides "clusterConnections" | deepCopy) -}}
+
 {{- $merged | toYaml }}
 {{- end }}
 

--- a/charts/s2s-proxy/tests/configmap_test.yaml
+++ b/charts/s2s-proxy/tests/configmap_test.yaml
@@ -36,3 +36,25 @@ tests:
           pattern: |-
             muxAddressInfo:
               \s*address: addr:3333
+
+  - it: should apply top-level configOverride keys
+    set:
+      configOverride:
+        metrics:
+          prometheus:
+            listenAddress: "0.0.0.0:9999"
+        clusterConnections:
+          - local:
+              tcpClient:
+                address: "frontend-other:2222"
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: |-
+            prometheus:
+              \s*listenAddress: 0.0.0.0:9999
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: |-
+            tcpClient:
+              \s*address: frontend-other:2222


### PR DESCRIPTION
draft