### PR TITLE
Export FetchCACert from the encryption package

### DIFF
--- a/encryption/certificate_test.go
+++ b/encryption/certificate_test.go
@@ -113,7 +113,7 @@ func (s *tlsTestSuite) Test_isCACert() {
 	s.False(isCACert(parseFirst(unconstrainedPEM(t, "legacy"))))
 }
 
-func (s *tlsTestSuite) Test_fetchCACert() {
+func (s *tlsTestSuite) Test_FetchCACert() {
 	t := s.T()
 
 	caBytes := caPEM(t, "root")
@@ -147,7 +147,7 @@ func (s *tlsTestSuite) Test_fetchCACert() {
 			path := filepath.Join(t.TempDir(), "ca.pem")
 			s.Require().NoError(os.WriteFile(path, tc.bundle, 0600))
 
-			pool, err := fetchCACert(path)
+			pool, err := FetchCACert(path)
 			if tc.wantErrIs != nil {
 				s.Require().Error(err)
 				s.Require().ErrorIs(err, tc.wantErrIs)
@@ -162,8 +162,8 @@ func (s *tlsTestSuite) Test_fetchCACert() {
 	}
 }
 
-func (s *tlsTestSuite) Test_fetchCACert_MissingFile() {
-	_, err := fetchCACert(filepath.Join(s.T().TempDir(), "does-not-exist.pem"))
+func (s *tlsTestSuite) Test_FetchCACert_MissingFile() {
+	_, err := FetchCACert(filepath.Join(s.T().TempDir(), "does-not-exist.pem"))
 	s.Require().Error(err)
 	s.Require().True(errors.Is(err, os.ErrNotExist))
 }

--- a/encryption/tls.go
+++ b/encryption/tls.go
@@ -53,7 +53,7 @@ func GetServerTLSConfig(serverConfig TLSConfig, logger log.Logger) (tlsConfig *t
 	tlsConfig = auth.NewEmptyTLSConfig()
 	if !serverConfig.SkipCAVerification {
 		tlsConfig.ClientAuth = tls.RequireAnyClientCert
-		tlsConfig.ClientCAs, err = fetchCACert(serverConfig.RemoteCAPath)
+		tlsConfig.ClientCAs, err = FetchCACert(serverConfig.RemoteCAPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read CACert from %s: %w", serverConfig.RemoteCAPath, err)
 		}
@@ -126,7 +126,7 @@ func GetClientTLSConfig(clientConfig TLSConfig) (tlsConfig *tls.Config, err erro
 	}
 
 	if clientConfig.RemoteCAPath != "" {
-		caCertPool, err := fetchCACert(clientConfig.RemoteCAPath)
+		caCertPool, err := FetchCACert(clientConfig.RemoteCAPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load CA cert: %w", err)
 		}
@@ -146,7 +146,8 @@ func GetClientTLSConfig(clientConfig TLSConfig) (tlsConfig *tls.Config, err erro
 	return
 }
 
-func fetchCACert(pathOrUrl string) (*x509.CertPool, error) {
+// FetchCACert reads a CA bundle from a file path or an https URL.
+func FetchCACert(pathOrUrl string) (*x509.CertPool, error) {
 	var caBytes []byte
 	var err error
 


### PR DESCRIPTION
Exports `fetchCACert` as `FetchCACert`, for callers that build their own `tls.Config` rather than going through `GetClientTLSConfig` or `GetServerTLSConfig`.

The function already handles both a file path and an https URL. Nothing about its behaviour changes. This only widens its visibility and updates the two internal callers and the tests.

## Testing

- `make lint`: 0 issues.
- `go build ./...` passes.
- `go test ./encryption/`: passes. `Test_fetchCACert` and `Test_fetchCACert_MissingFile` already cover both paths and are renamed with the function.
