### PR TITLE
Add OperatorService proxy and wire it into buildProxyServer

### DIFF
--- a/logging/logger_provider.go
+++ b/logging/logger_provider.go
@@ -10,6 +10,7 @@ import (
 const (
 	AdminService       = "adminService"
 	WorkflowService    = "workflowService"
+	OperatorService    = "operatorService"
 	ReplicationStreams = "replicationStreams"
 	ShardManager       = "shardManager"
 	ShardRouting       = "shardRouting"

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -363,8 +363,12 @@ func buildProxyServer(c serverConfiguration, tlsConfig encryption.TLSConfig, obs
 	if c.aclPolicy != nil {
 		accessControl = auth.NewAccesControl(c.aclPolicy.AllowedNamespaces)
 	}
-	workflowServiceImpl := NewWorkflowServiceProxyServer("inboundWorkflowService", workflowservice.NewWorkflowServiceClient(c.client),
-		accessControl, c.loggers)
+	workflowServiceImpl := NewWorkflowServiceProxyServer(
+		fmt.Sprintf("%sWorkflowService", c.directionLabel),
+		workflowservice.NewWorkflowServiceClient(c.client),
+		accessControl,
+		c.loggers,
+	)
 	operatorServiceImpl := NewOperatorServiceProxyServer(
 		fmt.Sprintf("%sOperatorService", c.directionLabel),
 		operatorservice.NewOperatorServiceClient(c.client),

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -11,6 +11,7 @@ import (
 
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common/log"
@@ -364,8 +365,15 @@ func buildProxyServer(c serverConfiguration, tlsConfig encryption.TLSConfig, obs
 	}
 	workflowServiceImpl := NewWorkflowServiceProxyServer("inboundWorkflowService", workflowservice.NewWorkflowServiceClient(c.client),
 		accessControl, c.loggers)
+	operatorServiceImpl := NewOperatorServiceProxyServer(
+		fmt.Sprintf("%sOperatorService", c.directionLabel),
+		operatorservice.NewOperatorServiceClient(c.client),
+		[]string{c.directionLabel},
+		c.loggers,
+	)
 	adminservice.RegisterAdminServiceServer(server, adminServiceImpl)
 	workflowservice.RegisterWorkflowServiceServer(server, workflowServiceImpl)
+	operatorservice.RegisterOperatorServiceServer(server, operatorServiceImpl)
 	return server, nil
 }
 

--- a/proxy/operatorservice.go
+++ b/proxy/operatorservice.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"context"
+
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+
+	"github.com/temporalio/s2s-proxy/common"
+	"github.com/temporalio/s2s-proxy/logging"
+)
+
+type operatorServiceProxyServer struct {
+	operatorservice.UnimplementedOperatorServiceServer
+	operatorServiceClient operatorservice.OperatorServiceClient
+	logger                log.Logger
+	metricLabelValues     []string
+}
+
+// NewOperatorServiceProxyServer creates an OperatorServiceServer suitable for registering with a gRPC Server.
+// Requests are forwarded to the passed in OperatorService client.
+func NewOperatorServiceProxyServer(
+	serviceName string,
+	operatorServiceClient operatorservice.OperatorServiceClient,
+	metricLabelValues []string,
+	logProvider logging.LoggerProvider,
+) operatorservice.OperatorServiceServer {
+	return &operatorServiceProxyServer{
+		operatorServiceClient: operatorServiceClient,
+		logger:                log.With(logProvider.Get(logging.OperatorService), common.ServiceTag(serviceName)),
+		metricLabelValues:     metricLabelValues,
+	}
+}
+
+func (s *operatorServiceProxyServer) AddSearchAttributes(ctx context.Context, in0 *operatorservice.AddSearchAttributesRequest) (*operatorservice.AddSearchAttributesResponse, error) {
+	return s.operatorServiceClient.AddSearchAttributes(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) RemoveSearchAttributes(ctx context.Context, in0 *operatorservice.RemoveSearchAttributesRequest) (*operatorservice.RemoveSearchAttributesResponse, error) {
+	return s.operatorServiceClient.RemoveSearchAttributes(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) ListSearchAttributes(ctx context.Context, in0 *operatorservice.ListSearchAttributesRequest) (*operatorservice.ListSearchAttributesResponse, error) {
+	return s.operatorServiceClient.ListSearchAttributes(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) DeleteNamespace(ctx context.Context, in0 *operatorservice.DeleteNamespaceRequest) (*operatorservice.DeleteNamespaceResponse, error) {
+	return s.operatorServiceClient.DeleteNamespace(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) AddOrUpdateRemoteCluster(ctx context.Context, in0 *operatorservice.AddOrUpdateRemoteClusterRequest) (*operatorservice.AddOrUpdateRemoteClusterResponse, error) {
+	s.logger.Info("Received AddOrUpdateRemoteCluster",
+		tag.Address(in0.GetFrontendAddress()),
+		tag.NewBoolTag("Enabled", in0.GetEnableRemoteClusterConnection()),
+		tag.NewStringsTag("configTags", s.metricLabelValues))
+	return s.operatorServiceClient.AddOrUpdateRemoteCluster(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) RemoveRemoteCluster(ctx context.Context, in0 *operatorservice.RemoveRemoteClusterRequest) (*operatorservice.RemoveRemoteClusterResponse, error) {
+	s.logger.Info("Received RemoveRemoteCluster",
+		tag.NewStringTag("ClusterName", in0.GetClusterName()),
+		tag.NewStringsTag("configTags", s.metricLabelValues))
+	return s.operatorServiceClient.RemoveRemoteCluster(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) ListClusters(ctx context.Context, in0 *operatorservice.ListClustersRequest) (*operatorservice.ListClustersResponse, error) {
+	return s.operatorServiceClient.ListClusters(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) GetNexusEndpoint(ctx context.Context, in0 *operatorservice.GetNexusEndpointRequest) (*operatorservice.GetNexusEndpointResponse, error) {
+	return s.operatorServiceClient.GetNexusEndpoint(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) CreateNexusEndpoint(ctx context.Context, in0 *operatorservice.CreateNexusEndpointRequest) (*operatorservice.CreateNexusEndpointResponse, error) {
+	return s.operatorServiceClient.CreateNexusEndpoint(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) UpdateNexusEndpoint(ctx context.Context, in0 *operatorservice.UpdateNexusEndpointRequest) (*operatorservice.UpdateNexusEndpointResponse, error) {
+	return s.operatorServiceClient.UpdateNexusEndpoint(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) DeleteNexusEndpoint(ctx context.Context, in0 *operatorservice.DeleteNexusEndpointRequest) (*operatorservice.DeleteNexusEndpointResponse, error) {
+	return s.operatorServiceClient.DeleteNexusEndpoint(ctx, in0)
+}
+
+func (s *operatorServiceProxyServer) ListNexusEndpoints(ctx context.Context, in0 *operatorservice.ListNexusEndpointsRequest) (*operatorservice.ListNexusEndpointsResponse, error) {
+	return s.operatorServiceClient.ListNexusEndpoints(ctx, in0)
+}

--- a/proxy/operatorservice_forward_test.go
+++ b/proxy/operatorservice_forward_test.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"go.temporal.io/api/operatorservice/v1"
+)
+
+// TestAllOperatorMethodsForwarded guards against silently dropping new RPCs on a
+// go.temporal.io/api upgrade. The embedded UnimplementedOperatorServiceServer
+// makes such gaps compile cleanly, so the compiler cannot catch them; its
+// default implementation returns codes.Unimplemented.
+//
+// The proxy is built as a zero value, so operatorServiceClient/logger are nil. A
+// real forwarding implementation panics on the nil client/logger before
+// returning; the embedded default returns codes.Unimplemented without touching
+// them. Any outcome other than a clean codes.Unimplemented therefore means the
+// method is explicitly implemented. See returnsUnimplemented in
+// adminservice_forward_test.go.
+func TestAllOperatorMethodsForwarded(t *testing.T) {
+	iface := reflect.TypeFor[operatorservice.OperatorServiceServer]()
+	srv := reflect.ValueOf(&operatorServiceProxyServer{})
+	ctxType := reflect.TypeFor[context.Context]()
+
+	for i := 0; i < iface.NumMethod(); i++ {
+		m := iface.Method(i)
+
+		// Skip the unexported mustEmbedUnimplementedOperatorServiceServer() marker
+		// method, which has no params/returns.
+		if m.PkgPath != "" {
+			continue
+		}
+
+		// Build call args from the method signature (no receiver on interface
+		// methods): a real context where the parameter is a context.Context
+		// (every unary RPC), and a zero value elsewhere.
+		mt := m.Type
+		in := make([]reflect.Value, mt.NumIn())
+		for j := 0; j < mt.NumIn(); j++ {
+			if mt.In(j) == ctxType {
+				in[j] = reflect.ValueOf(context.Background())
+			} else {
+				in[j] = reflect.Zero(mt.In(j))
+			}
+		}
+
+		if returnsUnimplemented(srv.MethodByName(m.Name), in) {
+			t.Errorf("OperatorService.%s is not explicitly forwarded (falls through to "+
+				"UnimplementedOperatorServiceServer). Add a pass-through in operatorservice.go.", m.Name)
+		}
+	}
+}


### PR DESCRIPTION
Add operatorServiceProxyServer that forwards all 12 go.temporal.io/api
OperatorService RPCs (search attributes, DeleteNamespace, remote-cluster
management, Nexus endpoints).

The reason is so we can call ListSearchAttributes for custom search attributes validation during cloud migration.
ListSearchAttributes (OperatorService) was added in Temporal server v1.16.0.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
