### PR TITLE
Add OperatorService method ACL to AccessControlInterceptor

### DIFF
--- a/charts/s2s-proxy/example.yaml
+++ b/charts/s2s-proxy/example.yaml
@@ -18,6 +18,8 @@ data:
           - ReapplyEvents
           - GetNamespace
           - SyncWorkflowState
+          operatorService:
+          - ListSearchAttributes
         allowedNamespaces:
         - temporal-system
         - myNamespace

--- a/charts/s2s-proxy/files/default.yaml
+++ b/charts/s2s-proxy/files/default.yaml
@@ -51,6 +51,9 @@ clusterConnections:
           - ReapplyEvents
           - GetNamespace
           - SyncWorkflowState
+        operatorService:
+        # Optional. If configured, only these OperatorService methods are allowed.
+          - ListSearchAttributes
       allowedNamespaces:
         # Optional. If configured, the temporal-system namespace must be included to allow migration workflows to run.
         - "temporal-system"

--- a/config/config.go
+++ b/config/config.go
@@ -92,7 +92,8 @@ type (
 	}
 
 	AllowedMethods struct {
-		AdminService []string `yaml:"adminService"`
+		AdminService    []string `yaml:"adminService"`
+		OperatorService []string `yaml:"operatorService"`
 	}
 
 	ACLPolicy struct {

--- a/develop/config/cluster-a-mux-client-proxy.yaml
+++ b/develop/config/cluster-a-mux-client-proxy.yaml
@@ -14,4 +14,7 @@ clusterConnections:
       mappings:
         - local: "myNamespace"
           remote: "myNamespace.accountid"
-
+    aclPolicy:
+      allowedMethods:
+        operatorService:
+          - ListSearchAttributes

--- a/interceptor/access_control.go
+++ b/interceptor/access_control.go
@@ -85,7 +85,9 @@ func (i *AccessControlInterceptor) Intercept(
 	}
 
 	if i.namespaceAccess != nil &&
-		(strings.HasPrefix(info.FullMethod, api.WorkflowServicePrefix) || strings.HasPrefix(info.FullMethod, api.AdminServicePrefix)) {
+		(strings.HasPrefix(info.FullMethod, api.WorkflowServicePrefix) ||
+			strings.HasPrefix(info.FullMethod, api.AdminServicePrefix) ||
+			strings.HasPrefix(info.FullMethod, api.OperatorServicePrefix)) {
 		allowed, err := isNamespaceAccessAllowed(i.logger, req, i.namespaceAccess)
 		if !allowed || err != nil {
 			methodName := api.MethodName(info.FullMethod)

--- a/interceptor/access_control.go
+++ b/interceptor/access_control.go
@@ -16,30 +16,24 @@ import (
 
 type (
 	AccessControlInterceptor struct {
-		logger             log.Logger
-		adminServiceAccess *auth.AccessControl
-		namespaceAccess    *auth.AccessControl
-	}
-	ACLConfig interface {
-		AllowedNamespaces() []string
-		AdminServiceAllowedMethods() []string
+		logger                log.Logger
+		adminServiceAccess    *auth.AccessControl
+		operatorServiceAccess *auth.AccessControl
+		namespaceAccess       *auth.AccessControl
 	}
 )
 
 func NewAccessControlInterceptor(
 	logger log.Logger,
 	adminServiceAllowedMethods []string,
+	operatorServiceAllowedMethods []string,
 	allowedNamespaces []string,
 ) *AccessControlInterceptor {
-	var adminServiceAccess *auth.AccessControl
-	var namespaceAccess *auth.AccessControl
-	adminServiceAccess = auth.NewAccesControl(adminServiceAllowedMethods)
-	namespaceAccess = auth.NewAccesControl(allowedNamespaces)
-
 	return &AccessControlInterceptor{
-		logger:             logger,
-		adminServiceAccess: adminServiceAccess,
-		namespaceAccess:    namespaceAccess,
+		logger:                logger,
+		adminServiceAccess:    auth.NewAccesControl(adminServiceAllowedMethods),
+		operatorServiceAccess: auth.NewAccesControl(operatorServiceAllowedMethods),
+		namespaceAccess:       auth.NewAccesControl(allowedNamespaces),
 	}
 }
 
@@ -79,6 +73,13 @@ func (i *AccessControlInterceptor) Intercept(
 	if i.adminServiceAccess != nil && strings.HasPrefix(info.FullMethod, api.AdminServicePrefix) {
 		methodName := api.MethodName(info.FullMethod)
 		if !i.adminServiceAccess.IsAllowed(methodName) {
+			return nil, status.Errorf(codes.PermissionDenied, "Calling method %s is not allowed.", methodName)
+		}
+	}
+
+	if i.operatorServiceAccess != nil && strings.HasPrefix(info.FullMethod, api.OperatorServicePrefix) {
+		methodName := api.MethodName(info.FullMethod)
+		if !i.operatorServiceAccess.IsAllowed(methodName) {
 			return nil, status.Errorf(codes.PermissionDenied, "Calling method %s is not allowed.", methodName)
 		}
 	}

--- a/interceptor/access_control_test.go
+++ b/interceptor/access_control_test.go
@@ -52,7 +52,7 @@ func TestMethodAccessControlInterceptor(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			i := NewAccessControlInterceptor(logger, c.adminServiceAllowedMethods, c.allowedNamespaces)
+			i := NewAccessControlInterceptor(logger, c.adminServiceAllowedMethods, nil, c.allowedNamespaces)
 			_, err := i.Intercept(context.Background(), nil, unaryInfo, unaryHandler)
 			if c.notAllowed {
 				require.ErrorContains(t, err, "PermissionDenied")
@@ -61,6 +61,51 @@ func TestMethodAccessControlInterceptor(t *testing.T) {
 			}
 
 			err = i.StreamIntercept(nil, nil, streamInfo, streamHandler)
+			if c.notAllowed {
+				require.ErrorContains(t, err, "PermissionDenied")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOperatorServiceAccessControl(t *testing.T) {
+	cases := []struct {
+		name                          string
+		operatorServiceAllowedMethods []string
+		calledMethod                  string
+		notAllowed                    bool
+	}{
+		{
+			name:         "no AccessControl allows all",
+			calledMethod: "ListSearchAttributes",
+		},
+		{
+			name:                          "allowed method",
+			operatorServiceAllowedMethods: []string{"ListSearchAttributes"},
+			calledMethod:                  "ListSearchAttributes",
+		},
+		{
+			name:                          "method not in allowlist",
+			operatorServiceAllowedMethods: []string{"ListSearchAttributes"},
+			calledMethod:                  "AddSearchAttributes",
+			notAllowed:                    true,
+		},
+	}
+
+	logger := log.NewTestLogger()
+	unaryHandler := func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			i := NewAccessControlInterceptor(logger, nil, c.operatorServiceAllowedMethods, nil)
+			unaryInfo := &grpc.UnaryServerInfo{
+				FullMethod: api.OperatorServicePrefix + c.calledMethod,
+			}
+			_, err := i.Intercept(context.Background(), nil, unaryInfo, unaryHandler)
 			if c.notAllowed {
 				require.ErrorContains(t, err, "PermissionDenied")
 			} else {
@@ -90,7 +135,7 @@ func TestAllowedWorkflowMigrationAPIs(t *testing.T) {
 	}
 
 	logger := log.NewTestLogger()
-	i := NewAccessControlInterceptor(logger, nil, nil)
+	i := NewAccessControlInterceptor(logger, nil, nil, nil)
 
 	unaryHandler := func(ctx context.Context, req any) (any, error) {
 		return nil, nil

--- a/interceptor/namespace_translator_test.go
+++ b/interceptor/namespace_translator_test.go
@@ -12,6 +12,7 @@ import (
 	"go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/history/v1"
 	"go.temporal.io/api/namespace/v1"
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/replication/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
@@ -72,6 +73,13 @@ func generateNamespaceObjCases() []objCase {
 			containsObj: true,
 			makeType: func(ns string) any {
 				return &StructWithNamespaceField{Namespace: ns}
+			},
+		},
+		{
+			objName:     "operatorservice ListSearchAttributesRequest",
+			containsObj: true,
+			makeType: func(ns string) any {
+				return &operatorservice.ListSearchAttributesRequest{Namespace: ns}
 			},
 		},
 		{

--- a/interceptor/translation_interceptor.go
+++ b/interceptor/translation_interceptor.go
@@ -42,7 +42,8 @@ func (i *TranslationInterceptor) Intercept(
 ) (any, error) {
 	if common.IsRequestTranslationDisabled(ctx) || len(i.translators) == 0 ||
 		(!strings.HasPrefix(info.FullMethod, api.WorkflowServicePrefix) &&
-			!strings.HasPrefix(info.FullMethod, api.AdminServicePrefix)) {
+			!strings.HasPrefix(info.FullMethod, api.AdminServicePrefix) &&
+			!strings.HasPrefix(info.FullMethod, api.OperatorServicePrefix)) {
 		return handler(ctx, req)
 	}
 

--- a/interceptor/translation_interceptor_test.go
+++ b/interceptor/translation_interceptor_test.go
@@ -32,15 +32,14 @@ func (s *spyTranslator) TranslateResponse(any) (bool, error) {
 
 func TestTranslationInterceptor(t *testing.T) {
 	logger := log.NewTestLogger()
-	info := &grpc.UnaryServerInfo{
-		FullMethod: api.WorkflowServicePrefix + "DescribeWorkflowExecution",
-	}
 	handler := func(_ context.Context, _ any) (any, error) {
 		return &workflowservice.DescribeWorkflowExecutionResponse{}, nil
 	}
 
 	cases := []struct {
 		name string
+		// fullMethod is the gRPC method the interceptor sees.
+		fullMethod string
 		// incomingHeaders is attached to the request context (nil for none).
 		incomingHeaders map[string]string
 		// MatchMethod is consulted once per phase (request + response) when translation runs.
@@ -50,17 +49,39 @@ func TestTranslationInterceptor(t *testing.T) {
 	}{
 		{
 			name:               "header_false_skips_translators",
+			fullMethod:         api.WorkflowServicePrefix + "DescribeWorkflowExecution",
 			incomingHeaders:    map[string]string{common.RequestTranslationHeaderName: "false"},
 			expectedMatchCalls: 0,
 			expectedReqCalls:   0,
 			expectedRespCalls:  0,
 		},
 		{
-			name:               "header_absent_invokes_translators",
-			incomingHeaders:    nil,
+			name:               "workflow_method_invokes_translators",
+			fullMethod:         api.WorkflowServicePrefix + "DescribeWorkflowExecution",
 			expectedMatchCalls: 2,
 			expectedReqCalls:   1,
 			expectedRespCalls:  1,
+		},
+		{
+			name:               "admin_method_invokes_translators",
+			fullMethod:         api.AdminServicePrefix + "DescribeMutableState",
+			expectedMatchCalls: 2,
+			expectedReqCalls:   1,
+			expectedRespCalls:  1,
+		},
+		{
+			name:               "operator_method_invokes_translators",
+			fullMethod:         api.OperatorServicePrefix + "DeleteNamespace",
+			expectedMatchCalls: 2,
+			expectedReqCalls:   1,
+			expectedRespCalls:  1,
+		},
+		{
+			name:               "other_service_skips_translators",
+			fullMethod:         "/grpc.health.v1.Health/Check",
+			expectedMatchCalls: 0,
+			expectedReqCalls:   0,
+			expectedRespCalls:  0,
 		},
 	}
 
@@ -68,6 +89,7 @@ func TestTranslationInterceptor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			spy := &spyTranslator{}
 			ti := NewTranslationInterceptor(logger, []Translator{spy})
+			info := &grpc.UnaryServerInfo{FullMethod: tc.fullMethod}
 
 			ctx := context.Background()
 			if tc.incomingHeaders != nil {

--- a/proxy/cluster_connection.go
+++ b/proxy/cluster_connection.go
@@ -419,7 +419,7 @@ func makeServerOptions(c serverConfiguration, tlsConfig encryption.TLSConfig) ([
 			tag.NewAnyTag("policy", c.aclPolicy),
 			tag.NewStringTag("serverConfig", fmt.Sprintf("%+v", c)))
 		aclInterceptor := interceptor.NewAccessControlInterceptor(c.loggers.Get(LogInterceptor),
-			c.aclPolicy.AllowedMethods.AdminService, c.aclPolicy.AllowedNamespaces)
+			c.aclPolicy.AllowedMethods.AdminService, c.aclPolicy.AllowedMethods.OperatorService, c.aclPolicy.AllowedNamespaces)
 		unaryInterceptors = append(unaryInterceptors, aclInterceptor.Intercept)
 		streamInterceptors = append(streamInterceptors, aclInterceptor.StreamIntercept)
 	}


### PR DESCRIPTION
## Summary

Mirrors the existing **AdminService** method allowlist for **OperatorService**, so an ACL policy can restrict which OperatorService RPCs are proxied. Built on top of the OperatorService proxy (`haifengh/operatorService`).

Also make Namespace/search-attribute **translation** cover OperatorService