### PR TITLE
Add the ProxyAdminService operator listener to the config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,9 +47,17 @@ type (
 	S2SProxyConfig struct {
 		Metrics            *MetricsConfig           `yaml:"metrics"`
 		ProfilingConfig    *ProfilingConfig         `yaml:"profiling"`
+		ProxyAdmin         ProxyAdminConfig         `yaml:"proxyAdmin"`
 		Logging            LoggingConfig            `yaml:"logging"`
 		LogConfigs         map[string]LoggingConfig `yaml:"logConfigs"`
 		ClusterConnections []ClusterConnConfig      `yaml:"clusterConnections"`
+	}
+
+	// ProxyAdminConfig configures ProxyAdminService.
+	ProxyAdminConfig struct {
+		// ListenAddress serves ProxyAdminService for local operator queries.
+		// Validate accepts only a loopback address.
+		ListenAddress string `yaml:"listenAddress"`
 	}
 
 	SATranslationConfig struct {
@@ -366,5 +374,6 @@ func (c *S2SProxyConfig) Validate() error {
 	return validation.Validate(
 		"",
 		validation.Children("clusterConnections", c.ClusterConnections, (*ClusterConnConfig).Validate),
+		validation.Nested("proxyAdmin", &c.ProxyAdmin),
 	)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -322,3 +322,28 @@ func TestExampleChart(t *testing.T) {
 	require.Equal(t, ConnectionType("mux-client"), cc.Remote.ConnectionType)
 	require.Equal(t, "s2s-proxy-sample.example.tmprl.cloud:8233", cc.Remote.MuxAddressInfo.ConnectionString)
 }
+
+func TestProxyAdminConfig(t *testing.T) {
+	const clusterConnections = `
+clusterConnections:
+  - name: only
+`
+
+	t.Run("absent means no server runs", func(t *testing.T) {
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections))
+		require.NoError(t, err)
+		require.Empty(t, cfg.ProxyAdmin.ListenAddress)
+	})
+
+	t.Run("listen address round-trips", func(t *testing.T) {
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t,
+			clusterConnections+"proxyAdmin:\n  listenAddress: \"localhost:6061\"\n"))
+		require.NoError(t, err)
+		require.Equal(t, "localhost:6061", cfg.ProxyAdmin.ListenAddress)
+	})
+
+	t.Run("an unknown key under proxyAdmin is rejected", func(t *testing.T) {
+		_, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+"proxyAdmin:\n  nope: 1\n"))
+		require.Error(t, err)
+	})
+}

--- a/config/proxyadmin.go
+++ b/config/proxyadmin.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/temporalio/temporal-proxy/pkg/validation"
+)
+
+func (c *ProxyAdminConfig) Validate() error {
+	return validation.Validate(
+		"",
+		validation.Field("listenAddress", c.ListenAddress,
+			validation.When(isSet,
+				validation.IsHostPort(),
+				validation.When(parsesAsHostPort, isLoopback()),
+			)),
+	)
+}
+
+func isSet(s string) bool { return s != "" }
+
+func parsesAsHostPort(listenAddress string) bool {
+	_, _, err := net.SplitHostPort(listenAddress)
+	return err == nil
+}
+
+func isLoopback() validation.Check[string] {
+	return func(listenAddress string) error {
+		if loopbackListenAddress(listenAddress) {
+			return nil
+		}
+		return fmt.Errorf("is %q, not a loopback address: this publishes an unauthenticated view "+
+			"of the deployment topology to anything that can reach it", listenAddress)
+	}
+}
+
+func loopbackListenAddress(listenAddress string) bool {
+	host, _, err := net.SplitHostPort(listenAddress)
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -121,8 +122,6 @@ func TestS2SProxyConfigValidate(t *testing.T) {
 	}
 }
 
-// TestS2SProxyConfigValidateFromYAML runs the whole path an operator hits: a
-// config file with a typo in a key URI, loaded and then validated.
 func TestS2SProxyConfigValidateFromYAML(t *testing.T) {
 	path := writeYAML(t, `
 clusterConnections:
@@ -148,4 +147,88 @@ clusterConnections:
 			Message: invalidURI("vault://alias/typo"),
 		},
 	})
+}
+
+func notLoopback(listenAddress string) string {
+	return fmt.Sprintf("is %q, not a loopback address: this publishes an unauthenticated view "+
+		"of the deployment topology to anything that can reach it", listenAddress)
+}
+
+func proxyAdmin(c ProxyAdminConfig) S2SProxyConfig {
+	return S2SProxyConfig{ProxyAdmin: c}
+}
+
+func TestProxyAdminValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  S2SProxyConfig
+		want validation.Errors
+	}{
+		{
+			name: "no proxyAdmin block",
+		},
+		{
+			name: "operator on loopback by name",
+			cfg:  proxyAdmin(ProxyAdminConfig{ListenAddress: "localhost:6061"}),
+		},
+		{
+			name: "operator on loopback by address",
+			cfg:  proxyAdmin(ProxyAdminConfig{ListenAddress: "127.0.0.1:6061"}),
+		},
+		{
+			name: "operator off loopback",
+			cfg:  proxyAdmin(ProxyAdminConfig{ListenAddress: "0.0.0.0:6061"}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin",
+				Field:   "listenAddress",
+				Message: notLoopback("0.0.0.0:6061"),
+			}},
+		},
+		{
+			name: "operator on a hostname that is not localhost",
+			cfg:  proxyAdmin(ProxyAdminConfig{ListenAddress: "admin.svc.cluster.local:6061"}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin",
+				Field:   "listenAddress",
+				Message: notLoopback("admin.svc.cluster.local:6061"),
+			}},
+		},
+		{
+			name: "operator on loopback with no port",
+			cfg:  proxyAdmin(ProxyAdminConfig{ListenAddress: "localhost"}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin",
+				Field:   "listenAddress",
+				Message: "is not a valid host:port",
+			}},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.Validate()
+			if c.want == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			requireErrors(t, err, c.want)
+		})
+	}
+}
+
+func TestProxyAdminValidateFromYAML(t *testing.T) {
+	cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, `
+clusterConnections:
+  - name: cluster-a
+proxyAdmin:
+  listenAddress: "0.0.0.0:6061"
+`))
+	require.NoError(t, err)
+
+	requireErrors(t, cfg.Validate(), validation.Errors{{
+		Subject: "proxyAdmin",
+		Field:   "listenAddress",
+		Message: notLoopback("0.0.0.0:6061"),
+	}})
 }


### PR DESCRIPTION
The first in a series (see stacked PR!) to add config for the proxy admin service!

This PR adds a top level `proxyAdmin` - presence of which, indicates we should start up the proxy admin service. 

There's also a nested `listenAddress` which is the address that will serve ProxyAdminService for local operator queries - as it's for local use - this requires a loopback address, as it's insecure. 

The proxy admin service will also be exposed through the mux to other cluster connections, and to other proxy pod peers (see stacked PRs for config)

Example: 

```yaml
proxyAdmin:
  listenAddress: "127.0.0.1:6061"
```


