### PR TITLE
Add the ProxyAdminService peer listener and discovery selector to the config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/temporalio/s2s-proxy/collect"
+	"github.com/temporalio/s2s-proxy/encryption"
 )
 
 const (
@@ -58,6 +59,33 @@ type (
 		// ListenAddress serves ProxyAdminService for local operator queries.
 		// Validate accepts only a loopback address.
 		ListenAddress string `yaml:"listenAddress"`
+
+		// Peer serves ProxyAdminService to the other pods of this proxy deployment.
+		// Absent means this pod only ever describes itself.
+		Peer *ProxyAdminPeerConfig `yaml:"peer"`
+	}
+
+	ProxyAdminPeerConfig struct {
+		// ListenAddress must be reachable from sibling pods.
+		ListenAddress string `yaml:"listenAddress"`
+
+		// AllowInsecure permits a non-loopback ListenAddress with no TLS.
+		AllowInsecure bool `yaml:"allowInsecure"`
+
+		// TLS secures peer traffic and verifies the client chain.
+		// CAServerName must name a SAN that every pod's certificate carries.
+		TLS *encryption.TLSConfig `yaml:"tls"`
+
+		// Discovery selects how this pod finds its siblings.
+		Discovery DiscoveryConfig `yaml:"discovery"`
+	}
+
+	// DiscoveryConfig selects one provider by name.
+	// Each provider reads only its own block.
+	DiscoveryConfig struct {
+		// Provider names the mechanism.
+		// Empty means DiscoveryNone.
+		Provider string `yaml:"provider"`
 	}
 
 	SATranslationConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -346,4 +346,37 @@ clusterConnections:
 		_, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+"proxyAdmin:\n  nope: 1\n"))
 		require.Error(t, err)
 	})
+
+	t.Run("absent peer means this pod describes itself only", func(t *testing.T) {
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections))
+		require.NoError(t, err)
+		require.Nil(t, cfg.ProxyAdmin.Peer)
+	})
+
+	t.Run("the peer block round-trips", func(t *testing.T) {
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "0.0.0.0:9234"
+    allowInsecure: true
+    discovery:
+      provider: none
+`))
+		require.NoError(t, err)
+		require.Equal(t, "0.0.0.0:9234", cfg.ProxyAdmin.Peer.ListenAddress)
+		require.True(t, cfg.ProxyAdmin.Peer.AllowInsecure)
+		require.Equal(t, DiscoveryNone, cfg.ProxyAdmin.Peer.Discovery.Provider)
+	})
+
+	t.Run("an unknown key under discovery is rejected", func(t *testing.T) {
+		_, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "127.0.0.1:9234"
+    discovery:
+      provider: none
+      nmae: typo
+`))
+		require.Error(t, err)
+	})
 }

--- a/config/proxyadmin.go
+++ b/config/proxyadmin.go
@@ -1,11 +1,19 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"slices"
 
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
+
+const (
+	DiscoveryNone = "none"
+)
+
+var DiscoveryProviders = []string{DiscoveryNone}
 
 func (c *ProxyAdminConfig) Validate() error {
 	return validation.Validate(
@@ -13,9 +21,62 @@ func (c *ProxyAdminConfig) Validate() error {
 		validation.Field("listenAddress", c.ListenAddress,
 			validation.When(isSet,
 				validation.IsHostPort(),
-				validation.When(parsesAsHostPort, isLoopback()),
+				validation.When(parsesAsHostPort, isLoopback(
+					"Bind it to loopback, or serve siblings through proxyAdmin.peer. The peer listener authenticates its callers.")),
 			)),
+		validation.WhenNested(func() bool { return c.Peer != nil }, "peer", c.Peer),
 	)
+}
+
+func (p *ProxyAdminPeerConfig) Validate() error {
+	tlsEnabled := p.TLS != nil && p.TLS.IsEnabled()
+
+	rules := []validation.Rule{
+		validation.Field("listenAddress", p.ListenAddress,
+			validation.Required[string](),
+			validation.When(isSet,
+				validation.IsHostPort(),
+				validation.When(parsesAsHostPort,
+					validation.WhenFn(func() bool { return !tlsEnabled && !p.AllowInsecure }, isLoopback(
+						"Configure proxyAdmin.peer.tls, or set proxyAdmin.peer.allowInsecure to accept it."))),
+			)),
+		validation.Field("discovery.provider", p.Discovery.Provider, knownDiscoveryProvider()),
+	}
+	if tlsEnabled {
+		rules = append(rules, p.tlsRules()...)
+	}
+
+	return validation.Validate("", rules...)
+}
+
+func (p *ProxyAdminPeerConfig) tlsRules() []validation.Rule {
+	return []validation.Rule{
+		validation.Field("tls.certificatePath", p.TLS.CertificatePath, validation.Required[string]()),
+		validation.Field("tls.keyPath", p.TLS.KeyPath, validation.Required[string]()),
+		validation.Field("tls.remoteCAPath", p.TLS.RemoteCAPath, validation.Required[string]()),
+		validation.Field("tls.caServerName", p.TLS.CAServerName, validation.Required[string]()),
+		validation.Field("tls.skipCAVerification", p.TLS.SkipCAVerification, isFalse(
+			"disables verification of every sibling this pod dials. The peer TLS set alongside it then does nothing.")),
+	}
+}
+
+func knownDiscoveryProvider() validation.Check[string] {
+	return func(provider string) error {
+		if provider == "" || slices.Contains(DiscoveryProviders, provider) {
+			return nil
+		}
+		return fmt.Errorf("is %q, want one of %v or empty for %q",
+			provider, DiscoveryProviders, DiscoveryNone)
+	}
+}
+
+func isFalse(because string) validation.Check[bool] {
+	return func(v bool) error {
+		if !v {
+			return nil
+		}
+		return errors.New(because)
+	}
 }
 
 func isSet(s string) bool { return s != "" }
@@ -25,13 +86,13 @@ func parsesAsHostPort(listenAddress string) bool {
 	return err == nil
 }
 
-func isLoopback() validation.Check[string] {
+func isLoopback(remedy string) validation.Check[string] {
 	return func(listenAddress string) error {
 		if loopbackListenAddress(listenAddress) {
 			return nil
 		}
 		return fmt.Errorf("is %q, not a loopback address: this publishes an unauthenticated view "+
-			"of the deployment topology to anything that can reach it", listenAddress)
+			"of the deployment topology to anything that can reach it. %s", listenAddress, remedy)
 	}
 }
 

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/temporalio/temporal-proxy/pkg/validation"
+
+	"github.com/temporalio/s2s-proxy/encryption"
 )
 
 func TestS2SProxyConfigValidate(t *testing.T) {
@@ -149,9 +151,18 @@ clusterConnections:
 	})
 }
 
-func notLoopback(listenAddress string) string {
+func notLoopback(listenAddress, remedy string) string {
 	return fmt.Sprintf("is %q, not a loopback address: this publishes an unauthenticated view "+
-		"of the deployment topology to anything that can reach it", listenAddress)
+		"of the deployment topology to anything that can reach it. %s", listenAddress, remedy)
+}
+
+const (
+	operatorRemedy = "Bind it to loopback, or serve siblings through proxyAdmin.peer. The peer listener authenticates its callers."
+	peerRemedy     = "Configure proxyAdmin.peer.tls, or set proxyAdmin.peer.allowInsecure to accept it."
+)
+
+func peerAt(listenAddress string) *ProxyAdminPeerConfig {
+	return &ProxyAdminPeerConfig{ListenAddress: listenAddress}
 }
 
 func proxyAdmin(c ProxyAdminConfig) S2SProxyConfig {
@@ -181,7 +192,7 @@ func TestProxyAdminValidate(t *testing.T) {
 			want: validation.Errors{{
 				Subject: "proxyAdmin",
 				Field:   "listenAddress",
-				Message: notLoopback("0.0.0.0:6061"),
+				Message: notLoopback("0.0.0.0:6061", operatorRemedy),
 			}},
 		},
 		{
@@ -190,7 +201,7 @@ func TestProxyAdminValidate(t *testing.T) {
 			want: validation.Errors{{
 				Subject: "proxyAdmin",
 				Field:   "listenAddress",
-				Message: notLoopback("admin.svc.cluster.local:6061"),
+				Message: notLoopback("admin.svc.cluster.local:6061", operatorRemedy),
 			}},
 		},
 		{
@@ -200,6 +211,109 @@ func TestProxyAdminValidate(t *testing.T) {
 				Subject: "proxyAdmin",
 				Field:   "listenAddress",
 				Message: "is not a valid host:port",
+			}},
+		},
+		{
+			name: "peer without a listen address",
+			cfg:  proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "listenAddress",
+				Message: "is required",
+			}},
+		},
+		{
+			name: "peer listen address is not host:port",
+			cfg:  proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{ListenAddress: "peers.svc", AllowInsecure: true}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "listenAddress",
+				Message: "is not a valid host:port",
+			}},
+		},
+		{
+			name: "peer off loopback with no tls",
+			cfg:  proxyAdmin(ProxyAdminConfig{Peer: peerAt("0.0.0.0:9234")}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "listenAddress",
+				Message: notLoopback("0.0.0.0:9234", peerRemedy),
+			}},
+		},
+		{
+			name: "peer off loopback with allowInsecure",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "0.0.0.0:9234", AllowInsecure: true,
+			}}),
+		},
+		{
+			name: "peer off loopback with tls",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "0.0.0.0:9234",
+				TLS: &encryption.TLSConfig{
+					CertificatePath: "/c", KeyPath: "/k", RemoteCAPath: "/ca", CAServerName: "peers",
+				},
+			}}),
+		},
+		{
+			name: "tls with only a caServerName",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "0.0.0.0:9234",
+				TLS:           &encryption.TLSConfig{CAServerName: "peers"},
+			}}),
+			want: validation.Errors{
+				{Subject: "proxyAdmin.peer", Field: "tls.certificatePath", Message: "is required"},
+				{Subject: "proxyAdmin.peer", Field: "tls.keyPath", Message: "is required"},
+				{Subject: "proxyAdmin.peer", Field: "tls.remoteCAPath", Message: "is required"},
+			},
+		},
+		{
+			name: "tls without a CA or a server name",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "0.0.0.0:9234",
+				TLS:           &encryption.TLSConfig{CertificatePath: "/c", KeyPath: "/k"},
+			}}),
+			want: validation.Errors{
+				{Subject: "proxyAdmin.peer", Field: "tls.remoteCAPath", Message: "is required"},
+				{Subject: "proxyAdmin.peer", Field: "tls.caServerName", Message: "is required"},
+			},
+		},
+		{
+			name: "tls with verification skipped",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "0.0.0.0:9234",
+				TLS: &encryption.TLSConfig{
+					CertificatePath: "/c", KeyPath: "/k", RemoteCAPath: "/ca",
+					CAServerName: "peers", SkipCAVerification: true,
+				},
+			}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "tls.skipCAVerification",
+				Message: "disables verification of every sibling this pod dials. The peer TLS set alongside it then does nothing.",
+			}},
+		},
+		{
+			name: "discovery provider left empty",
+			cfg:  proxyAdmin(ProxyAdminConfig{Peer: peerAt("127.0.0.1:9234")}),
+		},
+		{
+			name: "discovery provider none",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery:     DiscoveryConfig{Provider: DiscoveryNone},
+			}}),
+		},
+		{
+			name: "unknown discovery provider",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery:     DiscoveryConfig{Provider: "carrier-pigeon"},
+			}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "discovery.provider",
+				Message: `is "carrier-pigeon", want one of [none] or empty for "none"`,
 			}},
 		},
 	}
@@ -229,6 +343,6 @@ proxyAdmin:
 	requireErrors(t, cfg.Validate(), validation.Errors{{
 		Subject: "proxyAdmin",
 		Field:   "listenAddress",
-		Message: notLoopback("0.0.0.0:6061"),
+		Message: notLoopback("0.0.0.0:6061", operatorRemedy),
 	}})
 }


### PR DESCRIPTION
The second in the series of proxy admin service config (see stacked PR!) - this adds the peer listener, so one pod can answer for the whole deployment rather than just itself.

`proxyAdmin.peer` is where siblings reach this pod. Unlike the operator listener it's on the pod network, so it either needs tls (which verifies the client chain, not just encrypts) or an explicit `allowInsecure` 

There's also discovery, which selects how this pod finds its siblings by name. Only none is accepted for now - `dns` and `static` land in the next two PRs.

```yaml
proxyAdmin:
  listenAddress: "localhost:6061"
  peer:
    listenAddress: "0.0.0.0:6062"
    tls:
      certificatePath: /certs/peer.pem
      keyPath: /certs/peer.key
      remoteCAPath: /certs/ca.pem
      caServerName: s2s-proxy-peers
    discovery:
      provider: none
```