### PR TITLE
Add DNS peer discovery to the ProxyAdminService config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -86,6 +86,17 @@ type (
 		// Provider names the mechanism.
 		// Empty means DiscoveryNone.
 		Provider string `yaml:"provider"`
+
+		DNS DNSDiscoveryConfig `yaml:"dns"`
+	}
+
+	DNSDiscoveryConfig struct {
+		// Name is one Service name, shared by every pod.
+		// It resolves to one address per ready pod.
+		Name string `yaml:"name"`
+
+		// Port defaults to the port the peer listener binds.
+		Port int `yaml:"port"`
 	}
 
 	SATranslationConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -368,6 +368,22 @@ proxyAdmin:
 		require.Equal(t, DiscoveryNone, cfg.ProxyAdmin.Peer.Discovery.Provider)
 	})
 
+	t.Run("the dns block round-trips and the port defaults from the listener", func(t *testing.T) {
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "127.0.0.1:9234"
+    discovery:
+      provider: dns
+      dns:
+        name: peers.svc.cluster.local
+`))
+		require.NoError(t, err)
+		require.Equal(t, "peers.svc.cluster.local", cfg.ProxyAdmin.Peer.Discovery.DNS.Name)
+		require.Zero(t, cfg.ProxyAdmin.Peer.Discovery.DNS.Port)
+		require.Equal(t, 9234, cfg.ProxyAdmin.Peer.PeerPort())
+	})
+
 	t.Run("an unknown key under discovery is rejected", func(t *testing.T) {
 		_, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+`
 proxyAdmin:

--- a/config/proxyadmin.go
+++ b/config/proxyadmin.go
@@ -5,15 +5,17 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"strconv"
 
 	"github.com/temporalio/temporal-proxy/pkg/validation"
 )
 
 const (
 	DiscoveryNone = "none"
+	DiscoveryDNS  = "dns"
 )
 
-var DiscoveryProviders = []string{DiscoveryNone}
+var DiscoveryProviders = []string{DiscoveryNone, DiscoveryDNS}
 
 func (c *ProxyAdminConfig) Validate() error {
 	return validation.Validate(
@@ -42,11 +44,23 @@ func (p *ProxyAdminPeerConfig) Validate() error {
 			)),
 		validation.Field("discovery.provider", p.Discovery.Provider, knownDiscoveryProvider()),
 	}
+	rules = append(rules, p.discoveryRules()...)
 	if tlsEnabled {
 		rules = append(rules, p.tlsRules()...)
 	}
 
 	return validation.Validate("", rules...)
+}
+
+func (p *ProxyAdminPeerConfig) discoveryRules() []validation.Rule {
+	d := p.Discovery
+	return []validation.Rule{
+		validation.WhenRules(func() bool { return d.Provider == DiscoveryDNS },
+			validation.Field("discovery.dns.name", d.DNS.Name, validation.Required[string]()),
+			validation.Field("discovery.dns.port", d.DNS.Port,
+				validation.WhenFn(func() bool { return p.PeerPort() == 0 }, validation.Required[int]())),
+		),
+	}
 }
 
 func (p *ProxyAdminPeerConfig) tlsRules() []validation.Rule {
@@ -106,4 +120,16 @@ func loopbackListenAddress(listenAddress string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+func (p *ProxyAdminPeerConfig) PeerPort() int {
+	_, portStr, err := net.SplitHostPort(p.ListenAddress)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0
+	}
+	return port
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -313,8 +313,67 @@ func TestProxyAdminValidate(t *testing.T) {
 			want: validation.Errors{{
 				Subject: "proxyAdmin.peer",
 				Field:   "discovery.provider",
-				Message: `is "carrier-pigeon", want one of [none] or empty for "none"`,
+				Message: `is "carrier-pigeon", want one of [none dns] or empty for "none"`,
 			}},
+		},
+		{
+			name: "dns provider without a name",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery:     DiscoveryConfig{Provider: DiscoveryDNS},
+			}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "discovery.dns.name",
+				Message: "is required",
+			}},
+		},
+		{
+			name: "dns provider inherits the peer listener port",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery: DiscoveryConfig{
+					Provider: DiscoveryDNS,
+					DNS:      DNSDiscoveryConfig{Name: "peers.svc.cluster.local"},
+				},
+			}}),
+		},
+		{
+			name: "dns provider with no port to dial",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:0",
+				AllowInsecure: true,
+				Discovery: DiscoveryConfig{
+					Provider: DiscoveryDNS,
+					DNS:      DNSDiscoveryConfig{Name: "peers.svc.cluster.local"},
+				},
+			}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "discovery.dns.port",
+				Message: "is required",
+			}},
+		},
+		{
+			name: "dns provider with an explicit port",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:0",
+				AllowInsecure: true,
+				Discovery: DiscoveryConfig{
+					Provider: DiscoveryDNS,
+					DNS:      DNSDiscoveryConfig{Name: "peers.svc.cluster.local", Port: 9234},
+				},
+			}}),
+		},
+		{
+			name: "an incomplete dns block is inert while unselected",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery: DiscoveryConfig{
+					Provider: DiscoveryNone,
+					DNS:      DNSDiscoveryConfig{Port: 9999},
+				},
+			}}),
 		},
 	}
 


### PR DESCRIPTION
Third in the series of proxy admin service config (see stacked PR!) - the first real peer discovery provider.

`dns` resolves one `name` to one address per ready pod, which is what a Kubernetes headless Service gives us. The same name sits in every pod's `ConfigMap` - `port` is optional and defaults to whatever port the peer listener binds.

```yaml
proxyAdmin:
  peer:
    listenAddress: "0.0.0.0:6062"
    allowInsecure: true
    discovery:
      provider: dns
      dns:
        name: s2s-proxy.default.svc.cluster.local
```
