### PR TITLE
Add static peer discovery to the ProxyAdminService config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,7 +87,8 @@ type (
 		// Empty means DiscoveryNone.
 		Provider string `yaml:"provider"`
 
-		DNS DNSDiscoveryConfig `yaml:"dns"`
+		DNS    DNSDiscoveryConfig    `yaml:"dns"`
+		Static StaticDiscoveryConfig `yaml:"static"`
 	}
 
 	DNSDiscoveryConfig struct {
@@ -97,6 +98,12 @@ type (
 
 		// Port defaults to the port the peer listener binds.
 		Port int `yaml:"port"`
+	}
+
+	StaticDiscoveryConfig struct {
+		// Addresses is one host:port per sibling pod.
+		// This pod's own address is included.
+		Addresses []string `yaml:"addresses"`
 	}
 
 	SATranslationConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -384,6 +384,24 @@ proxyAdmin:
 		require.Equal(t, 9234, cfg.ProxyAdmin.Peer.PeerPort())
 	})
 
+	t.Run("an unselected provider's block still decodes", func(t *testing.T) {
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+`
+proxyAdmin:
+  peer:
+    listenAddress: "127.0.0.1:9234"
+    discovery:
+      provider: static
+      dns:
+        name: leftover.svc.cluster.local
+      static:
+        addresses: ["a:9234", "b:9234"]
+`))
+		require.NoError(t, err)
+		require.Equal(t, DiscoveryStatic, cfg.ProxyAdmin.Peer.Discovery.Provider)
+		require.Equal(t, "leftover.svc.cluster.local", cfg.ProxyAdmin.Peer.Discovery.DNS.Name)
+		require.Equal(t, []string{"a:9234", "b:9234"}, cfg.ProxyAdmin.Peer.Discovery.Static.Addresses)
+	})
+
 	t.Run("an unknown key under discovery is rejected", func(t *testing.T) {
 		_, err := LoadConfig[S2SProxyConfig](writeYAML(t, clusterConnections+`
 proxyAdmin:

--- a/config/proxyadmin.go
+++ b/config/proxyadmin.go
@@ -11,11 +11,12 @@ import (
 )
 
 const (
-	DiscoveryNone = "none"
-	DiscoveryDNS  = "dns"
+	DiscoveryNone   = "none"
+	DiscoveryDNS    = "dns"
+	DiscoveryStatic = "static"
 )
 
-var DiscoveryProviders = []string{DiscoveryNone, DiscoveryDNS}
+var DiscoveryProviders = []string{DiscoveryNone, DiscoveryDNS, DiscoveryStatic}
 
 func (c *ProxyAdminConfig) Validate() error {
 	return validation.Validate(
@@ -60,6 +61,18 @@ func (p *ProxyAdminPeerConfig) discoveryRules() []validation.Rule {
 			validation.Field("discovery.dns.port", d.DNS.Port,
 				validation.WhenFn(func() bool { return p.PeerPort() == 0 }, validation.Required[int]())),
 		),
+		validation.WhenRules(func() bool { return d.Provider == DiscoveryStatic },
+			validation.Field("discovery.static.addresses", d.Static.Addresses, nonEmpty()),
+		),
+	}
+}
+
+func nonEmpty() validation.Check[[]string] {
+	return func(addresses []string) error {
+		if len(addresses) == 0 {
+			return errors.New("is required")
+		}
+		return nil
 	}
 }
 

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -313,7 +313,7 @@ func TestProxyAdminValidate(t *testing.T) {
 			want: validation.Errors{{
 				Subject: "proxyAdmin.peer",
 				Field:   "discovery.provider",
-				Message: `is "carrier-pigeon", want one of [none dns] or empty for "none"`,
+				Message: `is "carrier-pigeon", want one of [none dns static] or empty for "none"`,
 			}},
 		},
 		{
@@ -372,6 +372,39 @@ func TestProxyAdminValidate(t *testing.T) {
 				Discovery: DiscoveryConfig{
 					Provider: DiscoveryNone,
 					DNS:      DNSDiscoveryConfig{Port: 9999},
+				},
+			}}),
+		},
+		{
+			name: "static provider without addresses",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery:     DiscoveryConfig{Provider: DiscoveryStatic},
+			}}),
+			want: validation.Errors{{
+				Subject: "proxyAdmin.peer",
+				Field:   "discovery.static.addresses",
+				Message: "is required",
+			}},
+		},
+		{
+			name: "static provider with addresses",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery: DiscoveryConfig{
+					Provider: DiscoveryStatic,
+					Static:   StaticDiscoveryConfig{Addresses: []string{"a:9234", "b:9234"}},
+				},
+			}}),
+		},
+		{
+			name: "the previous provider's block survives the switch",
+			cfg: proxyAdmin(ProxyAdminConfig{Peer: &ProxyAdminPeerConfig{
+				ListenAddress: "127.0.0.1:9234",
+				Discovery: DiscoveryConfig{
+					Provider: DiscoveryStatic,
+					DNS:      DNSDiscoveryConfig{Name: "leftover.svc.cluster.local"},
+					Static:   StaticDiscoveryConfig{Addresses: []string{"a:9234", "b:9234"}},
 				},
 			}}),
 		},


### PR DESCRIPTION
Fourth in the stack of proxy admin service config PRs (see stacked PR!) - a static peer discovery provider, for when there's no DNS. 

`static` is a fixed list of `host:port`, one per sibling, (including this pod's own address).

```yaml
proxyAdmin:
  peer:
    listenAddress: "0.0.0.0:6062"
    allowInsecure: true
    discovery:
      provider: static
      static:
        addresses:
          - "10.0.0.1:6062"
          - "10.0.0.2:6062"
```