### PR TITLE
Add the counterparty method allowlist to the ProxyAdminService config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,6 +147,16 @@ type (
 
 	AllowedMethods struct {
 		AdminService []string `yaml:"adminService"`
+
+		// ProxyAdmin narrows what the remote cluster may call on this proxy's own admin API.
+		// Short method names, like AdminService above.
+		//
+		// Nil applies the built-in ceiling: DescribeClusterConnections and nothing else.
+		// An empty list serves nothing.
+		//
+		// "proxyAdmin:" with no value is nil.
+		// "proxyAdmin: []" is the empty list.
+		ProxyAdmin []string `yaml:"proxyAdmin"`
 	}
 
 	ACLPolicy struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -414,3 +414,38 @@ proxyAdmin:
 		require.Error(t, err)
 	})
 }
+
+func TestAllowedMethodsProxyAdmin(t *testing.T) {
+	load := func(t *testing.T, aclBody string) *ACLPolicy {
+		t.Helper()
+		cfg, err := LoadConfig[S2SProxyConfig](writeYAML(t, `
+clusterConnections:
+  - name: only
+    aclPolicy:
+      allowedMethods:
+`+aclBody))
+		require.NoError(t, err)
+		return cfg.ClusterConnections[0].ACLPolicy
+	}
+
+	t.Run("absent is nil", func(t *testing.T) {
+		acl := load(t, "        adminService: [\"DescribeCluster\"]\n")
+		require.Nil(t, acl.AllowedMethods.ProxyAdmin)
+	})
+
+	t.Run("an explicit null is nil", func(t *testing.T) {
+		acl := load(t, "        proxyAdmin:\n")
+		require.Nil(t, acl.AllowedMethods.ProxyAdmin)
+	})
+
+	t.Run("an empty list is present and empty", func(t *testing.T) {
+		acl := load(t, "        proxyAdmin: []\n")
+		require.NotNil(t, acl.AllowedMethods.ProxyAdmin)
+		require.Empty(t, acl.AllowedMethods.ProxyAdmin)
+	})
+
+	t.Run("names round-trip", func(t *testing.T) {
+		acl := load(t, "        proxyAdmin: [\"DescribeClusterConnections\"]\n")
+		require.Equal(t, []string{"DescribeClusterConnections"}, acl.AllowedMethods.ProxyAdmin)
+	})
+}


### PR DESCRIPTION
Last PR in the series (see stacked PR!) of proxy admin service config.

This is the ACL for what a peer cluster may ask.

`aclPolicy.allowedMethods.proxyAdmin` narrows what a counterparty can call over the mux.

```yaml
clusterConnections:
  - name: cluster-b
    aclPolicy:
      allowedMethods:
        proxyAdmin:
          - DescribeClusterConnections
```