### PR TITLE
Add customer-side proxy self-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ s2sB:L <--> R:s2sPortB
 s2sPortB:L <--> R:s2sPortA
 ```
 
+## Validate a customer-side proxy
+
+Run the self-check inside the proxy pod:
+
+```shell
+kubectl exec s2s-proxy-0 -- s2s-proxy validate --only proxy
+```
+
+The command reads the mounted config from `CONFIG_YML`. You can also pass `--config <path>`.
+It checks config structure, TLS files, ACLs, namespace mappings, callback syntax, effective defaults,
+config freshness, and local listeners. Use `--output json` for structured output.
+
+This check uses generic rules only. It does not contact the customer cluster, Temporal Cloud, or the
+Kubernetes API. A successful result means the values are internally consistent and possible to use.
+It does not prove that customer-specific values match a separate specification.
+
+Exit code `0` means no check failed or was unknown. Exit code `1` means a check failed. Exit code `2`
+means the command could not run. Exit code `3` means no check failed, but a runtime check was unknown.
+
 ## Features
 The S2S-Proxy attempts to make it much easier to connect Temporal Clusters that do not share a trusted network.
 Here's a short list of what it can do and how that helps you connect clusters.
@@ -91,4 +110,3 @@ recent incompatibility between servers is the switch from GoGo protobufs to Go-G
 GoGo protobuf allowed incomplete UTF-8 data inside of string objects, which is disallowed in Go-GRPC, which can
 break some connections between Temporal <1.22 and Temporal >1.22. The S2S-proxy will remove those UTF8 errors
 in-stream without the need to modify the data on the source Temporal deployment.
-

--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	urcli "github.com/urfave/cli/v2"
 	"go.temporal.io/server/common/log"
@@ -9,13 +10,18 @@ import (
 
 	"github.com/temporalio/s2s-proxy/config"
 	"github.com/temporalio/s2s-proxy/logging"
+	"github.com/temporalio/s2s-proxy/preflight"
 	"github.com/temporalio/s2s-proxy/proto/compat"
 	"github.com/temporalio/s2s-proxy/proxy"
 )
 
 const (
 	DefaultName = "s2s-proxy"
+	onlyFlag    = "only"
+	outputFlag  = "output"
 )
+
+type proxyCheck func(configPath string, version string) preflight.Report
 
 type proxyRunner interface {
 	Start() error
@@ -23,13 +29,14 @@ type proxyRunner interface {
 }
 
 type App struct {
-	name      string
-	version   string
-	extraOpts []fx.Option
+	name       string
+	version    string
+	extraOpts  []fx.Option
+	checkProxy proxyCheck
 }
 
 func New(name, version string, extraOpts ...fx.Option) *App {
-	return &App{name: name, version: version, extraOpts: extraOpts}
+	return &App{name: name, version: version, extraOpts: extraOpts, checkProxy: preflight.CheckProxy}
 }
 
 func (a *App) Run(ctx context.Context, args []string) error {
@@ -52,11 +59,7 @@ func (a *App) buildApp(ctx context.Context) *urcli.App {
 			Name:  "start",
 			Usage: "Starts the proxy.",
 			Flags: []urcli.Flag{
-				&urcli.StringFlag{
-					Name:     config.ConfigPathFlag,
-					Usage:    "path to proxy config yaml file",
-					Required: true,
-				},
+				configPathFlag(),
 				&urcli.StringFlag{
 					Name:     config.LogLevelFlag,
 					Usage:    "Set log level(debug, info, warn, error). Default level is info",
@@ -67,9 +70,71 @@ func (a *App) buildApp(ctx context.Context) *urcli.App {
 				return a.startProxy(ctx, cliCtx)
 			},
 		},
+		{
+			Name:  "validate",
+			Usage: "Checks the customer-side proxy configuration and local runtime.",
+			Flags: []urcli.Flag{
+				validationConfigPathFlag(),
+				&urcli.StringFlag{
+					Name:  onlyFlag,
+					Usage: "validation stage to run",
+					Value: "proxy",
+				},
+				&urcli.StringFlag{
+					Name:  outputFlag,
+					Usage: "output format: text or json",
+					Value: "text",
+				},
+			},
+			Action: a.validateProxy,
+		},
 	}
 
 	return app
+}
+
+func configPathFlag() *urcli.StringFlag {
+	return &urcli.StringFlag{
+		Name:     config.ConfigPathFlag,
+		Usage:    "path to proxy config yaml file",
+		Required: true,
+	}
+}
+
+func validationConfigPathFlag() urcli.Flag {
+	flag := configPathFlag()
+	flag.EnvVars = []string{"CONFIG_YML"}
+	return flag
+}
+
+func (a *App) validateProxy(cliCtx *urcli.Context) error {
+	if only := cliCtx.String(onlyFlag); only != "proxy" {
+		return urcli.Exit(fmt.Sprintf("unsupported validation stage %q; phase 1 supports only proxy", only), 2)
+	}
+	output := cliCtx.String(outputFlag)
+	if output != "text" && output != "json" {
+		return urcli.Exit(fmt.Sprintf("unsupported output format %q; use text or json", output), 2)
+	}
+
+	report := a.checkProxy(cliCtx.String(config.ConfigPathFlag), a.version)
+	switch output {
+	case "text":
+		if err := report.WriteText(cliCtx.App.Writer); err != nil {
+			return urcli.Exit(fmt.Sprintf("write validation output: %v", err), 2)
+		}
+	case "json":
+		if err := report.WriteJSON(cliCtx.App.Writer); err != nil {
+			return urcli.Exit(fmt.Sprintf("write validation output: %v", err), 2)
+		}
+	}
+
+	if report.HasFailures() {
+		return urcli.Exit("", 1)
+	}
+	if report.HasUnknowns() {
+		return urcli.Exit("", 3)
+	}
+	return nil
 }
 
 func (a *App) startProxy(runCtx context.Context, cliCtx *urcli.Context) error {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,15 +1,19 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	urcli "github.com/urfave/cli/v2"
 	"go.uber.org/fx"
 
 	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/preflight"
 )
 
 type stubbedProxy struct {
@@ -48,6 +52,97 @@ func TestBuildApp_ReflectsNameAndVersion(t *testing.T) {
 	app := New("just-another-proxy-💁", "9.9.9").buildApp(context.Background())
 	assert.Equal(t, "just-another-proxy-💁", app.Name)
 	assert.Equal(t, "9.9.9", app.Version)
+}
+
+func TestBuildApp_IncludesValidateCommand(t *testing.T) {
+	app := New(DefaultName, testVersion).buildApp(context.Background())
+	require.NotNil(t, app.Command("validate"))
+}
+
+func TestRunValidate_UsesConfigEnvironmentAndWritesReport(t *testing.T) {
+	t.Setenv("CONFIG_YML", "/config/config.yaml")
+	var checkedPath string
+	a := New(DefaultName, testVersion)
+	a.checkProxy = func(configPath string, version string) preflight.Report {
+		checkedPath = configPath
+		return preflight.Report{
+			ConfigPath:   configPath,
+			ConfigSHA256: "abc123",
+			Version:      version,
+			Pod:          "proxy-pod-0",
+			Results:      []preflight.Result{{Status: preflight.StatusPass, Name: "config file parses"}},
+		}
+	}
+	cliApp := a.buildApp(context.Background())
+	var output bytes.Buffer
+	cliApp.Writer = &output
+
+	require.NoError(t, cliApp.Run([]string{"app", "validate", "--only", "proxy"}))
+	assert.Equal(t, "/config/config.yaml", checkedPath)
+	assert.Contains(t, output.String(), "config file parses")
+}
+
+func TestValidateProxy_ExitCodes(t *testing.T) {
+	tests := []struct {
+		name        string
+		stage       string
+		output      string
+		results     []preflight.Result
+		wantCode    int
+		wantNoError bool
+	}{
+		{
+			name:        "success",
+			stage:       "proxy",
+			output:      "text",
+			results:     []preflight.Result{{Status: preflight.StatusPass, Name: "good"}},
+			wantNoError: true,
+		},
+		{
+			name:     "failed check",
+			stage:    "proxy",
+			output:   "text",
+			results:  []preflight.Result{{Status: preflight.StatusFail, Name: "bad"}},
+			wantCode: 1,
+		},
+		{
+			name:     "incomplete check",
+			stage:    "proxy",
+			output:   "json",
+			results:  []preflight.Result{{Status: preflight.StatusUnknown, Name: "not observed"}},
+			wantCode: 3,
+		},
+		{
+			name:     "unsupported stage",
+			stage:    "cluster",
+			output:   "text",
+			wantCode: 2,
+		},
+		{
+			name:     "unsupported output",
+			stage:    "proxy",
+			output:   "xml",
+			wantCode: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := New(DefaultName, testVersion)
+			a.checkProxy = func(configPath string, version string) preflight.Report {
+				return preflight.Report{ConfigPath: configPath, Version: version, Results: tt.results}
+			}
+			cliCtx := validationContext(t, tt.stage, tt.output)
+			err := a.validateProxy(cliCtx)
+			if tt.wantNoError {
+				require.NoError(t, err)
+				return
+			}
+			var exitCoder urcli.ExitCoder
+			require.ErrorAs(t, err, &exitCoder)
+			assert.Equal(t, tt.wantCode, exitCoder.ExitCode())
+		})
+	}
 }
 
 func TestRun_MissingConfigFlag_ReturnsError(t *testing.T) {
@@ -114,4 +209,17 @@ func TestRun_LogLevelFlag_ParsedWithoutError(t *testing.T) {
 	stub := &stubbedProxy{}
 	err := runWithCancelledCtx(t, New(DefaultName, testVersion, withStubbedConfig(), withStubbedProxy(stub)))
 	require.NoError(t, err)
+}
+
+func validationContext(t *testing.T, stage string, output string) *urcli.Context {
+	t.Helper()
+	flags := flag.NewFlagSet("validate", flag.ContinueOnError)
+	flags.String(config.ConfigPathFlag, "/config/config.yaml", "")
+	flags.String(onlyFlag, "proxy", "")
+	flags.String(outputFlag, "text", "")
+	require.NoError(t, flags.Set(onlyFlag, stage))
+	require.NoError(t, flags.Set(outputFlag, output))
+	cliApp := urcli.NewApp()
+	cliApp.Writer = &bytes.Buffer{}
+	return urcli.NewContext(cliApp, flags, nil)
 }

--- a/encryption/certificate.go
+++ b/encryption/certificate.go
@@ -41,3 +41,12 @@ func validateHasCA(certs []*x509.Certificate, source string) error {
 	}
 	return nil
 }
+
+// ValidateCABundle verifies that PEM data contains at least one usable CA certificate.
+func ValidateCABundle(pemBytes []byte, source string) error {
+	certs, err := certificatesFromPEM(pemBytes)
+	if err != nil {
+		return fmt.Errorf("cannot parse ca file %q: %w", source, err)
+	}
+	return validateHasCA(certs, source)
+}

--- a/encryption/certificate_test.go
+++ b/encryption/certificate_test.go
@@ -51,6 +51,29 @@ func (s *tlsTestSuite) Test_validateHasCA_WrapsSentinel() {
 	s.Require().ErrorIs(err, errNoCACertificates)
 }
 
+func (s *tlsTestSuite) TestValidateCABundle() {
+	tests := []struct {
+		name    string
+		pem     []byte
+		wantErr string
+	}{
+		{name: "CA bundle", pem: caPEM(s.T(), "root")},
+		{name: "leaf only", pem: leafPEM(s.T(), "server"), wantErr: "no usable CA certificates found"},
+		{name: "malformed certificate", pem: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("bad")}), wantErr: "cannot parse ca file"},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			err := ValidateCABundle(tt.pem, "ca.pem")
+			if tt.wantErr == "" {
+				s.NoError(err)
+				return
+			}
+			s.ErrorContains(err, tt.wantErr)
+		})
+	}
+}
+
 func (s *tlsTestSuite) Test_certificatesFromPEM() {
 	t := s.T()
 

--- a/encryption/tls.go
+++ b/encryption/tls.go
@@ -171,11 +171,7 @@ func fetchCACert(pathOrUrl string) (*x509.CertPool, error) {
 		}
 	}
 
-	certs, err := certificatesFromPEM(caBytes)
-	if err != nil {
-		return nil, fmt.Errorf("cannot parse ca file %q: %w", pathOrUrl, err)
-	}
-	if err := validateHasCA(certs, pathOrUrl); err != nil {
+	if err := ValidateCABundle(caBytes, pathOrUrl); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/procfs v0.21.1
 	github.com/stretchr/testify v1.12.1
 	github.com/temporalio/temporal-proxy v0.5.2
 	github.com/urfave/cli/v2 v2.27.7
@@ -169,7 +170,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
-	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/robfig/cron v1.2.0 // indirect

--- a/preflight/proxy.go
+++ b/preflight/proxy.go
@@ -1,0 +1,882 @@
+package preflight
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/procfs"
+	"gopkg.in/yaml.v3"
+
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/encryption"
+	"github.com/temporalio/s2s-proxy/transport/mux"
+)
+
+const (
+	defaultListenerTimeout = 500 * time.Millisecond
+	certificateWarningAge  = 30 * 24 * time.Hour
+	temporalSystem         = "temporal-system"
+)
+
+var requiredAdminMethods = []string{
+	"AddOrUpdateRemoteCluster",
+	"RemoveRemoteCluster",
+	"DescribeCluster",
+	"DescribeMutableState",
+	"GetNamespaceReplicationMessages",
+	"GetWorkflowExecutionRawHistoryV2",
+	"ListClusters",
+	"StreamWorkflowReplicationMessages",
+	"ReapplyEvents",
+	"GetNamespace",
+	"SyncWorkflowState",
+}
+
+type ProxyCheckOptions struct {
+	Now              func() time.Time
+	Hostname         func() (string, error)
+	ProcessStartTime func() (time.Time, error)
+	CheckListener    func(string) error
+}
+
+func CheckProxy(configPath string, version string) Report {
+	return CheckProxyWithOptions(configPath, version, ProxyCheckOptions{})
+}
+
+func CheckProxyWithOptions(configPath string, version string, opts ProxyCheckOptions) Report {
+	opts = defaultProxyCheckOptions(opts)
+	pod, err := opts.Hostname()
+	if err != nil || pod == "" {
+		pod = "unknown"
+	}
+	report := Report{
+		ConfigPath:   configPath,
+		ConfigSHA256: "unknown",
+		Version:      version,
+		Pod:          pod,
+		Scope:        GenericProxyScope,
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		report.Results = append(report.Results, Result{
+			Status: StatusFail,
+			Name:   "config file cannot be read",
+			Details: []string{
+				err.Error(),
+			},
+		})
+		return report
+	}
+	report.ConfigSHA256 = fmt.Sprintf("%x", sha256.Sum256(data))
+
+	if err := parseSingleYAMLDocument(data); err != nil {
+		report.Results = append(report.Results, Result{
+			Status:  StatusFail,
+			Name:    "config file does not parse",
+			Details: []string{err.Error()},
+		})
+		return report
+	}
+	report.Results = append(report.Results, Result{Status: StatusPass, Name: "config file parses"})
+
+	cfg, err := config.LoadConfig[config.S2SProxyConfig](configPath)
+	if err != nil {
+		report.Results = append(report.Results, Result{
+			Status:  StatusFail,
+			Name:    "config format is not supported",
+			Details: splitErrorLines(err),
+		})
+		return report
+	}
+	report.Results = append(report.Results, checkConfigStructure(cfg))
+	report.Results = append(report.Results,
+		checkTLSConfiguration(cfg),
+		checkCertificateFiles(cfg, opts.Now()),
+		checkAdminPermissions(cfg),
+		checkTemporalSystem(cfg),
+		checkAllowedNamespaceSide(cfg),
+		checkNamespaceMappings(cfg),
+		checkReplicationEndpoints(cfg),
+		checkConnectionNames(cfg),
+		checkNumericSettings(cfg),
+		effectiveConfig(cfg),
+		binaryIdentity(version, pod),
+		checkConfigFreshness(configPath, opts.ProcessStartTime),
+		checkLocalListeners(cfg, opts.ProcessStartTime, opts.CheckListener),
+	)
+
+	return report
+}
+
+func defaultProxyCheckOptions(opts ProxyCheckOptions) ProxyCheckOptions {
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.Hostname == nil {
+		opts.Hostname = os.Hostname
+	}
+	if opts.ProcessStartTime == nil {
+		opts.ProcessStartTime = proxyProcessStartTime
+	}
+	if opts.CheckListener == nil {
+		opts.CheckListener = checkListener
+	}
+	return opts
+}
+
+func parseSingleYAMLDocument(data []byte) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return errors.New("config file is empty")
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var doc yaml.Node
+	if err := decoder.Decode(&doc); err != nil {
+		return err
+	}
+
+	var extra yaml.Node
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return err
+		}
+		return errors.New("config contains more than one YAML document")
+	}
+	return nil
+}
+
+func checkConfigStructure(cfg config.S2SProxyConfig) Result {
+	problems := splitErrorLines(cfg.Validate())
+	if len(cfg.ClusterConnections) == 0 {
+		problems = append(problems, "clusterConnections must contain at least one connection")
+	}
+
+	for i, conn := range cfg.ClusterConnections {
+		prefix := fmt.Sprintf("clusterConnections[%d]", i)
+		if conn.Local.ConnectionType != config.ConnTypeTCP {
+			problems = append(problems, fmt.Sprintf("%s.local.connectionType must be tcp for the customer-side proxy", prefix))
+		}
+		if conn.Remote.ConnectionType != config.ConnTypeMuxClient {
+			problems = append(problems, fmt.Sprintf("%s.remote.connectionType must be mux-client for the customer-side proxy", prefix))
+		}
+
+		problems = append(problems,
+			dialAddressProblems(prefix+".local.tcpClient.address", conn.Local.TcpClient.ConnectionString)...)
+		problems = append(problems,
+			listenAddressProblems(prefix+".local.tcpServer.address", conn.Local.TcpServer.ConnectionString)...)
+		problems = append(problems,
+			dialAddressProblems(prefix+".remote.muxAddressInfo.address", conn.Remote.MuxAddressInfo.ConnectionString)...)
+		if isAddressPlaceholder(conn.Remote.MuxAddressInfo.ConnectionString) {
+			problems = append(problems, prefix+".remote.muxAddressInfo.address still contains a template placeholder")
+		}
+		problems = append(problems, healthCheckProblems(prefix+".remoteClusterHealthCheck", conn.RemoteClusterHealthCheck)...)
+		problems = append(problems, healthCheckProblems(prefix+".localClusterHealthCheck", conn.LocalClusterHealthCheck)...)
+	}
+
+	if cfg.Metrics != nil && cfg.Metrics.Prometheus.ListenAddress != "" {
+		problems = append(problems, listenAddressProblems("metrics.prometheus.listenAddress", cfg.Metrics.Prometheus.ListenAddress)...)
+	}
+	if cfg.ProfilingConfig != nil && cfg.ProfilingConfig.PProfHTTPAddress != "" {
+		problems = append(problems, listenAddressProblems("profiling.pprofAddress", cfg.ProfilingConfig.PProfHTTPAddress)...)
+	}
+	problems = append(problems, duplicateListenerProblems(cfg)...)
+
+	if len(problems) > 0 {
+		return Result{Status: StatusFail, Name: "config structure is not usable", Details: problems}
+	}
+	return Result{Status: StatusPass, Name: "config format and structure are supported"}
+}
+
+func healthCheckProblems(path string, health config.HealthCheckConfig) []string {
+	if health.ListenAddress == "" && health.Protocol == "" {
+		return nil
+	}
+	var problems []string
+	if health.Protocol != config.HTTP {
+		problems = append(problems, fmt.Sprintf("%s.protocol must be http", path))
+	}
+	problems = append(problems, listenAddressProblems(path+".listenAddress", health.ListenAddress)...)
+	return problems
+}
+
+func dialAddressProblems(path string, address string) []string {
+	return hostPortProblems(path, address, true)
+}
+
+func listenAddressProblems(path string, address string) []string {
+	return hostPortProblems(path, address, false)
+}
+
+func hostPortProblems(path string, address string, requireHost bool) []string {
+	if address == "" {
+		return []string{path + " is required"}
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil || strings.ContainsAny(host, "/") || (requireHost && host == "") {
+		return []string{path + " is not a usable host:port"}
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil || p <= 0 || p > 65535 {
+		return []string{path + " is not a usable host:port"}
+	}
+	return nil
+}
+
+func duplicateListenerProblems(cfg config.S2SProxyConfig) []string {
+	seen := make(map[string]string)
+	var problems []string
+	add := func(path string, address string) {
+		if address == "" {
+			return
+		}
+		key := normalizedListenerAddress(address)
+		if previous, ok := seen[key]; ok {
+			problems = append(problems, fmt.Sprintf("%s and %s use the same listener address %q", previous, path, address))
+			return
+		}
+		seen[key] = path
+	}
+	for i, conn := range cfg.ClusterConnections {
+		prefix := fmt.Sprintf("clusterConnections[%d]", i)
+		add(prefix+".local.tcpServer.address", conn.Local.TcpServer.ConnectionString)
+		if i == 0 {
+			add(prefix+".remoteClusterHealthCheck.listenAddress", conn.RemoteClusterHealthCheck.ListenAddress)
+			add(prefix+".localClusterHealthCheck.listenAddress", conn.LocalClusterHealthCheck.ListenAddress)
+		}
+	}
+	if cfg.Metrics != nil {
+		add("metrics.prometheus.listenAddress", cfg.Metrics.Prometheus.ListenAddress)
+	}
+	if cfg.ProfilingConfig != nil {
+		add("profiling.pprofAddress", cfg.ProfilingConfig.PProfHTTPAddress)
+	}
+	return problems
+}
+
+func normalizedListenerAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "*"
+	}
+	return net.JoinHostPort(strings.ToLower(host), port)
+}
+
+type tlsLocation struct {
+	path            string
+	config          encryption.TLSConfig
+	required        bool
+	client          bool
+	requireIdentity bool
+}
+
+func tlsLocations(cfg config.S2SProxyConfig) []tlsLocation {
+	var locations []tlsLocation
+	for i, conn := range cfg.ClusterConnections {
+		prefix := fmt.Sprintf("clusterConnections[%d]", i)
+		locations = append(locations,
+			tlsLocation{path: prefix + ".local.tcpClient.tls", config: conn.Local.TcpClient.TLSConfig, client: true},
+			tlsLocation{path: prefix + ".local.tcpServer.tls", config: conn.Local.TcpServer.TLSConfig, requireIdentity: true},
+			tlsLocation{path: prefix + ".remote.muxAddressInfo.tls", config: conn.Remote.MuxAddressInfo.TLSConfig, required: true, client: true, requireIdentity: true},
+		)
+	}
+	return locations
+}
+
+func checkTLSConfiguration(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "TLS cannot be checked without a cluster connection"}
+	}
+	var problems []string
+	for _, location := range tlsLocations(cfg) {
+		tlsCfg := location.config
+		configured := hasTLSValue(tlsCfg)
+		if location.required && !configured {
+			problems = append(problems, location.path+" is required for the customer-side cloud connection")
+			continue
+		}
+		if !configured {
+			continue
+		}
+		if (tlsCfg.CertificatePath == "") != (tlsCfg.KeyPath == "") {
+			problems = append(problems, location.path+" requires both certificatePath and keyPath")
+		}
+		if location.requireIdentity && (tlsCfg.CertificatePath == "" || tlsCfg.KeyPath == "") {
+			problems = append(problems, location.path+" requires a certificate and key")
+		}
+		if location.client && !tlsCfg.SkipCAVerification && tlsCfg.CAServerName == "" {
+			problems = append(problems, location.path+".caServerName is required when skipCAVerification is false")
+		}
+		if !location.client && !tlsCfg.SkipCAVerification && tlsCfg.RemoteCAPath == "" {
+			problems = append(problems, location.path+".remoteCAPath is required when client certificate verification is enabled")
+		}
+	}
+
+	if len(problems) > 0 {
+		return Result{Status: StatusFail, Name: "TLS configuration is incomplete", Details: problems}
+	}
+	return Result{Status: StatusPass, Name: "TLS is configured for the remote connection"}
+}
+
+func hasTLSValue(cfg encryption.TLSConfig) bool {
+	return cfg.CertificatePath != "" || cfg.KeyPath != "" || cfg.RemoteCAPath != "" ||
+		cfg.CAServerName != ""
+}
+
+func checkCertificateFiles(cfg config.S2SProxyConfig, now time.Time) Result {
+	var failures []string
+	var warnings []string
+	var details []string
+	checked := 0
+	incompletePairs := 0
+
+	for _, location := range tlsLocations(cfg) {
+		tlsCfg := location.config
+		if (tlsCfg.CertificatePath == "") != (tlsCfg.KeyPath == "") {
+			incompletePairs++
+		}
+		if tlsCfg.CertificatePath != "" && tlsCfg.KeyPath != "" {
+			checked++
+			pair, err := tls.LoadX509KeyPair(tlsCfg.CertificatePath, tlsCfg.KeyPath)
+			if err != nil {
+				failures = append(failures, fmt.Sprintf("%s certificate/key: %v", location.path, err))
+			} else if len(pair.Certificate) == 0 {
+				failures = append(failures, location.path+" certificate file contains no certificate")
+			} else {
+				certificate, err := x509.ParseCertificate(pair.Certificate[0])
+				if err != nil {
+					failures = append(failures, fmt.Sprintf("%s certificate: %v", location.path, err))
+				} else {
+					remaining := certificate.NotAfter.Sub(now)
+					switch {
+					case now.Before(certificate.NotBefore):
+						failures = append(failures, fmt.Sprintf("%s certificate is not valid until %s", location.path, certificate.NotBefore.Format(time.RFC3339)))
+					case remaining <= 0:
+						failures = append(failures, fmt.Sprintf("%s certificate expired at %s", location.path, certificate.NotAfter.Format(time.RFC3339)))
+					case remaining <= certificateWarningAge:
+						warnings = append(warnings, fmt.Sprintf("%s certificate expires in %s", location.path, remaining.Round(time.Hour)))
+					default:
+						details = append(details, fmt.Sprintf("%s certificate expires in %s", location.path, remaining.Round(24*time.Hour)))
+					}
+				}
+			}
+		}
+
+		if tlsCfg.RemoteCAPath == "" {
+			continue
+		}
+		if strings.HasPrefix(tlsCfg.RemoteCAPath, "http://") {
+			failures = append(failures, location.path+".remoteCAPath uses HTTP; only a local file or HTTPS URL is supported")
+			continue
+		}
+		if strings.HasPrefix(tlsCfg.RemoteCAPath, "https://") {
+			warnings = append(warnings, location.path+".remoteCAPath is a URL and was not fetched by this local check")
+			continue
+		}
+		checked++
+		if err := validateCAFile(tlsCfg.RemoteCAPath); err != nil {
+			failures = append(failures, fmt.Sprintf("%s.remoteCAPath: %v", location.path, err))
+		}
+	}
+
+	if len(failures) > 0 {
+		return Result{Status: StatusFail, Name: "certificate files are invalid", Details: append(failures, warnings...)}
+	}
+	if len(warnings) > 0 {
+		return Result{Status: StatusWarn, Name: "certificate files need review", Details: append(warnings, details...)}
+	}
+	if checked == 0 {
+		if incompletePairs > 0 {
+			return Result{Status: StatusSkip, Name: "certificate pairs cannot be loaded until both paths are configured"}
+		}
+		return Result{Status: StatusSkip, Name: "no certificate files are configured"}
+	}
+	return Result{Status: StatusPass, Name: "certificate files load", Details: details}
+}
+
+func validateCAFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return encryption.ValidateCABundle(data, path)
+}
+
+func checkAdminPermissions(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "admin permissions cannot be checked without a cluster connection"}
+	}
+	var missing []string
+	restricted := 0
+	for i, conn := range cfg.ClusterConnections {
+		if conn.ACLPolicy == nil || len(conn.ACLPolicy.AllowedMethods.AdminService) == 0 {
+			continue
+		}
+		restricted++
+		for _, method := range requiredAdminMethods {
+			if !slices.Contains(conn.ACLPolicy.AllowedMethods.AdminService, method) {
+				missing = append(missing, fmt.Sprintf("clusterConnections[%d] is missing %s", i, method))
+			}
+		}
+	}
+
+	if len(missing) > 0 {
+		return Result{Status: StatusFail, Name: "admin permissions are incomplete", Details: missing}
+	}
+	if restricted == 0 {
+		return Result{Status: StatusSkip, Name: "admin methods are unrestricted"}
+	}
+	return Result{Status: StatusPass, Name: "admin permissions include all required migration methods"}
+}
+
+func checkTemporalSystem(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "allowed namespaces cannot be checked without a cluster connection"}
+	}
+	var missing []string
+	restricted := 0
+	for i, conn := range cfg.ClusterConnections {
+		if conn.ACLPolicy == nil || len(conn.ACLPolicy.AllowedNamespaces) == 0 {
+			continue
+		}
+		restricted++
+		if !slices.Contains(conn.ACLPolicy.AllowedNamespaces, temporalSystem) {
+			missing = append(missing, fmt.Sprintf("clusterConnections[%d].aclPolicy.allowedNamespaces", i))
+		}
+	}
+
+	if len(missing) > 0 {
+		return Result{Status: StatusFail, Name: "temporal-system is not allowed", Details: missing}
+	}
+	if restricted == 0 {
+		return Result{Status: StatusSkip, Name: "namespaces are unrestricted"}
+	}
+	return Result{Status: StatusPass, Name: "temporal-system is allowed"}
+}
+
+func checkAllowedNamespaceSide(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "allowed namespace side cannot be checked without a cluster connection"}
+	}
+	var wrong []string
+	applicable := false
+	for i, conn := range cfg.ClusterConnections {
+		if conn.ACLPolicy == nil || len(conn.ACLPolicy.AllowedNamespaces) == 0 || len(conn.NamespaceTranslation.Mappings) == 0 {
+			continue
+		}
+		applicable = true
+		for _, mapping := range conn.NamespaceTranslation.Mappings {
+			if mapping.Local != mapping.Remote && slices.Contains(conn.ACLPolicy.AllowedNamespaces, mapping.Remote) {
+				wrong = append(wrong, fmt.Sprintf("clusterConnections[%d] allows remote name %q; use local name %q", i, mapping.Remote, mapping.Local))
+			}
+		}
+	}
+
+	if len(wrong) > 0 {
+		return Result{Status: StatusFail, Name: "allowed namespaces use the wrong side", Details: wrong}
+	}
+	if !applicable {
+		return Result{Status: StatusSkip, Name: "allowed namespace side cannot be compared"}
+	}
+	return Result{Status: StatusPass, Name: "allowed namespaces use customer-side names"}
+}
+
+func checkNamespaceMappings(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "namespace mappings cannot be checked without a cluster connection"}
+	}
+	var failures []string
+	var warnings []string
+	applicable := false
+	for i, conn := range cfg.ClusterConnections {
+		prefix := fmt.Sprintf("clusterConnections[%d].namespaceTranslation", i)
+		if len(conn.NamespaceTranslation.Mappings) > 0 {
+			applicable = true
+		}
+		for j, mapping := range conn.NamespaceTranslation.Mappings {
+			path := fmt.Sprintf("%s.mappings[%d]", prefix, j)
+			if mapping.Local == "" || mapping.Remote == "" {
+				failures = append(failures, path+" requires both local and remote names")
+			}
+			if isNamespacePlaceholder(mapping.Local) || isNamespacePlaceholder(mapping.Remote) {
+				failures = append(failures, path+" still contains a template placeholder")
+			}
+		}
+		if _, err := conn.NamespaceTranslation.AsLocalToRemoteBiMap(); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", prefix, err))
+		}
+
+		if conn.ACLPolicy != nil && len(conn.ACLPolicy.AllowedNamespaces) > 0 {
+			for _, namespace := range conn.ACLPolicy.AllowedNamespaces {
+				if namespace == temporalSystem {
+					continue
+				}
+				if !slices.ContainsFunc(conn.NamespaceTranslation.Mappings, func(mapping config.StringMapping) bool {
+					return mapping.Local == namespace
+				}) {
+					warnings = append(warnings, fmt.Sprintf("%s has no explicit mapping for allowed namespace %q; this is valid only when both sides use the same name", prefix, namespace))
+				}
+			}
+		}
+	}
+
+	if len(failures) > 0 {
+		return Result{Status: StatusFail, Name: "namespace mappings are unusable", Details: append(failures, warnings...)}
+	}
+	if len(warnings) > 0 {
+		return Result{Status: StatusWarn, Name: "namespace mappings need review", Details: warnings}
+	}
+	if !applicable {
+		return Result{Status: StatusSkip, Name: "no namespace mappings are configured"}
+	}
+	return Result{Status: StatusPass, Name: "namespace mappings are internally consistent"}
+}
+
+func isNamespacePlaceholder(value string) bool {
+	return value == "myNamespace" || value == "myNamespace.accountid" || value == "my-local" || value == "my-cloud.acct"
+}
+
+func isAddressPlaceholder(value string) bool {
+	return value == "remote_proxy_service:8233" || value == "address-of-your-s2s-proxy-deployment:9233"
+}
+
+func checkReplicationEndpoints(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "replication endpoint cannot be checked without a cluster connection"}
+	}
+	var failures []string
+	var warnings []string
+	for i, conn := range cfg.ClusterConnections {
+		path := fmt.Sprintf("clusterConnections[%d].replicationEndpoint", i)
+		if isAddressPlaceholder(conn.ReplicationEndpoint) {
+			failures = append(failures, path+" still contains a template placeholder")
+			continue
+		}
+		host, port, err := splitUsableHostPort(conn.ReplicationEndpoint)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s %v", path, err))
+			continue
+		}
+		if host == "localhost" || isLoopback(host) {
+			warnings = append(warnings, fmt.Sprintf("%s uses loopback address %q", path, host))
+		}
+
+		_, listenerPort, err := net.SplitHostPort(conn.Local.TcpServer.ConnectionString)
+		if err == nil && listenerPort != port {
+			warnings = append(warnings, fmt.Sprintf("%s port %s differs from local listener port %s; this may be valid when internal routing translates ports", path, port, listenerPort))
+		}
+	}
+
+	if len(failures) > 0 {
+		return Result{Status: StatusFail, Name: "replication endpoint is unusable", Details: append(failures, warnings...)}
+	}
+	if len(warnings) > 0 {
+		return Result{Status: StatusWarn, Name: "replication endpoint needs review", Details: warnings}
+	}
+	return Result{Status: StatusPass, Name: "replication endpoint is syntactically usable", Details: []string{"routability is not verified by this local check"}}
+}
+
+func splitUsableHostPort(address string) (string, string, error) {
+	if address == "" {
+		return "", "", errors.New("is required")
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil || host == "" {
+		return "", "", errors.New("is not a usable host:port")
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil || p <= 0 || p > 65535 {
+		return "", "", errors.New("is not a usable host:port")
+	}
+	return host, port, nil
+}
+
+func isLoopback(host string) bool {
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func checkConnectionNames(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "connection names cannot be checked without a cluster connection"}
+	}
+	seen := make(map[string]struct{}, len(cfg.ClusterConnections))
+	var problems []string
+	for i, conn := range cfg.ClusterConnections {
+		if conn.Name == "" {
+			problems = append(problems, fmt.Sprintf("clusterConnections[%d].name is required", i))
+			continue
+		}
+		if _, duplicate := seen[conn.Name]; duplicate {
+			problems = append(problems, fmt.Sprintf("duplicate connection name %q", conn.Name))
+		}
+		seen[conn.Name] = struct{}{}
+	}
+	if len(problems) > 0 {
+		return Result{Status: StatusFail, Name: "connection names are not unique", Details: problems}
+	}
+	return Result{Status: StatusPass, Name: "connection names are unique"}
+}
+
+func checkNumericSettings(cfg config.S2SProxyConfig) Result {
+	if len(cfg.ClusterConnections) == 0 {
+		return Result{Status: StatusSkip, Name: "numeric settings cannot be checked without a cluster connection"}
+	}
+	var failures []string
+	var warnings []string
+	applicable := false
+	for i, conn := range cfg.ClusterConnections {
+		path := fmt.Sprintf("clusterConnections[%d].shardCount", i)
+		shards := conn.ShardCountConfig
+		if conn.Remote.MuxCount < 0 {
+			failures = append(failures, fmt.Sprintf("clusterConnections[%d].remote.muxCount cannot be negative", i))
+		}
+
+		switch shards.Mode {
+		case config.ShardCountDefault:
+			if shards.LocalShardCount != 0 || shards.RemoteShardCount != 0 {
+				warnings = append(warnings, path+" counts are configured but mode is empty, so the values are inactive")
+			}
+		case config.ShardCountLCM, config.ShardCountRouting:
+			applicable = true
+			if shards.LocalShardCount <= 0 || shards.RemoteShardCount <= 0 {
+				failures = append(failures, path+" requires positive localShardCount and remoteShardCount when mode is active")
+			} else if shards.Mode == config.ShardCountLCM && lcmOverflowsInt32(shards.LocalShardCount, shards.RemoteShardCount) {
+				failures = append(failures, path+" least common multiple exceeds the supported integer range")
+			}
+		default:
+			failures = append(failures, fmt.Sprintf("%s.mode %q is not supported", path, shards.Mode))
+		}
+	}
+
+	if len(failures) > 0 {
+		return Result{Status: StatusFail, Name: "numeric settings are unusable", Details: append(failures, warnings...)}
+	}
+	if len(warnings) > 0 {
+		return Result{Status: StatusWarn, Name: "numeric settings are configured but inactive", Details: warnings}
+	}
+	if !applicable {
+		return Result{Status: StatusSkip, Name: "no shard-count translation is configured"}
+	}
+	return Result{Status: StatusPass, Name: "numeric settings are active and usable"}
+}
+
+func lcmOverflowsInt32(a int32, b int32) bool {
+	gcd := func(x int64, y int64) int64 {
+		for y != 0 {
+			x, y = y, x%y
+		}
+		return x
+	}
+	result := int64(a) / gcd(int64(a), int64(b)) * int64(b)
+	return result > math.MaxInt32
+}
+
+func effectiveConfig(cfg config.S2SProxyConfig) Result {
+	var details []string
+	for _, conn := range cfg.ClusterConnections {
+		name := fmt.Sprintf("connection %q", conn.Name)
+		details = append(details,
+			fmt.Sprintf("%s: customer cluster dial=%s %s, TLS=%s", name, conn.Local.ConnectionType, conn.Local.TcpClient.ConnectionString, tlsState(conn.Local.TcpClient.TLSConfig)),
+			fmt.Sprintf("%s: customer callback listen=%s, TLS=%s, advertised=%s", name, conn.Local.TcpServer.ConnectionString, tlsState(conn.Local.TcpServer.TLSConfig), conn.ReplicationEndpoint),
+			fmt.Sprintf("%s: remote proxy dial=%s %s, muxCount=%d, TLS=%s", name, conn.Remote.ConnectionType, conn.Remote.MuxAddressInfo.ConnectionString, mux.DesiredMuxCount(conn.Remote), tlsState(conn.Remote.MuxAddressInfo.TLSConfig)),
+		)
+
+		shardMode := string(conn.ShardCountConfig.Mode)
+		if shardMode == "" {
+			shardMode = "none"
+		}
+		details = append(details, fmt.Sprintf(
+			"%s: shardMode=%s, localShardCount=%d, remoteShardCount=%d, localFVI=%d, remoteFVI=%d",
+			name,
+			shardMode,
+			conn.ShardCountConfig.LocalShardCount,
+			conn.ShardCountConfig.RemoteShardCount,
+			conn.FVITranslation.Local,
+			conn.FVITranslation.Remote,
+		))
+
+		if conn.ACLPolicy == nil || len(conn.ACLPolicy.AllowedMethods.AdminService) == 0 {
+			details = append(details, name+": admin methods=unrestricted")
+		} else {
+			details = append(details, fmt.Sprintf("%s: admin methods=%d configured", name, len(conn.ACLPolicy.AllowedMethods.AdminService)))
+		}
+		if conn.ACLPolicy == nil || len(conn.ACLPolicy.AllowedNamespaces) == 0 {
+			details = append(details, name+": namespaces=unrestricted")
+		} else {
+			details = append(details, fmt.Sprintf("%s: allowed namespaces=%s", name, strings.Join(conn.ACLPolicy.AllowedNamespaces, ",")))
+		}
+		for _, mapping := range conn.NamespaceTranslation.Mappings {
+			details = append(details, fmt.Sprintf("%s: namespace %s -> %s", name, mapping.Local, mapping.Remote))
+		}
+	}
+	if cfg.Metrics != nil {
+		details = append(details, "metrics="+cfg.Metrics.Prometheus.ListenAddress)
+	}
+	if cfg.ProfilingConfig != nil {
+		details = append(details, "profiling="+cfg.ProfilingConfig.PProfHTTPAddress)
+	}
+	return Result{Status: StatusInfo, Name: "effective config", Details: details}
+}
+
+func tlsState(cfg encryption.TLSConfig) string {
+	if !cfg.IsEnabled() {
+		return "disabled"
+	}
+	if cfg.SkipCAVerification {
+		return "enabled, verification skipped"
+	}
+	trust := "system roots"
+	if cfg.RemoteCAPath != "" {
+		trust = cfg.RemoteCAPath
+	}
+	if cfg.CAServerName != "" {
+		return fmt.Sprintf("enabled, trust=%s, serverName=%s", trust, cfg.CAServerName)
+	}
+	return "enabled, trust=" + trust
+}
+
+func binaryIdentity(version string, pod string) Result {
+	return Result{Status: StatusInfo, Name: "running binary identity", Details: []string{"version=" + version, "pod=" + pod}}
+}
+
+func checkConfigFreshness(configPath string, processStartTime func() (time.Time, error)) Result {
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return Result{Status: StatusUnknown, Name: "config freshness could not be checked", Details: []string{err.Error()}}
+	}
+	startedAt, err := processStartTime()
+	if err != nil {
+		return Result{Status: StatusUnknown, Name: "config freshness could not be checked", Details: []string{err.Error()}}
+	}
+	if info.ModTime().After(startedAt) {
+		return Result{
+			Status: StatusWarn,
+			Name:   "config file changed after the proxy started",
+			Details: []string{
+				"proxy started: " + startedAt.Format(time.RFC3339),
+				"config changed: " + info.ModTime().Format(time.RFC3339),
+				"restart may be required",
+			},
+		}
+	}
+	return Result{Status: StatusPass, Name: "config file is unchanged since proxy startup"}
+}
+
+func proxyProcessStartTime() (time.Time, error) {
+	cmdline, err := os.ReadFile("/proc/1/cmdline")
+	if err != nil {
+		return time.Time{}, errors.New("PID 1 proxy process is not available")
+	}
+	args := strings.FieldsFunc(string(cmdline), func(r rune) bool { return r == 0 })
+	if len(args) < 2 || !strings.Contains(args[0], "s2s-proxy") || args[1] != "start" {
+		return time.Time{}, errors.New("PID 1 is not s2s-proxy start")
+	}
+
+	proc, err := procfs.NewProc(1)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("inspect PID 1: %w", err)
+	}
+	stat, err := proc.Stat()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("inspect PID 1: %w", err)
+	}
+	startedAt, err := stat.StartTime()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("inspect PID 1 start time: %w", err)
+	}
+	seconds, fraction := math.Modf(startedAt)
+	return time.Unix(int64(seconds), int64(fraction*float64(time.Second))), nil
+}
+
+func checkLocalListeners(
+	cfg config.S2SProxyConfig,
+	processStartTime func() (time.Time, error),
+	check func(string) error,
+) Result {
+	if _, err := processStartTime(); err != nil {
+		return Result{Status: StatusUnknown, Name: "local listeners could not be checked", Details: []string{err.Error()}}
+	}
+
+	addresses := configuredListenerAddresses(cfg)
+	if len(addresses) == 0 {
+		return Result{Status: StatusSkip, Name: "no local listeners are configured"}
+	}
+
+	var failures []string
+	for _, address := range addresses {
+		if err := check(address); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", address, err))
+		}
+	}
+	if len(failures) > 0 {
+		return Result{Status: StatusFail, Name: "configured local listeners are not all reachable", Details: failures}
+	}
+	return Result{Status: StatusPass, Name: "configured local listeners are reachable", Details: addresses}
+}
+
+func configuredListenerAddresses(cfg config.S2SProxyConfig) []string {
+	seen := make(map[string]struct{})
+	var addresses []string
+	add := func(address string) {
+		if address == "" {
+			return
+		}
+		if _, ok := seen[address]; ok {
+			return
+		}
+		seen[address] = struct{}{}
+		addresses = append(addresses, address)
+	}
+	for _, conn := range cfg.ClusterConnections {
+		add(conn.Local.TcpServer.ConnectionString)
+	}
+	if len(cfg.ClusterConnections) > 0 {
+		add(cfg.ClusterConnections[0].RemoteClusterHealthCheck.ListenAddress)
+		add(cfg.ClusterConnections[0].LocalClusterHealthCheck.ListenAddress)
+	}
+	if cfg.Metrics != nil {
+		add(cfg.Metrics.Prometheus.ListenAddress)
+	}
+	if cfg.ProfilingConfig != nil {
+		add(cfg.ProfilingConfig.PProfHTTPAddress)
+	}
+	return addresses
+}
+
+func checkListener(address string) error {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" || host == "[::]" {
+		host = "127.0.0.1"
+	}
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), defaultListenerTimeout)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func splitErrorLines(err error) []string {
+	if err == nil {
+		return nil
+	}
+	return strings.Split(err.Error(), "\n")
+}

--- a/preflight/proxy_test.go
+++ b/preflight/proxy_test.go
@@ -1,0 +1,397 @@
+package preflight
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/temporalio/s2s-proxy/config"
+	"github.com/temporalio/s2s-proxy/encryption"
+)
+
+func TestCheckProxyWithOptions_HealthyCustomerProxy(t *testing.T) {
+	now := time.Date(2026, time.September, 11, 12, 0, 0, 0, time.UTC)
+	certificatePath, keyPath, _ := writeCertificateFiles(t, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	cfg := healthyProxyConfig(certificatePath, keyPath)
+	configPath := writeProxyConfig(t, cfg)
+	info, err := os.Stat(configPath)
+	require.NoError(t, err)
+
+	var checkedListeners []string
+	report := CheckProxyWithOptions(configPath, "v-test", ProxyCheckOptions{
+		Now:      func() time.Time { return now },
+		Hostname: func() (string, error) { return "proxy-pod-0", nil },
+		ProcessStartTime: func() (time.Time, error) {
+			return info.ModTime().Add(time.Hour), nil
+		},
+		CheckListener: func(address string) error {
+			checkedListeners = append(checkedListeners, address)
+			return nil
+		},
+	})
+
+	assert.False(t, report.HasFailures())
+	assert.False(t, report.HasUnknowns())
+	assert.NotEqual(t, "unknown", report.ConfigSHA256)
+	assert.Len(t, report.ConfigSHA256, 64)
+	assert.Equal(t, "proxy-pod-0", report.Pod)
+	assert.Equal(t, []string{"0.0.0.0:9233", "0.0.0.0:8234", "0.0.0.0:9090", "localhost:6060"}, checkedListeners)
+	assert.Equal(t, StatusInfo, resultNamed(t, report, "effective config").Status)
+	assert.Contains(t, strings.Join(resultNamed(t, report, "effective config").Details, "\n"), "muxCount=10")
+	for _, result := range report.Results {
+		assert.NotEqual(t, StatusWarn, result.Status, result.Name)
+	}
+}
+
+func TestCheckProxyWithOptions_ConfigReadAndFormatFailures(t *testing.T) {
+	opts := ProxyCheckOptions{
+		Hostname:         func() (string, error) { return "proxy-pod-0", nil },
+		ProcessStartTime: func() (time.Time, error) { return time.Now(), nil },
+		CheckListener:    func(string) error { return nil },
+	}
+
+	t.Run("missing file", func(t *testing.T) {
+		report := CheckProxyWithOptions(filepath.Join(t.TempDir(), "missing.yaml"), "v-test", opts)
+		require.Len(t, report.Results, 1)
+		assert.Equal(t, StatusFail, report.Results[0].Status)
+		assert.Equal(t, "unknown", report.ConfigSHA256)
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("clusterConnections: ["), 0o600))
+		report := CheckProxyWithOptions(path, "v-test", opts)
+		require.Len(t, report.Results, 1)
+		assert.Equal(t, "config file does not parse", report.Results[0].Name)
+	})
+
+	t.Run("unknown field", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("clusterConnections: []\nlegacyField: true\n"), 0o600))
+		report := CheckProxyWithOptions(path, "v-test", opts)
+		require.Len(t, report.Results, 2)
+		assert.Equal(t, "config format is not supported", report.Results[1].Name)
+	})
+
+	t.Run("multiple yaml documents", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("clusterConnections: []\n---\nclusterConnections: []\n"), 0o600))
+		report := CheckProxyWithOptions(path, "v-test", opts)
+		require.Len(t, report.Results, 1)
+		assert.Equal(t, "config file does not parse", report.Results[0].Name)
+	})
+}
+
+func TestCheckConfigStructure(t *testing.T) {
+	cfg := healthyProxyConfig("cert.pem", "key.pem")
+	assert.Equal(t, StatusPass, checkConfigStructure(cfg).Status)
+
+	t.Run("customer side shape", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].Remote.ConnectionType = config.ConnTypeMuxServer
+		result := checkConfigStructure(cfg)
+		assert.Equal(t, StatusFail, result.Status)
+		assert.Contains(t, strings.Join(result.Details, "\n"), "must be mux-client")
+	})
+
+	t.Run("placeholder remote address", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].Remote.MuxAddressInfo.ConnectionString = "remote_proxy_service:8233"
+		result := checkConfigStructure(cfg)
+		assert.Equal(t, StatusFail, result.Status)
+		assert.Contains(t, strings.Join(result.Details, "\n"), "template placeholder")
+	})
+
+	t.Run("duplicate listener", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.Metrics.Prometheus.ListenAddress = ":9233"
+		result := checkConfigStructure(cfg)
+		assert.Equal(t, StatusFail, result.Status)
+		assert.Contains(t, strings.Join(result.Details, "\n"), "same listener address")
+	})
+
+	t.Run("invalid port", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].Local.TcpClient.ConnectionString = "temporal.example:0"
+		assert.Equal(t, StatusFail, checkConfigStructure(cfg).Status)
+	})
+}
+
+func TestCheckTLSConfiguration(t *testing.T) {
+	t.Run("remote tls is required", func(t *testing.T) {
+		cfg := healthyProxyConfig("", "")
+		assert.Equal(t, StatusFail, checkTLSConfiguration(cfg).Status)
+	})
+
+	t.Run("remote ca alone does not enable tls", func(t *testing.T) {
+		cfg := healthyProxyConfig("", "")
+		cfg.ClusterConnections[0].Remote.MuxAddressInfo.TLSConfig.RemoteCAPath = "ca.pem"
+		result := checkTLSConfiguration(cfg)
+		assert.Equal(t, StatusFail, result.Status)
+		assert.Contains(t, strings.Join(result.Details, "\n"), "requires a certificate and key")
+	})
+
+	t.Run("empty local tls with skip verification is disabled", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].Local.TcpClient.TLSConfig.SkipCAVerification = true
+		cfg.ClusterConnections[0].Local.TcpServer.TLSConfig.SkipCAVerification = true
+		assert.Equal(t, StatusPass, checkTLSConfiguration(cfg).Status)
+	})
+
+	t.Run("local client may use server-only tls", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].Local.TcpClient.TLSConfig.CAServerName = "temporal.example"
+		assert.Equal(t, StatusPass, checkTLSConfiguration(cfg).Status)
+	})
+}
+
+func TestACLAndNamespaceChecks(t *testing.T) {
+	t.Run("empty acl is unrestricted", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ACLPolicy = nil
+		assert.Equal(t, StatusSkip, checkAdminPermissions(cfg).Status)
+		assert.Equal(t, StatusSkip, checkTemporalSystem(cfg).Status)
+	})
+
+	t.Run("partial admin acl fails", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ACLPolicy.AllowedMethods.AdminService = []string{"DescribeCluster"}
+		result := checkAdminPermissions(cfg)
+		assert.Equal(t, StatusFail, result.Status)
+		assert.Contains(t, strings.Join(result.Details, "\n"), "SyncWorkflowState")
+	})
+
+	t.Run("temporal system is required when namespaces are restricted", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ACLPolicy.AllowedNamespaces = []string{"orders"}
+		assert.Equal(t, StatusFail, checkTemporalSystem(cfg).Status)
+	})
+
+	t.Run("acl uses local namespace names", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ACLPolicy.AllowedNamespaces = []string{temporalSystem, "orders.cloud-account"}
+		assert.Equal(t, StatusFail, checkAllowedNamespaceSide(cfg).Status)
+	})
+
+	t.Run("allowed namespace without mapping is a concern", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].NamespaceTranslation.Mappings = nil
+		result := checkNamespaceMappings(cfg)
+		assert.Equal(t, StatusWarn, result.Status)
+		assert.Contains(t, strings.Join(result.Details, "\n"), "valid only when both sides use the same name")
+	})
+
+	t.Run("template namespace fails", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ACLPolicy.AllowedNamespaces = []string{temporalSystem, "myNamespace"}
+		cfg.ClusterConnections[0].NamespaceTranslation.Mappings[0] = config.StringMapping{Local: "myNamespace", Remote: "myNamespace.accountid"}
+		assert.Equal(t, StatusFail, checkNamespaceMappings(cfg).Status)
+	})
+}
+
+func TestReplicationEndpointIsConcernNotCustomerSpecificVerdict(t *testing.T) {
+	cfg := healthyProxyConfig("cert.pem", "key.pem")
+	cfg.ClusterConnections[0].ReplicationEndpoint = "127.0.0.1:433"
+	result := checkReplicationEndpoints(cfg)
+	assert.Equal(t, StatusWarn, result.Status)
+	assert.Contains(t, strings.Join(result.Details, "\n"), "internal routing translates ports")
+}
+
+func TestIdentityAndNumericChecks(t *testing.T) {
+	t.Run("duplicate names", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections = append(cfg.ClusterConnections, cfg.ClusterConnections[0])
+		assert.Equal(t, StatusFail, checkConnectionNames(cfg).Status)
+	})
+
+	t.Run("inactive shard counts warn", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ShardCountConfig = config.ShardCountConfig{LocalShardCount: 4, RemoteShardCount: 8}
+		assert.Equal(t, StatusWarn, checkNumericSettings(cfg).Status)
+	})
+
+	t.Run("lcm overflow fails", func(t *testing.T) {
+		cfg := healthyProxyConfig("cert.pem", "key.pem")
+		cfg.ClusterConnections[0].ShardCountConfig = config.ShardCountConfig{
+			Mode:             config.ShardCountLCM,
+			LocalShardCount:  2_147_483_647,
+			RemoteShardCount: 2_147_483_646,
+		}
+		assert.Equal(t, StatusFail, checkNumericSettings(cfg).Status)
+	})
+}
+
+func TestCertificateFiles(t *testing.T) {
+	now := time.Date(2026, time.September, 11, 12, 0, 0, 0, time.UTC)
+
+	t.Run("valid pair loads", func(t *testing.T) {
+		certificatePath, keyPath, caPath := writeCertificateFiles(t, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+		cfg := healthyProxyConfig(certificatePath, keyPath)
+		cfg.ClusterConnections[0].Remote.MuxAddressInfo.TLSConfig.RemoteCAPath = caPath
+		assert.Equal(t, StatusPass, checkCertificateFiles(cfg, now).Status)
+	})
+
+	t.Run("missing key fails", func(t *testing.T) {
+		certificatePath, _, _ := writeCertificateFiles(t, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+		cfg := healthyProxyConfig(certificatePath, filepath.Join(t.TempDir(), "missing.key"))
+		assert.Equal(t, StatusFail, checkCertificateFiles(cfg, now).Status)
+	})
+
+	t.Run("near expiry warns", func(t *testing.T) {
+		certificatePath, keyPath, _ := writeCertificateFiles(t, now.Add(-time.Hour), now.Add(7*24*time.Hour))
+		cfg := healthyProxyConfig(certificatePath, keyPath)
+		assert.Equal(t, StatusWarn, checkCertificateFiles(cfg, now).Status)
+	})
+
+	t.Run("https ca is not fetched", func(t *testing.T) {
+		certificatePath, keyPath, _ := writeCertificateFiles(t, now.Add(-time.Hour), now.Add(90*24*time.Hour))
+		cfg := healthyProxyConfig(certificatePath, keyPath)
+		cfg.ClusterConnections[0].Remote.MuxAddressInfo.TLSConfig.RemoteCAPath = "https://example.test/ca.pem"
+		assert.Equal(t, StatusWarn, checkCertificateFiles(cfg, now).Status)
+	})
+}
+
+func TestRuntimeChecks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("clusterConnections: []\n"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, StatusPass, checkConfigFreshness(path, func() (time.Time, error) {
+		return info.ModTime().Add(time.Hour), nil
+	}).Status)
+	assert.Equal(t, StatusWarn, checkConfigFreshness(path, func() (time.Time, error) {
+		return info.ModTime().Add(-time.Hour), nil
+	}).Status)
+	assert.Equal(t, StatusUnknown, checkConfigFreshness(path, func() (time.Time, error) {
+		return time.Time{}, errors.New("not in proxy pod")
+	}).Status)
+
+	cfg := healthyProxyConfig("cert.pem", "key.pem")
+	result := checkLocalListeners(cfg, func() (time.Time, error) { return time.Now(), nil }, func(address string) error {
+		if address == "0.0.0.0:9233" {
+			return errors.New("connection refused")
+		}
+		return nil
+	})
+	assert.Equal(t, StatusFail, result.Status)
+	assert.Contains(t, strings.Join(result.Details, "\n"), "connection refused")
+}
+
+func healthyProxyConfig(certificatePath string, keyPath string) config.S2SProxyConfig {
+	methods := slices.Clone(requiredAdminMethods)
+	return config.S2SProxyConfig{
+		ClusterConnections: []config.ClusterConnConfig{
+			{
+				Name: "orders-migration",
+				Local: config.ClusterDefinition{
+					ConnectionType: config.ConnTypeTCP,
+					TcpClient:      config.TCPTLSInfo{ConnectionString: "temporal-frontend.temporal.svc.cluster.local:7233"},
+					TcpServer:      config.TCPTLSInfo{ConnectionString: "0.0.0.0:9233"},
+				},
+				Remote: config.ClusterDefinition{
+					ConnectionType: config.ConnTypeMuxClient,
+					MuxAddressInfo: config.TCPTLSInfo{
+						ConnectionString: "cloud-proxy.example.tmprl.cloud:8233",
+						TLSConfig: encryption.TLSConfig{
+							CertificatePath:    certificatePath,
+							KeyPath:            keyPath,
+							SkipCAVerification: true,
+						},
+					},
+				},
+				ReplicationEndpoint: "s2s-proxy.temporal.svc.cluster.local:9233",
+				FVITranslation:      config.IntMapping{Local: 100, Remote: 1_000_000},
+				ACLPolicy: &config.ACLPolicy{
+					AllowedMethods:    config.AllowedMethods{AdminService: methods},
+					AllowedNamespaces: []string{temporalSystem, "orders"},
+				},
+				NamespaceTranslation: config.StringTranslator{Mappings: []config.StringMapping{
+					{Local: "orders", Remote: "orders.cloud-account"},
+				}},
+				RemoteClusterHealthCheck: config.HealthCheckConfig{Protocol: config.HTTP, ListenAddress: "0.0.0.0:8234"},
+				ShardCountConfig: config.ShardCountConfig{
+					Mode:             config.ShardCountLCM,
+					LocalShardCount:  4,
+					RemoteShardCount: 8,
+				},
+			},
+		},
+		Metrics:         &config.MetricsConfig{Prometheus: config.PrometheusConfig{ListenAddress: "0.0.0.0:9090"}},
+		ProfilingConfig: &config.ProfilingConfig{PProfHTTPAddress: "localhost:6060"},
+	}
+}
+
+func writeProxyConfig(t *testing.T, cfg config.S2SProxyConfig) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, config.WriteConfig(cfg, path))
+	return path
+}
+
+func writeCertificateFiles(t *testing.T, notBefore time.Time, notAfter time.Time) (string, string, string) {
+	t.Helper()
+	directory := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             notBefore.Add(-time.Hour),
+		NotAfter:              notAfter.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caTemplate, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	require.NoError(t, err)
+
+	certificatePath := filepath.Join(directory, "client.pem")
+	keyPath := filepath.Join(directory, "client.key")
+	caPath := filepath.Join(directory, "ca.pem")
+	require.NoError(t, os.WriteFile(certificatePath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: leafKeyDER}), 0o600))
+	require.NoError(t, os.WriteFile(caPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), 0o600))
+	return certificatePath, keyPath, caPath
+}
+
+func resultNamed(t *testing.T, report Report, name string) Result {
+	t.Helper()
+	for _, result := range report.Results {
+		if result.Name == name {
+			return result
+		}
+	}
+	t.Fatalf("result %q not found", name)
+	return Result{}
+}

--- a/preflight/report.go
+++ b/preflight/report.go
@@ -1,0 +1,91 @@
+package preflight
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+const GenericProxyScope = "this pod and customer-provided config, using generic rules only; customer-specific correctness is not verified"
+
+type Status string
+
+const (
+	StatusPass    Status = "PASS"
+	StatusWarn    Status = "WARN"
+	StatusFail    Status = "FAIL"
+	StatusSkip    Status = "SKIP"
+	StatusUnknown Status = "UNKNOWN"
+	StatusInfo    Status = "INFO"
+)
+
+type Result struct {
+	Status  Status   `json:"status"`
+	Name    string   `json:"name"`
+	Details []string `json:"details,omitempty"`
+}
+
+type Report struct {
+	ConfigPath   string   `json:"configPath"`
+	ConfigSHA256 string   `json:"configSHA256"`
+	Version      string   `json:"version"`
+	Pod          string   `json:"pod"`
+	Scope        string   `json:"scope"`
+	Results      []Result `json:"results"`
+}
+
+func (r Report) HasFailures() bool {
+	for _, result := range r.Results {
+		if result.Status == StatusFail {
+			return true
+		}
+	}
+	return false
+}
+
+func (r Report) HasUnknowns() bool {
+	for _, result := range r.Results {
+		if result.Status == StatusUnknown {
+			return true
+		}
+	}
+	return false
+}
+
+func (r Report) WriteText(w io.Writer) error {
+	var output bytes.Buffer
+	_, _ = fmt.Fprintln(&output, "s2s-proxy validate: proxy self-check")
+	_, _ = fmt.Fprintf(&output, "config  %s  sha256 %s\n", r.ConfigPath, r.ConfigSHA256)
+	_, _ = fmt.Fprintf(&output, "proxy   %s  pod %s\n\n", r.Version, r.Pod)
+
+	counts := make(map[Status]int)
+	for _, result := range r.Results {
+		counts[result.Status]++
+		_, _ = fmt.Fprintf(&output, "%-8s%s\n", result.Status, result.Name)
+		for _, detail := range result.Details {
+			_, _ = fmt.Fprintf(&output, "        %s\n", detail)
+		}
+	}
+
+	_, _ = fmt.Fprintf(
+		&output,
+		"\n%d failed, %d warnings, %d passed, %d skipped, %d unknown\n",
+		counts[StatusFail],
+		counts[StatusWarn],
+		counts[StatusPass],
+		counts[StatusSkip],
+		counts[StatusUnknown],
+	)
+	if r.Scope != "" {
+		_, _ = fmt.Fprintln(&output, "scope: "+r.Scope)
+	}
+	_, err := w.Write(output.Bytes())
+	return err
+}
+
+func (r Report) WriteJSON(w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(r)
+}

--- a/preflight/report_test.go
+++ b/preflight/report_test.go
@@ -1,0 +1,59 @@
+package preflight
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportWriteText(t *testing.T) {
+	report := Report{
+		ConfigPath:   "/config/config.yaml",
+		ConfigSHA256: "abc123",
+		Version:      "v-test",
+		Pod:          "proxy-pod-0",
+		Scope:        GenericProxyScope,
+		Results: []Result{
+			{Status: StatusPass, Name: "good"},
+			{Status: StatusWarn, Name: "concern", Details: []string{"review this value"}},
+			{Status: StatusFail, Name: "bad"},
+			{Status: StatusSkip, Name: "not applicable"},
+			{Status: StatusUnknown, Name: "not observed"},
+			{Status: StatusInfo, Name: "context"},
+		},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, report.WriteText(&output))
+
+	assert.Contains(t, output.String(), "config  /config/config.yaml  sha256 abc123")
+	assert.Contains(t, output.String(), "WARN    concern")
+	assert.Contains(t, output.String(), "review this value")
+	assert.Contains(t, output.String(), "1 failed, 1 warnings, 1 passed, 1 skipped, 1 unknown")
+	assert.Contains(t, output.String(), "scope: "+GenericProxyScope)
+	assert.True(t, report.HasFailures())
+	assert.True(t, report.HasUnknowns())
+}
+
+func TestReportWriteJSON(t *testing.T) {
+	report := Report{
+		ConfigPath:   "/config/config.yaml",
+		ConfigSHA256: "abc123",
+		Version:      "v-test",
+		Pod:          "proxy-pod-0",
+		Scope:        GenericProxyScope,
+		Results:      []Result{{Status: StatusPass, Name: "good"}},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, report.WriteJSON(&output))
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &decoded))
+	assert.Equal(t, "/config/config.yaml", decoded["configPath"])
+	assert.Equal(t, "abc123", decoded["configSHA256"])
+	assert.Equal(t, GenericProxyScope, decoded["scope"])
+}


### PR DESCRIPTION
## What changed

- Added `s2s-proxy validate --only proxy` for customer-side proxy pods.
- Added generic checks for config structure, TLS files, ACLs, namespace mappings, callback syntax, numeric settings, config freshness, and local listeners.
- Added text and JSON output with stable exit codes.
- Added command documentation and test coverage.

## Scope

This check reads the customer-provided config and local pod state. It does not contact the customer Temporal cluster, Temporal Cloud, or the Kubernetes API. A successful result means the setup is internally consistent and possible to use. It does not verify customer-specific values against a separate specification.

## Testing

- `make lint`
- `go test -race -tags test_dep -count=1 ./app ./encryption ./preflight`
- `make s2s-proxy`
- `git diff --check origin/main...HEAD`